### PR TITLE
circle.yml: Remove -V tag

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -18,7 +18,7 @@ test:
     - pip install coala-bears colorama==0.3.6 --pre -U:
         parallel: true
         timeout: 900  # Allow 15 mins
-    - coala-ci -V:
+    - coala-ci:
         parallel: true
     - bash .misc/deploy.coverage.sh:
         parallel: true


### PR DESCRIPTION
The coala-ci -V command in circle.yml shows a lot of unnecessary info.
Removing it helps display only the relevant information

Fixes https://github.com/coala/coala/issues/2777