### PR TITLE
ConsoleInteraction: Typing Error in docstring

### DIFF
--- a/coalib/output/ConsoleInteraction.py
+++ b/coalib/output/ConsoleInteraction.py
@@ -316,7 +316,7 @@ def print_affected_files(console_printer,
                          file_dict,
                          color=True):
     """
-    Prints all the afected files and affected lines within them.
+    Prints all the affected files and affected lines within them.
 
     :param console_printer: Object to print messages on the console.
     :param log_printer:     Printer responsible for logging the messages.


### PR DESCRIPTION
Change in coala/coalib/output/Consoleinteraction.py. Typo error in line 319.
Fixes https://github.com/coala/coala/issues/2836