### PR TITLE
Mention the section when a setting is missing

### DIFF
--- a/coalib/output/ConsoleInteraction.py
+++ b/coalib/output/ConsoleInteraction.py
@@ -54,7 +54,7 @@ def highlight_text(text, lexer=TextLexer(), style=None):
 
 
 STR_GET_VAL_FOR_SETTING = ("Please enter a value for the setting \"{}\" ({}) "
-                           "needed by {}: ")
+                           "needed by {} for section \"{}\": ")
 STR_LINE_DOESNT_EXIST = ("The line belonging to the following result "
                          "cannot be printed because it refers to a line "
                          "that doesn't seem to exist in the given file.")
@@ -470,7 +470,7 @@ def join_names(values):
         return values[0]
 
 
-def require_setting(setting_name, arr):
+def require_setting(setting_name, arr, section):
     """
     This method is responsible for prompting a user about a missing setting and
     taking its value as input from the user.
@@ -479,16 +479,19 @@ def require_setting(setting_name, arr):
     :param arr:          A list containing a description in [0] and the name
                          of the bears who need this setting in [1] and
                          following.
+    :param section:      The section the action corresponds to.
     """
     needed = join_names(arr[1:])
 
     # Don't use input, it can't deal with escapes!
-    print(colored(STR_GET_VAL_FOR_SETTING.format(setting_name, arr[0], needed),
+
+    print(colored(STR_GET_VAL_FOR_SETTING.format(setting_name, arr[0], needed,
+                                                 section.name),
                   REQUIRED_SETTINGS_COLOR))
     return input()
 
 
-def acquire_settings(log_printer, settings_names_dict):
+def acquire_settings(log_printer, settings_names_dict, section):
     """
     This method prompts the user for the given settings.
 
@@ -508,6 +511,9 @@ def acquire_settings(log_printer, settings_names_dict):
                      "SpaceConsistencyBear",
                      "SomeOtherBear"]}
 
+
+    :param section:
+        The section the action corresponds to.
     :return:
         A dictionary with the settings name as key and the given value as
         value.
@@ -519,7 +525,7 @@ def acquire_settings(log_printer, settings_names_dict):
     result = {}
     for setting_name, arr in sorted(settings_names_dict.items(),
                                     key=lambda x: (join_names(x[1][1:]), x[0])):
-        value = require_setting(setting_name, arr)
+        value = require_setting(setting_name, arr, section)
         result.update({setting_name: value} if value is not None else {})
 
     return result

--- a/coalib/output/Interactions.py
+++ b/coalib/output/Interactions.py
@@ -1,4 +1,4 @@
-def fail_acquire_settings(log_printer, settings_names_dict):
+def fail_acquire_settings(log_printer, settings_names_dict, section):
     """
     This method throws an exception if any setting needs to be acquired.
 

--- a/coalib/settings/SectionFilling.py
+++ b/coalib/settings/SectionFilling.py
@@ -86,7 +86,7 @@ def fill_section(section, acquire_settings, log_printer, bears):
 
     # Get missing ones.
     if len(needed_settings) > 0:
-        new_vals = acquire_settings(log_printer, needed_settings)
+        new_vals = acquire_settings(log_printer, needed_settings, section)
         for setting, help_text in new_vals.items():
             section.append(Setting(setting, help_text))
 

--- a/tests/output/ConsoleInteractionTest.py
+++ b/tests/output/ConsoleInteractionTest.py
@@ -150,25 +150,30 @@ class ConsoleInteractionTest(unittest.TestCase):
         ApplyPatchAction.is_applicable = self.old_apply_patch_applicable
 
     def test_require_settings(self):
-        self.assertRaises(TypeError, acquire_settings, self.log_printer, 0)
+        curr_section = Section("")
+        self.assertRaises(TypeError, acquire_settings,
+                          self.log_printer, 0, curr_section)
 
         with simulate_console_inputs(0, 1, 2) as generator:
             self.assertEqual(acquire_settings(self.log_printer,
                                               {"setting": ["help text",
-                                                           "SomeBear"]}),
+                                                           "SomeBear"]},
+                                              curr_section),
                              {"setting": 0})
 
             self.assertEqual(acquire_settings(self.log_printer,
                                               {"setting": ["help text",
                                                            "SomeBear",
-                                                           "AnotherBear"]}),
+                                                           "AnotherBear"]},
+                                              curr_section),
                              {"setting": 1})
 
             self.assertEqual(acquire_settings(self.log_printer,
                                               {"setting": ["help text",
                                                            "SomeBear",
                                                            "AnotherBear",
-                                                           "YetAnotherBear"]}),
+                                                           "YetAnotherBear"]},
+                                              curr_section),
                              {"setting": 2})
 
             self.assertEqual(generator.last_input, 2)

--- a/tests/output/InteractionsTest.py
+++ b/tests/output/InteractionsTest.py
@@ -4,15 +4,19 @@ from pyprint.NullPrinter import NullPrinter
 
 from coalib.output.Interactions import fail_acquire_settings
 from coalib.output.printers.LogPrinter import LogPrinter
+from coalib.settings.Section import Section
 
 
 class InteractionsTest(unittest.TestCase):
 
     def test_(self):
         log_printer = LogPrinter(NullPrinter())
-        self.assertRaises(TypeError, fail_acquire_settings, log_printer, None)
+        section = Section("")
+        self.assertRaises(TypeError, fail_acquire_settings, log_printer, None,
+                          section)
         self.assertRaises(AssertionError,
                           fail_acquire_settings,
                           log_printer,
-                          {"setting": ["description", "bear"]})
-        self.assertEqual(fail_acquire_settings(log_printer, {}), None)
+                          {"setting": ["description", "bear"]}, section)
+        self.assertEqual(fail_acquire_settings(log_printer, {}, section), None,
+                         section)


### PR DESCRIPTION
Mention the section name when a required setting is
missing for the user.
The user will know what section is used.

Closes https://github.com/coala/coala/issues/2589