### PR TITLE
DistributionRequirement: Use distro module

### DIFF
--- a/coalib/bears/requirements/DistributionRequirement.py
+++ b/coalib/bears/requirements/DistributionRequirement.py
@@ -38,16 +38,18 @@ class DistributionRequirement(PackageRequirement):
                         'redhat': 'yum',
                         'arch': 'pacman'}
 
-        if (platform.linux_distribution()[0] in manager_dict.keys() and
-                manager_dict[platform.linux_distribution()[0]]
+        if platform.system() == 'Linux':  # pragma: no cover
+            import distro
+            distro_name = distro.linux_distribution()[0]
+        if (distro_name in manager_dict.keys() and manager_dict[distro_name]
                 in self.package.keys()):
-            manager = manager_dict[platform.linux_distribution()[0]]
+            manager = manager_dict[distro_name]
             return [manager.replace("_", "-"),
                     'install', self.package[manager]]
         else:
             package_possibilites = (
                 {package for package in self.package.values()})
-            print('The package could not be automatically installed on your '
-                  'operating system. Please try installing it manually. It'
+            print('The package could not be automatically installed on your'
+                  ' operating system. Please try installing it manually. It'
                   ' should look like this: ' + repr(package_possibilites))
             raise OSError

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ setuptools>=19.2
 libclang-py3==0.2
 appdirs~=1.4
 coala_utils~=0.4.9
+distro>=0.6.0

--- a/tests/bears/requirements/DistributionRequirementTest.py
+++ b/tests/bears/requirements/DistributionRequirementTest.py
@@ -1,23 +1,31 @@
 import platform
+import subprocess
 import unittest
 from unittest.mock import patch
+
+try:
+    import distro
+except subprocess.CalledProcessError:
+    pass
 
 from coalib.bears.requirements.DistributionRequirement import (
     DistributionRequirement)
 
 
+@unittest.skipIf(platform.system() == 'Windows',
+                 "This test cannot be run on Windows.")
 class DistributionRequirementTestCase(unittest.TestCase):
 
-    @patch('platform.linux_distribution', return_value=('Fedora',))
+    @patch('distro.linux_distribution', return_value=('Fedora',))
     def test_install_command_mock_fedora(self, call_mock):
-        self.assertEqual(platform.linux_distribution()[0], 'Fedora')
+        self.assertEqual(distro.linux_distribution()[0], 'Fedora')
         self.assertEqual(DistributionRequirement(
             dnf='libclang', apt_get='libclangs').install_command(),
             ['dnf', 'install', 'libclang'])
 
-    @patch('platform.linux_distribution', return_value=('bad_os',))
+    @patch('distro.linux_distribution', return_value=('bad_os',))
     def test_install_command_mock_incompatible_os(self, call_mock):
-        self.assertEqual(platform.linux_distribution()[0], 'bad_os')
+        self.assertEqual(distro.linux_distribution()[0], 'bad_os')
         with self.assertRaises(OSError):
             DistributionRequirement(
                 dnf='libclang', apt_get='libclangs').install_command()


### PR DESCRIPTION
Some platform module functions are deprecated as of python version
3.5.
Source: https://bugs.python.org/issue1322

distro module is recommended as the alternative

Fixes https://github.com/coala-analyzer/coala/issues/2675

CC @AbdealiJK @Adrianzatreanu 
