### PR TITLE
documentation: Fix typo in bearlib/__init__.py

### DIFF
--- a/coalib/bearlib/__init__.py
+++ b/coalib/bearlib/__init__.py
@@ -60,7 +60,7 @@ def deprecate_settings(**depr_args):
      ['old']
 
      You cannot deprecate an already deprecated setting. Don't try. It will
-     introduce nondeterministic errors to your program.
+     introduce non-deterministic errors to your program.
 
      :param depr_args: A dictionary of settings as keys and their deprecated
                        names as values.

--- a/coalib/output/ConsoleInteraction.py
+++ b/coalib/output/ConsoleInteraction.py
@@ -321,7 +321,7 @@ def print_affected_files(console_printer,
     :param console_printer: Object to print messages on the console.
     :param log_printer:     Printer responsible for logging the messages.
     :param section:         The section to which the results belong to.
-    :param result_list:     List containing the results
+    :param result:          The result to print the context for.
     :param file_dict:       A dictionary containing all files with filename as
                             key.
     :param color:           Boolean variable to print the results in color or


### PR DESCRIPTION
Changed nondeterministic to non-deterministic

Closes https://github.com/coala/coala/issues/2838
