### PR TITLE
rename coala-analyzer to coala

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -10,7 +10,7 @@ design enhancements issues as well as pull Requests to make *coala* more
 convenient, functional and bug free.
 
 To begin contributing have a look at the open issues labeled with
-difficulty/newcomer - `newcomer issues <https://github.com/coala-analyzer/coala/issues?q=is%3Aissue+is%3Aopen+label%3Adifficulty%2Fnewcomer>`__.
+difficulty/newcomer - `newcomer issues <https://github.com/coala/coala/issues?q=is%3Aissue+is%3Aopen+label%3Adifficulty%2Fnewcomer>`__.
 
 Follow the instructions
 `here <https://coala.io/newcomers>`__
@@ -61,4 +61,4 @@ and again cluttering our history. If a reviewer has suggestions, the commit
 shall be amended so the history is not cluttered by “fixup commits”.
 
 For further information/queries feel free to discuss with us on
-`gitter <https://gitter.im/coala-analyzer/coala>`__.
+`gitter <https://gitter.im/coala/coala>`__.

--- a/README.rst
+++ b/README.rst
@@ -17,7 +17,7 @@ popular languages such as **C/C++**, **Python**, **JavaScript**, **CSS**,
 **Java** and many more, in addition to some generic language independent
 algorithms. To learn more about the different languages supported and the
 bears themselves,
-`click here. <https://github.com/coala-analyzer/bear-docs/blob/master/README.rst>`__
+`click here. <https://github.com/coala/bear-docs/blob/master/README.rst>`__
 
 To see what coala can do for your language, run:
 
@@ -49,16 +49,16 @@ To see what coala can do for your language, run:
 Features
 ========
 
-* Out-of-the-box support for various `popular languages <https://github.com/coala-analyzer/bear-docs/blob/master/README.rst>`__,
+* Out-of-the-box support for various `popular languages <https://github.com/coala/bear-docs/blob/master/README.rst>`__,
   such as **C/C++**, **Python**, **Javascript**, **CSS**, **Java** and many
   others with built-in check routines.
 * User-friendly interfaces such as JSON, interactive CLI or any custom format.
 * Plugins for
-  `gedit <https://github.com/coala-analyzer/coala-gedit>`__,
-  `Sublime Text <https://github.com/coala-analyzer/coala-sublime>`__,
-  `Atom <https://github.com/coala-analyzer/coala-atom>`__,
-  `Vim <https://github.com/coala-analyzer/coala-vim>`__ and
-  `Emacs <https://github.com/coala-analyzer/coala-emacs>`__.
+  `gedit <https://github.com/coala/coala-gedit>`__,
+  `Sublime Text <https://github.com/coala/coala-sublime>`__,
+  `Atom <https://github.com/coala/coala-atom>`__,
+  `Vim <https://github.com/coala/coala-vim>`__ and
+  `Emacs <https://github.com/coala/coala-emacs>`__.
 * Optimized performace with multi-threading to parallelize the routines - can
   complete a 26000 line python repository in less than 3 seconds.
 * File caching support - run only on changed files (experimental).
@@ -133,9 +133,9 @@ A sample ``.coafile`` will look something like this:
   python files inside the ``src/`` directory by using a glob expression.
 * The ``bears`` key specifies which bears (plugins) you want to use. We support
   a huge number of languages and you can find the whole list
-  `here <https://github.com/coala-analyzer/bear-docs/blob/master/README.rst>`__.
+  `here <https://github.com/coala/bear-docs/blob/master/README.rst>`__.
   If you don't find your langauge there, we've got some
-  `bears that work for all languages <https://github.com/coala-analyzer/bear-docs/blob/master/README.rst#all>`__. Or you can file an issue and we would create a bear for you!
+  `bears that work for all languages <https://github.com/coala/bear-docs/blob/master/README.rst#all>`__. Or you can file an issue and we would create a bear for you!
 * ``use_spaces`` enforces spaces over tabs in the codebase. ``use_spaces`` is a
   setting for the ``SpaceConsistencyBear``.
 
@@ -205,10 +205,10 @@ or need some help, feel free to contact us on Gitter or drop a mail at our
 Support
 =======
 
-Feel free to contact us at our `Gitter channel <https://gitter.im/coala-analyzer/coala>`__, we'd be happy to help!
+Feel free to contact us at our `Gitter channel <https://gitter.im/coala/coala>`__, we'd be happy to help!
 
 You can also drop an email at our
-`mailing list <https://github.com/coala-analyzer/coala/wiki/Mailing-Lists>`__.
+`mailing list <https://github.com/coala/coala/wiki/Mailing-Lists>`__.
 
 -----
 
@@ -232,20 +232,20 @@ License
 .. |Stable| image:: https://img.shields.io/badge/latest%20stable-0.8.1-green.svg
 .. |PyPI| image:: https://img.shields.io/pypi/pyversions/coala.svg
    :target: https://pypi.python.org/pypi/coala
-.. |Linux Build Status| image:: https://img.shields.io/circleci/project/coala-analyzer/coala/master.svg?label=linux%20build
-   :target: https://circleci.com/gh/coala-analyzer/coala
+.. |Linux Build Status| image:: https://img.shields.io/circleci/project/coala/coala/master.svg?label=linux%20build
+   :target: https://circleci.com/gh/coala/coala
 .. |Windows Build status| image:: https://img.shields.io/appveyor/ci/coala/coala/master.svg?label=windows%20build
    :target: https://ci.appveyor.com/project/coala/coala/branch/master
 .. |Scrutinizer Code Quality| image:: https://img.shields.io/scrutinizer/g/coala-analyzer/coala.svg?label=scrutinizer%20quality
    :target: https://scrutinizer-ci.com/g/coala-analyzer/coala/?branch=master
-.. |codecov.io| image:: https://img.shields.io/codecov/c/github/coala-analyzer/coala/master.svg?label=branch%20coverage
-   :target: https://codecov.io/github/coala-analyzer/coala?branch=master
+.. |codecov.io| image:: https://img.shields.io/codecov/c/github/coala/coala/master.svg?label=branch%20coverage
+   :target: https://codecov.io/github/coala/coala?branch=master
 .. |Documentation Status| image:: https://readthedocs.org/projects/coala/badge/?version=latest
    :target: http://coala.rtfd.org/
-.. |AGPL| image:: https://img.shields.io/github/license/coala-analyzer/coala.svg
+.. |AGPL| image:: https://img.shields.io/github/license/coala/coala.svg
    :target: https://www.gnu.org/licenses/agpl-3.0.html
 .. |Gitmate| image:: https://img.shields.io/badge/Gitmate-0%20issues-brightgreen.svg
    :target: http://gitmate.com/
-.. |gitter| image:: https://badges.gitter.im/coala-analyzer/coala.svg
-    :target: https://gitter.im/coala-analyzer/coala
+.. |gitter| image:: https://badges.gitter.im/coala/coala.svg
+    :target: https://gitter.im/coala/coala
     :alt: Chat on Gitter

--- a/coalib/parsing/DefaultArgParser.py
+++ b/coalib/parsing/DefaultArgParser.py
@@ -46,7 +46,7 @@ coala provides a common command-line interface for linting and fixing all your
 code, regardless of the programming languages you use.
 
 To find out what kind of analysis coala offers for the languages you use, visit
-<https://github.com/coala-analyzer/bear-docs/blob/master/README.rst#supported-languages>
+<https://github.com/coala/bear-docs/blob/master/README.rst#supported-languages>
 or run:
 
     $ coala --show-bears --filter-by-language C Python

--- a/setup.py
+++ b/setup.py
@@ -84,7 +84,7 @@ if __name__ == "__main__":
           maintainer_email=('lasse.schuirmann@gmail.com, '
                             'fabian@neuschmidt.de, '
                             'makman@alice.de'),
-          url='http://coala-analyzer.org/',
+          url='http://coala.io/',
           platforms='any',
           packages=find_packages(exclude=["build.*", "tests", "tests.*"]),
           install_requires=required,


### PR DESCRIPTION
everything is renamed, except Scrutinizer Code Quality (README 239-240) because coala account not exists.

ref #2813 