### PR TITLE
README.rst: Remove (experimental) from caching feature point

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -61,7 +61,7 @@ Features
   `Emacs <https://github.com/coala/coala-emacs>`__.
 * Optimized performace with multi-threading to parallelize the routines - can
   complete a 26000 line python repository in less than 3 seconds.
-* File caching support - run only on changed files (experimental).
+* File caching support - run only on changed files.
 
 -----
 


### PR DESCRIPTION
README.rst: Remove (experimental) from caching feature point

Since the file caching support feature is now enabled by default, it is no longer experimental. Thus the word "experimental" must no more appear in the line describing the caching feature.

Fixes #2841  