### PR TITLE
FunctionMetadata: Store params that are deprecated

### DIFF
--- a/coalib/bearlib/__init__.py
+++ b/coalib/bearlib/__init__.py
@@ -91,7 +91,7 @@ def deprecate_settings(**depr_args):
             deprecated_arg = (depr_arg_and_modifier[0]
                               if isinstance(depr_arg_and_modifier, tuple)
                               else depr_arg_and_modifier)
-            new_metadata.add_alias(arg, deprecated_arg)
+            new_metadata.add_deprecated_param(arg, deprecated_arg)
         wrapping_function.__metadata__ = new_metadata
 
         return wrapping_function

--- a/coalib/settings/FunctionMetadata.py
+++ b/coalib/settings/FunctionMetadata.py
@@ -17,7 +17,8 @@ class FunctionMetadata:
                  retval_desc: str="",
                  non_optional_params: (dict, None)=None,
                  optional_params: (dict, None)=None,
-                 omit: (set, tuple, list, frozenset)=frozenset()):
+                 omit: (set, tuple, list, frozenset)=frozenset(),
+                 deprecated_params: (set, tuple, list, frozenset)=frozenset()):
         """
         Creates the FunctionMetadata object.
 
@@ -34,6 +35,7 @@ class FunctionMetadata:
                                     the default value. To preserve the order,
                                     use OrderedDict.
         :param omit:                A set of parameters to omit.
+        :param deprecared_params:   A list of params that are deprecated.
         """
         if non_optional_params is None:
             non_optional_params = OrderedDict()
@@ -46,6 +48,7 @@ class FunctionMetadata:
         self._non_optional_params = non_optional_params
         self._optional_params = optional_params
         self.omit = set(omit)
+        self.deprecated_params = set(deprecated_params)
 
     @property
     def desc(self):
@@ -91,7 +94,7 @@ class FunctionMetadata:
         """
         return self._filter_out_omitted(self._optional_params)
 
-    def add_alias(self, original, alias):
+    def add_deprecated_param(self, original, alias):
         """
         Adds an alias for the original setting. The alias setting will have
         the same metadata as the original one. If the original setting is not
@@ -101,6 +104,7 @@ class FunctionMetadata:
         :param alias:     The name of the alias for the original.
         :raises KeyError: If the new setting doesn't exist in the metadata.
         """
+        self.deprecated_params.add(alias)
         self._optional_params[alias] = (
             self._optional_params[original]
             if original in self._optional_params
@@ -287,10 +291,13 @@ class FunctionMetadata:
             merged_optional_params.update(metadata._optional_params)
 
         merged_omit = set.union(*(metadata.omit for metadata in metadatas))
+        merged_deprecated_params = set.union(*(
+            metadata.deprecated_params for metadata in metadatas))
 
         return cls(merged_name,
                    merged_desc,
                    merged_retval_desc,
                    merged_non_optional_params,
                    merged_optional_params,
-                   merged_omit)
+                   merged_omit,
+                   merged_deprecated_params)

--- a/tests/settings/FunctionMetadataTest.py
+++ b/tests/settings/FunctionMetadataTest.py
@@ -107,14 +107,14 @@ class FunctionMetadataTest(unittest.TestCase):
         self.assertEqual(metadata.non_optional_params, non_optional_params)
         self.assertEqual(metadata.optional_params, optional_params)
 
-    def test_add_alias(self):
+    def test_add_deprecated_param(self):
         uut = FunctionMetadata(
             "test",
             non_optional_params={'not_optional': ('desc', str)},
             optional_params={'optional': ('desc2', str, 'default')})
 
-        uut.add_alias('optional', 'old_optional')
-        uut.add_alias('not_optional', 'old_not_optional')
+        uut.add_deprecated_param('optional', 'old_optional')
+        uut.add_deprecated_param('not_optional', 'old_not_optional')
 
         self.assertEqual(uut.non_optional_params,
                          {'not_optional': ('desc', str)})
@@ -130,7 +130,8 @@ class FunctionMetadataTest(unittest.TestCase):
             "Returns 0 on success",
             {"argc": ("argc desc", None), "argv": ("argv desc", None)},
             {"opt": ("opt desc", int, 88)},
-            {"self", "A"})
+            {"self", "A"},
+            {"test1"})
 
         metadata2 = FunctionMetadata(
             "process",
@@ -139,7 +140,8 @@ class FunctionMetadataTest(unittest.TestCase):
             {"argc": ("argc desc from process", int),
              "to_process": ("to_process desc", int)},
             {"opt2": ("opt2 desc", str, "hello")},
-            {"self", "B"})
+            {"self", "B"},
+            {"test2"})
 
         metadata3 = FunctionMetadata("nodesc", "", "", {}, {})
 
@@ -165,3 +167,6 @@ class FunctionMetadataTest(unittest.TestCase):
         self.assertEqual(
             merged_metadata.omit,
             frozenset({"self", "A", "B"}))
+        self.assertEqual(
+            merged_metadata.deprecated_params,
+            frozenset({"test1", "test2"}))


### PR DESCRIPTION
This is useful in the generation of bear-docs to remove the
deprecated params from listing.