### PR TITLE
LogPrinter: Change log type DEBUG to log type info

### DIFF
--- a/coalib/output/printers/LogPrinter.py
+++ b/coalib/output/printers/LogPrinter.py
@@ -115,7 +115,7 @@ class LogPrinter:
 
         self.log(log_level, message, timestamp=timestamp, **kwargs)
         self.log_message(
-            LogMessage(LOG_LEVEL.DEBUG,
+            LogMessage(LOG_LEVEL.INFO,
                        "Exception was:" + "\n" + traceback_str,
                        timestamp=timestamp),
             **kwargs)

--- a/tests/output/printers/LogPrinterTest.py
+++ b/tests/output/printers/LogPrinterTest.py
@@ -112,7 +112,7 @@ class LogPrinterTest(unittest.TestCase):
         self.assertTrue(uut.printer.string.startswith(
             "[ERROR][" + self.timestamp.strftime("%X") +
             "] Something failed.\n" +
-            "[DEBUG][" + self.timestamp.strftime("%X") +
+            "[INFO][" + self.timestamp.strftime("%X") +
             "] Exception was:"))
 
         uut.log_level = LOG_LEVEL.INFO


### PR DESCRIPTION
Instead of asking the user to run coala with ``-L DEBUG``,

it's better to have exception tracebacks default.

Closes #2660