### PR TITLE
Lint.py: Replace deprecated link

### DIFF
--- a/coalib/bearlib/abstractions/Lint.py
+++ b/coalib/bearlib/abstractions/Lint.py
@@ -43,7 +43,7 @@ class Lint(Bear):
     Deals with the creation of linting bears.
 
     For the tutorial see:
-    https://coala.readthedocs.io/en/stable/Users/Tutorials/Linter_Bears.html
+    http://docs.coala.io/en/stable/Users/Tutorials/Linter_Bears.html
 
     :param executable:                  The executable to run the linter.
     :param prerequisite_command:        The command to run as a prerequisite

--- a/coalib/bearlib/abstractions/Lint.py
+++ b/coalib/bearlib/abstractions/Lint.py
@@ -43,7 +43,7 @@ class Lint(Bear):
     Deals with the creation of linting bears.
 
     For the tutorial see:
-    http://coala.readthedocs.org/en/latest/Users/Tutorials/Linter_Bears.html
+    https://coala.readthedocs.io/en/stable/Users/Tutorials/Linter_Bears.html
 
     :param executable:                  The executable to run the linter.
     :param prerequisite_command:        The command to run as a prerequisite

--- a/coalib/bears/Bear.py
+++ b/coalib/bears/Bear.py
@@ -249,9 +249,8 @@ class Bear(Printer, LogPrinter):
             result = self.run_bear_from_section(args, kwargs)
             return [] if result is None else list(result)
         except:
-            self.warn(
-                "Bear {} failed to run. Take a look at debug messages (`-L "
-                "DEBUG`) for further information.".format(name))
+            self.warn("Bear {} failed to run. Take a look at debug messages"
+                      " (`-V`) for further information.".format(name))
             self.debug(
                 "The bear {bear} raised an exception. If you are the writer "
                 "of this bear, please make sure to catch all exceptions. If "

--- a/tests/bears/BearTest.py
+++ b/tests/bears/BearTest.py
@@ -89,7 +89,7 @@ class BearTest(unittest.TestCase):
         self.check_message(LOG_LEVEL.DEBUG)
         self.check_message(LOG_LEVEL.WARNING,
                            "Bear BadTestBear failed to run. Take a look at "
-                           "debug messages (`-L DEBUG`) for further "
+                           "debug messages (`-V`) for further "
                            "information.")
         # debug message contains custom content, dont test this here
         self.queue.get()


### PR DESCRIPTION
Replaced the deprecated link from the `Lint` class in `Lint.py`

Replaced the (deprecated)link "http://coala.readthedocs.io/en/latest/Users/Tutorials/Linter_Bears.html" in the `Lint` class' docstring in `Lint.py` to "https://coala.readthedocs.io/en/stable/Users/Tutorials/Linter_Bears.html"

Closes #2774 
