### PR TITLE
Add arg_parser doc

### DIFF
--- a/coalib/settings/ConfigurationGathering.py
+++ b/coalib/settings/ConfigurationGathering.py
@@ -336,6 +336,8 @@ def gather_configuration(acquire_settings,
     :param autoapply:        Set whether to autoapply patches. This is
                              overridable via any configuration file/CLI.
     :param arg_list:         CLI args to use
+    :param arg_parser:       Instance of ArgParser that is used to parse
+                             none-setting arguments.
     :return:                 A tuple with the following contents:
 
                              -  A dictionary with the sections


### PR DESCRIPTION
ConfigurationGathering.py: Add arg_parser doc

Add parameter arg_parser and its definition in the docstring

Closes https://github.com/coala/coala/issues/2811