### PR TITLE
Diff/Result: Add filename property to Diff

### DIFF
--- a/coalib/bearlib/abstractions/Lint.py
+++ b/coalib/bearlib/abstractions/Lint.py
@@ -166,10 +166,10 @@ class Lint(Bear):
                          diffs created by comparing the original and corrected
                          contents.
         """
-        for diff in self.__yield_diffs(file, output):
+        for diff in self.__yield_diffs(file, output, filename):
             yield Result(self,
                          self.diff_message,
-                         affected_code=(diff.range(filename),),
+                         affected_code=(diff.range(),),
                          diffs={filename: diff},
                          severity=self.diff_severity)
 
@@ -229,9 +229,9 @@ class Lint(Bear):
             self.warn(line)
 
     @staticmethod
-    def __yield_diffs(file, new_file):
+    def __yield_diffs(file, new_file, filename):
         if tuple(new_file) != tuple(file):
-            wholediff = Diff.from_string_arrays(file, new_file)
+            wholediff = Diff.from_string_arrays(file, new_file, filename)
 
             for diff in wholediff.split_diff():
                 yield diff

--- a/coalib/bearlib/abstractions/Linter.py
+++ b/coalib/bearlib/abstractions/Linter.py
@@ -326,11 +326,12 @@ def _create_linter(klass, options):
             """
             for diff in Diff.from_string_arrays(
                 file,
-                output.splitlines(keepends=True)).split_diff(
+                output.splitlines(keepends=True),
+                filename).split_diff(
                     distance=diff_distance):
                 yield Result(self,
                              result_message,
-                             affected_code=diff.affected_code(filename),
+                             affected_code=diff.affected_code(),
                              diffs={filename: diff},
                              severity=diff_severity)
 

--- a/coalib/results/Diff.py
+++ b/coalib/results/Diff.py
@@ -12,24 +12,34 @@ class Diff:
     A Diff result represents a difference for one file.
     """
 
-    def __init__(self, file_list, filename, rename=False, delete=False):
+    def __init__(self, file_list, filename=None, rename=False, delete=False):
         """
         Creates an empty diff for the given file.
 
+        Test to see if the deprecation warning prints properly.
+
+        >>> diff = Diff([])
+        WARNING! Initializing Diff without filename deprecated
+
         :param file_list: The original (unmodified) file as a list of its
                           lines.
-        :param filename:  A string containing the name of the file
+        :param filename:  None or a string containing the name of the file
         :param rename:    False or str containing new name of file.
         :param delete:    True if file is set to be deleted.
         """
         self._changes = {}
         self._file = file_list
+
+        # FIXME: Use builtin logging when it becomes available
+        if(not filename):
+            print("WARNING! Initializing Diff without filename deprecated")
+
         self.filename = filename
         self.rename = rename
         self.delete = delete
 
     @classmethod
-    def from_string_arrays(cls, file_array_1, file_array_2, filename,
+    def from_string_arrays(cls, file_array_1, file_array_2, filename=None,
                            rename=False):
         """
         Creates a Diff object from two arrays containing strings.
@@ -39,7 +49,7 @@ class Diff:
 
         :param file_array_1: Original array
         :param file_array_2: Array to compare
-        :param filename:     Name of file
+        :param filename:     None or a string containing the name of the file
         :param rename:       False or str containing new name of file.
         """
         result = cls(file_array_1, filename, rename=rename)
@@ -94,7 +104,7 @@ class Diff:
                     type(file)(newvalue.splitlines(True)) +
                     file[fixit.range.end.line:])
 
-        return cls.from_string_arrays(file, new_file, filename)
+        return cls.from_string_arrays(file, new_file, filename or self.filename)
 
     def _get_change(self, line_nr, min_line=1):
         if not isinstance(line_nr, int):
@@ -224,7 +234,7 @@ class Diff:
         return list(diff.range()
                     for diff in self.split_diff(distance=0))
 
-    def split_diff(self, distance=1):
+    def split_diff(self, distance=1, filename=None):
         """
         Splits this diff into small pieces, such that several continuously
         altered lines are still together in one diff. All subdiffs will be
@@ -261,12 +271,13 @@ class Diff:
 
         :param distance: Number of unchanged lines that are allowed in between
                          two changed lines so they get yielded as one diff.
+        :param filename: None or a string containing the name of the file
         """
         if not self:
             return
 
         last_line = -1
-        this_diff = Diff(self._file, self.filename,
+        this_diff = Diff(self._file, filename or self.filename,
                          rename=self.rename, delete=self.delete)
         for line in sorted(self._changes.keys()):
             if line > last_line + distance + 1 and len(this_diff._changes) > 0:
@@ -282,7 +293,7 @@ class Diff:
         # always.
         yield this_diff
 
-    def range(self):
+    def range(self, filename=None):
         """
         Calculates a SourceRange spanning over the whole Diff. If something is
         added after the 0th line (i.e. before the first line) the first line
@@ -296,14 +307,15 @@ class Diff:
         >>> print(range.start.line)
         None
 
-        :return:                A SourceRange object.
+        :param filename: None or a string containing the name of the file
+        :return:         A SourceRange object.
         """
         if len(self._changes) == 0:
-            return SourceRange.from_values(self.filename)
+            return SourceRange.from_values(filename or self.filename)
 
         start = min(self._changes.keys())
         end = max(self._changes.keys())
-        return SourceRange.from_values(self.filename,
+        return SourceRange.from_values(filename or self.filename,
                                        start_line=max(1, start),
                                        end_line=max(1, end))
 

--- a/coalib/results/Diff.py
+++ b/coalib/results/Diff.py
@@ -12,22 +12,25 @@ class Diff:
     A Diff result represents a difference for one file.
     """
 
-    def __init__(self, file_list, rename=False, delete=False):
+    def __init__(self, file_list, filename, rename=False, delete=False):
         """
         Creates an empty diff for the given file.
 
         :param file_list: The original (unmodified) file as a list of its
                           lines.
+        :param filename:  A string containing the name of the file
         :param rename:    False or str containing new name of file.
         :param delete:    True if file is set to be deleted.
         """
         self._changes = {}
         self._file = file_list
+        self.filename = filename
         self.rename = rename
         self.delete = delete
 
     @classmethod
-    def from_string_arrays(cls, file_array_1, file_array_2, rename=False):
+    def from_string_arrays(cls, file_array_1, file_array_2, filename,
+                           rename=False):
         """
         Creates a Diff object from two arrays containing strings.
 
@@ -36,9 +39,10 @@ class Diff:
 
         :param file_array_1: Original array
         :param file_array_2: Array to compare
+        :param filename:     Name of file
         :param rename:       False or str containing new name of file.
         """
-        result = cls(file_array_1, rename=rename)
+        result = cls(file_array_1, filename, rename=rename)
 
         matcher = difflib.SequenceMatcher(None, file_array_1, file_array_2)
         # We use this because its faster (generator) and doesn't yield as much
@@ -68,12 +72,13 @@ class Diff:
         return result
 
     @classmethod
-    def from_clang_fixit(cls, fixit, file):
+    def from_clang_fixit(cls, fixit, file, filename=None):
         """
         Creates a Diff object from a given clang fixit and the file contents.
 
-        :param fixit: A cindex.Fixit object.
-        :param file:  A list of lines in the file to apply the fixit to.
+        :param fixit:    A cindex.Fixit object.
+        :param file:     A list of lines in the file to apply the fixit to.
+        :param filename: None or a string containing the file name
         :return:      The corresponding Diff object.
         """
         assert isinstance(file, (list, tuple))
@@ -89,7 +94,7 @@ class Diff:
                     type(file)(newvalue.splitlines(True)) +
                     file[fixit.range.end.line:])
 
-        return cls.from_string_arrays(file, new_file)
+        return cls.from_string_arrays(file, new_file, filename)
 
     def _get_change(self, line_nr, min_line=1):
         if not isinstance(line_nr, int):
@@ -209,15 +214,14 @@ class Diff:
         """
         return self.unified_diff
 
-    def affected_code(self, filename):
+    def affected_code(self):
         """
         Creates a list of SourceRange objects which point to the related code.
         Changes on continuous lines will be put into one SourceRange.
 
-        :param filename: The filename to associate the SourceRange's to.
-        :return:         A list of all related SourceRange objects.
+        :return:                A list of all related SourceRange objects.
         """
-        return list(diff.range(filename)
+        return list(diff.range()
                     for diff in self.split_diff(distance=0))
 
     def split_diff(self, distance=1):
@@ -229,7 +233,8 @@ class Diff:
         A diff like this with changes being together closely won't be splitted:
 
         >>> diff = Diff.from_string_arrays([     'b', 'c', 'e'],
-        ...                                ['a', 'b', 'd', 'f'])
+        ...                                ['a', 'b', 'd', 'f'],
+        ...                                "file")
         >>> len(list(diff.split_diff()))
         1
 
@@ -246,12 +251,12 @@ class Diff:
 
         If a file gets renamed or deleted only, it will be yielded as is:
 
-        >>> len(list(Diff([], rename='test').split_diff()))
+        >>> len(list(Diff([], "file", rename='test').split_diff()))
         1
 
         An empty diff will not yield any diffs:
 
-        >>> len(list(Diff([]).split_diff()))
+        >>> len(list(Diff([], "file").split_diff()))
         0
 
         :param distance: Number of unchanged lines that are allowed in between
@@ -261,11 +266,12 @@ class Diff:
             return
 
         last_line = -1
-        this_diff = Diff(self._file, rename=self.rename, delete=self.delete)
+        this_diff = Diff(self._file, self.filename,
+                         rename=self.rename, delete=self.delete)
         for line in sorted(self._changes.keys()):
             if line > last_line + distance + 1 and len(this_diff._changes) > 0:
                 yield this_diff
-                this_diff = Diff(self._file, rename=self.rename,
+                this_diff = Diff(self._file, self.filename, rename=self.rename,
                                  delete=self.delete)
 
             last_line = line
@@ -276,7 +282,7 @@ class Diff:
         # always.
         yield this_diff
 
-    def range(self, filename):
+    def range(self):
         """
         Calculates a SourceRange spanning over the whole Diff. If something is
         added after the 0th line (i.e. before the first line) the first line
@@ -284,21 +290,20 @@ class Diff:
 
         The range of an empty diff will only affect the filename:
 
-        >>> range = Diff([]).range("file")
+        >>> range = Diff([], filename="file").range()
         >>> range.file is None
         False
         >>> print(range.start.line)
         None
 
-        :param filename: The filename to associate the SourceRange with.
-        :return:         A SourceRange object.
+        :return:                A SourceRange object.
         """
         if len(self._changes) == 0:
-            return SourceRange.from_values(filename)
+            return SourceRange.from_values(self.filename)
 
         start = min(self._changes.keys())
         end = max(self._changes.keys())
-        return SourceRange.from_values(filename,
+        return SourceRange.from_values(self.filename,
                                        start_line=max(1, start),
                                        end_line=max(1, end))
 
@@ -313,6 +318,9 @@ class Diff:
         if self.rename != other.rename and False not in (self.rename,
                                                          other.rename):
             raise ConflictError("Diffs contain conflicting renamings.")
+
+        if self.filename and other.filename and self.filename != other.filename:
+            raise ConflictError("Diffs are for different files")
 
         result = copy.deepcopy(self)
         result.rename = self.rename or other.rename
@@ -331,13 +339,13 @@ class Diff:
 
     def __bool__(self):
         """
-        >>> bool(Diff([]))
+        >>> bool(Diff([], "file"))
         False
-        >>> bool(Diff([], rename="some"))
+        >>> bool(Diff([], "file", rename="some"))
         True
-        >>> bool(Diff([], delete=True))
+        >>> bool(Diff([], "file", delete=True))
         True
-        >>> bool(Diff.from_string_arrays(['1'], []))
+        >>> bool(Diff.from_string_arrays(['1'], [], "file"))
         True
 
         :return: False if the patch has no effect at all when applied.

--- a/coalib/results/Result.py
+++ b/coalib/results/Result.py
@@ -5,6 +5,7 @@ from coala_utils.decorators import (
     enforce_signature, generate_ordering, generate_repr, get_public_members)
 from coalib.results.RESULT_SEVERITY import RESULT_SEVERITY
 from coalib.results.SourceRange import SourceRange
+from collections import Iterable
 
 
 # Omit additional info, debug message and diffs for brevity
@@ -36,7 +37,7 @@ class Result:
                  severity: int=RESULT_SEVERITY.NORMAL,
                  additional_info: str="",
                  debug_msg="",
-                 diffs: (dict, None)=None,
+                 diffs: (Iterable, None)=None,
                  confidence: int=100):
         """
         :param origin:          Class name or creator object of this object.
@@ -63,6 +64,11 @@ class Result:
         if severity not in RESULT_SEVERITY.reverse:
             raise ValueError("severity is not a valid RESULT_SEVERITY")
 
+        if(diffs and not isinstance(diffs, dict)):
+            self.diffs = {d.filename: d for d in diffs}
+        else:
+            self.diffs = diffs
+
         self.origin = origin
         self.message = message
         self.debug_msg = debug_msg
@@ -73,7 +79,6 @@ class Result:
         if confidence < 0 or confidence > 100:
             raise ValueError('Value of confidence should be between 0 and 100.')
         self.confidence = confidence
-        self.diffs = diffs
         self.id = uuid.uuid4().int
 
     @classmethod
@@ -89,7 +94,7 @@ class Result:
                     severity: int=RESULT_SEVERITY.NORMAL,
                     additional_info: str="",
                     debug_msg="",
-                    diffs: (dict, None)=None,
+                    diffs: (Iterable, None)=None,
                     confidence: int=100):
         """
         Creates a result with only one SourceRange with the given start and end

--- a/coalib/results/ResultFilter.py
+++ b/coalib/results/ResultFilter.py
@@ -27,7 +27,8 @@ def filter_results(original_file_dict,
     for file in original_file_dict:
         diffs_dict[file] = Diff.from_string_arrays(
             original_file_dict[file],
-            modified_file_dict[renamed_files.get(file, file)])
+            modified_file_dict[renamed_files.get(file, file)],
+            file)
 
     orig_result_diff_dict_dict = remove_result_ranges_diffs(original_results,
                                                             original_file_dict)
@@ -208,7 +209,8 @@ def remove_result_ranges_diffs(result_list, file_dict):
         for file_name in file_dict:
             diff_dict[file_name] = Diff.from_string_arrays(
                 file_dict[file_name],
-                mod_file_dict[file_name])
+                mod_file_dict[file_name],
+                file_name)
 
         result_diff_dict_dict[original_result] = diff_dict
 

--- a/coalib/results/result_actions/OpenEditorAction.py
+++ b/coalib/results/result_actions/OpenEditorAction.py
@@ -57,7 +57,9 @@ class OpenEditorAction(ResultAction):
         for original_name, filename in filenames.items():
             with open(filename, encoding='utf-8') as file:
                 file_diff_dict[original_name] = Diff.from_string_arrays(
-                    original_file_dict[original_name], file.readlines(),
+                    original_file_dict[original_name],
+                    file.readlines(),
+                    original_name,
                     rename=False if original_name == filename else filename)
 
         return file_diff_dict

--- a/tests/bearlib/abstractions/LinterTest.py
+++ b/tests/bearlib/abstractions/LinterTest.py
@@ -287,7 +287,8 @@ class LinterComponentTest(unittest.TestCase):
                                           "some-file.c",
                                           original))
 
-        diffs = list(Diff.from_string_arrays(original, fixed).split_diff())
+        diffs = list(Diff.from_string_arrays(
+            original, fixed, "some-file.c").split_diff())
         expected = [Result.from_values(uut,
                                        "Inconsistency found.",
                                        "some-file.c",
@@ -725,7 +726,8 @@ class LinterReallifeTest(unittest.TestCase):
 
         diffs = list(Diff.from_string_arrays(
             self.testfile_content,
-            expected_correction).split_diff())
+            expected_correction,
+            self.testfile_path).split_diff())
 
         expected = [Result(uut, "Custom message",
                            affected_code=(
@@ -835,7 +837,8 @@ class LinterReallifeTest(unittest.TestCase):
 
         diffs = list(Diff.from_string_arrays(
             self.testfile2_content,
-            expected_correction).split_diff())
+            expected_correction,
+            self.testfile2_path).split_diff())
 
         expected = [Result.from_values(uut,
                                        "Inconsistency found.",

--- a/tests/output/ConsoleInteractionTest.py
+++ b/tests/output/ConsoleInteractionTest.py
@@ -174,12 +174,12 @@ class ConsoleInteractionTest(unittest.TestCase):
 
     def test_print_diffs_info(self):
         file_dict = {"a": ["a\n", "b\n", "c\n"], "b": ["old_first\n"]}
-        diff_dict = {"a": Diff(file_dict['a']),
-                     "b": Diff(file_dict['b'])}
+        diff_dict = {"a": Diff(file_dict['a'], "a"),
+                     "b": Diff(file_dict['b'], "b")}
         diff_dict["a"].add_lines(1, ["test\n"])
         diff_dict["a"].delete_line(3)
         diff_dict["b"].add_lines(0, ["first\n"])
-        previous_diffs = {"a": Diff(file_dict['a'])}
+        previous_diffs = {"a": Diff(file_dict['a'], "a")}
         previous_diffs["a"].change_line(2, "b\n", "b_changed\n")
         with retrieve_stdout() as stdout:
             print_diffs_info(diff_dict, self.console_printer)
@@ -192,8 +192,8 @@ class ConsoleInteractionTest(unittest.TestCase):
            "apply_from_section")
     def test_print_result_interactive_small_patch(self, apply_from_section, _):
         file_dict = {"a": ["a\n", "b\n", "c\n"], "b": ["old_first\n"]}
-        diff_dict = {"a": Diff(file_dict['a']),
-                     "b": Diff(file_dict['b'])}
+        diff_dict = {"a": Diff(file_dict['a'], "a"),
+                     "b": Diff(file_dict['b'], "b")}
         diff_dict["a"].add_lines(1, ["test\n"])
         diff_dict["a"].delete_line(3)
         result = Result("origin", "msg", diffs=diff_dict)
@@ -213,8 +213,8 @@ class ConsoleInteractionTest(unittest.TestCase):
     @patch("coalib.output.ConsoleInteraction.print_diffs_info")
     def test_print_result_interactive_big_patch(self, diffs_info, _):
         file_dict = {"a": ["a\n", "b\n", "c\n"], "b": ["old_first\n"]}
-        diff_dict = {"a": Diff(file_dict['a']),
-                     "b": Diff(file_dict['b'])}
+        diff_dict = {"a": Diff(file_dict['a'], "a"),
+                     "b": Diff(file_dict['b'], "b")}
         diff_dict["a"].add_lines(1, ["test\n", "test1\n", "test2\n"])
         diff_dict["a"].delete_line(3)
         diff_dict["a"].add_lines(3, ["3test\n"])
@@ -251,7 +251,7 @@ class ConsoleInteractionTest(unittest.TestCase):
                 testfile_path: ["1\n", "2\n", "3\n"],
                 "f_b": ["1", "2", "3"]
             }
-            diff = Diff(file_dict[testfile_path])
+            diff = Diff(file_dict[testfile_path], testfile_path)
             diff.delete_line(2)
             diff.change_line(3, "3\n", "3_changed\n")
 
@@ -335,7 +335,7 @@ class ConsoleInteractionTest(unittest.TestCase):
     def test_acquire_actions_and_apply(self):
         with make_temp() as testfile_path:
             file_dict = {testfile_path: ["1\n", "2\n", "3\n"]}
-            diff = Diff(file_dict[testfile_path])
+            diff = Diff(file_dict[testfile_path], testfile_path)
             diff.delete_line(2)
             diff.change_line(3, "3\n", "3_changed\n")
             with simulate_console_inputs(1, 0) as generator, \
@@ -414,7 +414,7 @@ class ConsoleInteractionTest(unittest.TestCase):
     def test_print_result_no_input(self):
         with make_temp() as testfile_path:
             file_dict = {testfile_path: ["1\n", "2\n", "3\n"]}
-            diff = Diff(file_dict[testfile_path])
+            diff = Diff(file_dict[testfile_path], testfile_path)
             diff.delete_line(2)
             diff.change_line(3, "3\n", "3_changed\n")
             with simulate_console_inputs(1, 2, 3) as generator, \

--- a/tests/results/ResultFilterTest.py
+++ b/tests/results/ResultFilterTest.py
@@ -536,7 +536,9 @@ class ResultFilterTest(unittest.TestCase):
         result_diff = remove_result_ranges_diffs(
             [test_result],
             test_file_dict)[test_result][abspath("test_file")]
-        expected_diff = Diff.from_string_arrays(test_file, ["789\n"])
+        expected_diff = Diff.from_string_arrays(test_file,
+                                                ["789\n"],
+                                                abspath("test_file"))
 
         self.assertEqual(result_diff, expected_diff)
 
@@ -555,7 +557,8 @@ class ResultFilterTest(unittest.TestCase):
             [test_result],
             test_file_dict)[test_result][abspath("test_file")]
         expected_diff = Diff.from_string_arrays(test_file,
-                                                ["11", "2", "5", "66"])
+                                                ["11", "2", "5", "66"],
+                                                abspath("test_file"))
 
         self.assertEqual(result_diff, expected_diff)
 
@@ -569,7 +572,9 @@ class ResultFilterTest(unittest.TestCase):
         result_diff = remove_result_ranges_diffs(
             [test_result],
             test_file_dict)[test_result][abspath("test_file")]
-        expected_diff = Diff.from_string_arrays(test_file, ["abc"])
+        expected_diff = Diff.from_string_arrays(test_file,
+                                                ["abc"],
+                                                abspath("test_file"))
 
         self.assertEqual(result_diff, expected_diff)
 

--- a/tests/results/ResultTest.py
+++ b/tests/results/ResultTest.py
@@ -10,6 +10,18 @@ from coalib.output.JSONEncoder import create_json_encoder
 
 class ResultTest(unittest.TestCase):
 
+    def test_constructor(self):
+        fl = ["1", "2", "3", "4"]
+        list_diffs = [Diff(fl, filename="file"), Diff(fl, filename="file1")]
+        dict_diffs = {"file": Diff(fl, filename="file")}
+
+        uut = Result("origin", "msg", diffs=list_diffs)
+        self.assertEqual(uut.diffs["file"].filename, "file")
+        self.assertEqual(uut.diffs["file1"].filename, "file1")
+
+        uut = Result("origin", "msg", diffs=dict_diffs)
+        self.assertEqual(uut.diffs["file"], dict_diffs["file"])
+
     def test_origin(self):
         uut = Result("origin", "msg")
         self.assertEqual(uut.origin, "origin")
@@ -75,7 +87,7 @@ class ResultTest(unittest.TestCase):
             "f_a": ["1", "3_changed"],
             "f_b": ["1", "2", "3"]
         }
-        diff = Diff(file_dict['f_a'])
+        diff = Diff(file_dict['f_a'], "f_a")
         diff.delete_line(2)
         diff.change_line(3, "3", "3_changed")
 
@@ -96,15 +108,15 @@ class ResultTest(unittest.TestCase):
             "f_c": ["1", "2", "3"]
         }
 
-        diff = Diff(file_dict['f_a'])
+        diff = Diff(file_dict['f_a'], "f_a")
         diff.delete_line(2)
         uut1 = Result("origin", "msg", diffs={"f_a": diff})
 
-        diff = Diff(file_dict['f_a'])
+        diff = Diff(file_dict['f_a'], "f_a")
         diff.change_line(3, "3", "3_changed")
         uut2 = Result("origin", "msg", diffs={"f_a": diff})
 
-        diff = Diff(file_dict['f_b'])
+        diff = Diff(file_dict['f_b'], "f_a")
         diff.change_line(3, "3", "3_changed")
         uut3 = Result("origin", "msg", diffs={"f_b": diff})
 
@@ -153,7 +165,7 @@ class ResultTest(unittest.TestCase):
             "f_a": ["1", "3_changed"],
             "f_b": ["1", "2", "3"]
         }
-        diff = Diff(file_dict['f_a'])
+        diff = Diff(file_dict['f_a'], "f_a")
         diff.delete_line(2)
         diff.change_line(3, "3", "3_changed")
         uut = Result("origin", "msg", diffs={"f_a": diff}).__json__(True)

--- a/tests/results/SourceRangeTest.py
+++ b/tests/results/SourceRangeTest.py
@@ -108,12 +108,15 @@ class SourceRangeTest(unittest.TestCase):
         self.assertEqual(src_range.renamed_file({}), abspath('test_file'))
 
         self.assertEqual(
-            src_range.renamed_file({abspath('test_file'): Diff([])}),
+            src_range.renamed_file(
+                {abspath('test_file'): Diff([], "test_file")}),
             abspath('test_file'))
 
         self.assertEqual(
             src_range.renamed_file(
-                {abspath('test_file'): Diff([], rename='another_file')}),
+                {abspath('test_file'): Diff([],
+                                            "test_file",
+                                            rename='another_file')}),
             'another_file')
 
 

--- a/tests/results/result_actions/ApplyPatchActionTest.py
+++ b/tests/results/result_actions/ApplyPatchActionTest.py
@@ -28,21 +28,21 @@ class ApplyPatchActionTest(unittest.TestCase):
 
             file_diff_dict = {}
 
-            diff = Diff(file_dict[f_a])
+            diff = Diff(file_dict[f_a], "f_a")
             diff.delete_line(2)
             uut.apply_from_section(Result("origin", "msg", diffs={f_a: diff}),
                                    file_dict,
                                    file_diff_dict,
                                    Section("t"))
 
-            diff = Diff(file_dict[f_a])
+            diff = Diff(file_dict[f_a], "f_a")
             diff.change_line(3, "3\n", "3_changed\n")
             uut.apply_from_section(Result("origin", "msg", diffs={f_a: diff}),
                                    file_dict,
                                    file_diff_dict,
                                    Section("t"))
 
-            diff = Diff(file_dict[f_b])
+            diff = Diff(file_dict[f_b], "f_b")
             diff.change_line(3, "3\n", "3_changed\n")
             uut.apply(Result("origin", "msg", diffs={f_b: diff}),
                       file_dict,
@@ -72,13 +72,13 @@ class ApplyPatchActionTest(unittest.TestCase):
                 f_b: ["1\n", "2\n", "3_changed\n"]
                 }
             file_diff_dict = {}
-            diff = Diff(file_dict[f_a])
+            diff = Diff(file_dict[f_a], f_a)
             diff.change_line(3, "3\n", "3_changed\n")
             uut.apply(Result("origin", "msg", diffs={f_a: diff}),
                       file_dict,
                       file_diff_dict,
                       no_orig=True)
-            diff = Diff(file_dict[f_b])
+            diff = Diff(file_dict[f_b], f_b)
             diff.change_line(3, "3\n", "3_changed\n")
             uut.apply(Result("origin", "msg", diffs={f_b: diff}),
                       file_dict,
@@ -99,7 +99,7 @@ class ApplyPatchActionTest(unittest.TestCase):
             expected_file_dict = {f_a+".renamed":
                                       ["1\n", "2_changed\n", "3_changed\n"]}
             file_diff_dict = {}
-            diff = Diff(file_dict[f_a], rename=f_a+".renamed")
+            diff = Diff(file_dict[f_a], f_a, rename=f_a+".renamed")
             diff.change_line(3, "3\n", "3_changed\n")
             uut.apply(Result("origin", "msg", diffs={f_a: diff}),
                       file_dict,
@@ -108,7 +108,7 @@ class ApplyPatchActionTest(unittest.TestCase):
             self.assertTrue(isfile(f_a+".renamed"))
             self.assertFalse(isfile(f_a))
 
-            diff = Diff(file_dict[f_a])
+            diff = Diff(file_dict[f_a], f_a)
             diff.change_line(2, "2\n", "2_changed\n")
             uut.apply(Result("origin", "msg", diffs={f_a: diff}),
                       file_dict,
@@ -126,7 +126,7 @@ class ApplyPatchActionTest(unittest.TestCase):
         with make_temp() as f_a:
             file_dict = {f_a: ["1\n", "2\n", "3\n"]}
             file_diff_dict = {}
-            diff = Diff(file_dict[f_a], delete=True)
+            diff = Diff(file_dict[f_a], f_a, delete=True)
             uut.apply(Result("origin", "msg", diffs={f_a: diff}),
                       file_dict,
                       file_diff_dict)
@@ -134,7 +134,7 @@ class ApplyPatchActionTest(unittest.TestCase):
             self.assertTrue(isfile(f_a+".orig"))
             os.remove(f_a+".orig")
 
-            diff = Diff(file_dict[f_a])
+            diff = Diff(file_dict[f_a], f_a)
             diff.change_line(3, "3\n", "3_changed\n")
             uut.apply(Result("origin", "msg", diffs={f_a: diff}),
                       file_dict,
@@ -144,14 +144,14 @@ class ApplyPatchActionTest(unittest.TestCase):
             open(f_a, 'w').close()
 
     def test_is_applicable(self):
-        diff = Diff(["1\n", "2\n", "3\n"])
+        diff = Diff(["1\n", "2\n", "3\n"], "f")
         diff.delete_line(2)
         patch_result = Result("", "", diffs={'f': diff})
         self.assertTrue(
             ApplyPatchAction.is_applicable(patch_result, {}, {}))
 
     def test_is_applicable_conflict(self):
-        diff = Diff(["1\n", "2\n", "3\n"])
+        diff = Diff(["1\n", "2\n", "3\n"], "f")
         diff.add_lines(2, ['a line'])
 
         conflict_result = Result("", "", diffs={'f': diff})

--- a/tests/results/result_actions/OpenEditorActionTest.py
+++ b/tests/results/result_actions/OpenEditorActionTest.py
@@ -50,7 +50,7 @@ class OpenEditorActionTest(unittest.TestCase):
             "f_c": ["1\n", "2\n", "3\n"]}
 
         # A patch that was applied for some reason to make things complicated
-        diff_dict = {self.fb: Diff(file_dict[self.fb])}
+        diff_dict = {self.fb: Diff(file_dict[self.fb], self.fb)}
         diff_dict[self.fb].change_line(3, "3\n", "3_changed\n")
 
         # File contents after the patch was applied, that's what's in the files
@@ -97,7 +97,7 @@ class OpenEditorActionTest(unittest.TestCase):
 
         # A patch that was applied for some reason to make things complicated
         file_diff_dict = {}
-        diff = Diff(file_dict[self.fa], rename=self.fa+".renamed")
+        diff = Diff(file_dict[self.fa], self.fa, rename=self.fa+".renamed")
         diff.change_line(3, "3\n", "3_changed\n")
         ApplyPatchAction().apply(
             Result("origin", "msg", diffs={self.fa: diff}),

--- a/tests/results/result_actions/ShowPatchActionTest.py
+++ b/tests/results/result_actions/ShowPatchActionTest.py
@@ -13,8 +13,8 @@ class ShowPatchActionTest(unittest.TestCase):
     def setUp(self):
         self.uut = ShowPatchAction()
         self.file_dict = {"a": ["a\n", "b\n", "c\n"], "b": ["old_first\n"]}
-        self.diff_dict = {"a": Diff(self.file_dict['a']),
-                          "b": Diff(self.file_dict['b'])}
+        self.diff_dict = {"a": Diff(self.file_dict['a'], "a"),
+                          "b": Diff(self.file_dict['b'], "b")}
         self.diff_dict["a"].add_lines(1, ["test\n"])
         self.diff_dict["a"].delete_line(3)
         self.diff_dict["b"].add_lines(0, ["first\n"])
@@ -52,7 +52,7 @@ class ShowPatchActionTest(unittest.TestCase):
     def test_apply_renaming_only(self):
         with retrieve_stdout() as stdout:
             test_result = Result("origin", "message",
-                                 diffs={'a': Diff([], rename='b')})
+                                 diffs={'a': Diff([], "a", rename='b')})
             file_dict = {'a': []}
             self.assertEqual(self.uut.apply_from_section(test_result,
                                                          file_dict,
@@ -66,7 +66,7 @@ class ShowPatchActionTest(unittest.TestCase):
     def test_apply_empty(self):
         with retrieve_stdout() as stdout:
             test_result = Result("origin", "message",
-                                 diffs={'a': Diff([])})
+                                 diffs={'a': Diff([], "a")})
             file_dict = {'a': []}
             self.assertEqual(self.uut.apply_from_section(test_result,
                                                          file_dict,
@@ -77,7 +77,7 @@ class ShowPatchActionTest(unittest.TestCase):
 
     def test_apply_with_previous_patches(self):
         with retrieve_stdout() as stdout:
-            previous_diffs = {"a": Diff(self.file_dict['a'])}
+            previous_diffs = {"a": Diff(self.file_dict['a'], "a")}
             previous_diffs["a"].change_line(2, "b\n", "b_changed\n")
             self.assertEqual(self.uut.apply_from_section(self.test_result,
                                                          self.file_dict,
@@ -98,11 +98,11 @@ class ShowPatchActionTest(unittest.TestCase):
 
     def test_apply_with_rename(self):
         with retrieve_stdout() as stdout:
-            previous_diffs = {"a": Diff(self.file_dict['a'])}
+            previous_diffs = {"a": Diff(self.file_dict['a'], "a")}
             previous_diffs["a"].change_line(2, "b\n", "b_changed\n")
 
-            diff_dict = {"a": Diff(self.file_dict['a'], rename="a.rename"),
-                         "b": Diff(self.file_dict['b'], delete=True)}
+            diff_dict = {"a": Diff(self.file_dict['a'], "a", rename="a.rename"),
+                         "b": Diff(self.file_dict['b'], "b", delete=True)}
             diff_dict["a"].add_lines(1, ["test\n"])
             diff_dict["a"].delete_line(3)
             diff_dict["b"].add_lines(0, ["first\n"])

--- a/tests/test_bears/internal_folder/SpaceConsistencyTestBear.py
+++ b/tests/test_bears/internal_folder/SpaceConsistencyTestBear.py
@@ -59,7 +59,7 @@ class SpaceConsistencyTestBear(LocalBear):
                     result_texts.append("Spaces used instead of tabs.")
 
             if len(result_texts) > 0:
-                diff = Diff(file)
+                diff = Diff(file, filename)
                 diff.change_line(line_number, line, replacement)
                 inconsistencies = "".join("\n- " + string
                                           for string in result_texts)


### PR DESCRIPTION
Add a `filename` property to Diff, allowing a Results object to
be initialized with a collection of Diffs. Backwards compatable
with the previous method of initializing Diff and Result objects.

Addresses https://github.com/coala-analyzer/coala/issues/2194
