### PR TITLE
ConsoleInteraction.py: Add document string to the method

### DIFF
--- a/coalib/output/ConsoleInteraction.py
+++ b/coalib/output/ConsoleInteraction.py
@@ -423,6 +423,16 @@ def print_results(log_printer,
 
 
 def print_affected_lines(console_printer, file_dict, section, sourcerange):
+    """
+    Prints the lines affected by the bears.
+
+    :param console_printer:    Object to print messages on the console.
+    :param file_dict:          A dictionary containing all files with filename
+                               as key.
+    :param section:            The section to which the results belong to.
+    :param sourcerange:        The SourceRange object referring to the related
+                               lines to print.
+    """
     console_printer.print("\n" + os.path.relpath(sourcerange.file),
                           color=FILE_NAME_COLOR)
 


### PR DESCRIPTION
print_affected_lines

Adds the document string to make it more understandable.

Closes https://github.com/coala/coala/issues/2801