### PR TITLE
Collectors: Fix error message

### DIFF
--- a/coalib/collecting/Collectors.py
+++ b/coalib/collecting/Collectors.py
@@ -170,7 +170,7 @@ def collect_bears(bear_dirs, bear_globs, kinds, log_printer,
 
     if warn_if_unused_glob:
         _warn_if_unused_glob(log_printer, bear_globs, bear_globs_with_bears,
-                             "No bears were found matching '{}'. Make sure you "
+                             "No bears matching '{}' were found. Make sure you "
                              "have coala-bears installed or you have typed the "
                              "name correctly.")
     return bears_found

--- a/tests/collecting/CollectorsTest.py
+++ b/tests/collecting/CollectorsTest.py
@@ -211,7 +211,7 @@ class CollectBearsTest(unittest.TestCase):
                                        ["invalid kind"],
                                        self.log_printer), ([],))
         self.assertEqual([log.message for log in self.log_printer.logs],
-                         ["No bears were found matching 'invalid_name'. Make "
+                         ["No bears matching 'invalid_name' were found. Make "
                           "sure you have coala-bears installed or you have "
                           "typed the name correctly."])
 


### PR DESCRIPTION
This PR fixes issue #1476 

I have refactored the error message from <code>No bears were found matching 'pyLintBear'.</code> to <code>No bears matching 'pyLintBear' were found.</code>