### PR TITLE
Add `noqa` to the keywords to start ignoring bears

### DIFF
--- a/coalib/processes/Processing.py
+++ b/coalib/processes/Processing.py
@@ -443,8 +443,9 @@ def yield_ignore_ranges(file_dict):
         stop_ignoring = False
         for line_number, line in enumerate(file, start=1):
             # Before lowering all lines ever read, first look for the biggest
-            # common substring, case sensitive: I*gnor*e, start i*gnor*ing.
-            if 'gnor' in line:
+            # common substring, case sensitive: I*gnor*e, start i*gnor*ing,
+            # N*oqa*.
+            if 'gnor' in line or 'oqa' in line:
                 line = line.lower()
                 if 'start ignoring ' in line:
                     start = line_number
@@ -459,13 +460,17 @@ def yield_ignore_ranges(file_dict):
                                    1,
                                    line_number,
                                    len(file[line_number-1])))
-                elif 'ignore ' in line:
-                    end_line = min(line_number + 1, len(file))
-                    yield (get_ignore_scope(line, 'ignore '),
-                           SourceRange.from_values(
-                               filename,
-                               line_number, 1,
-                               end_line, len(file[end_line - 1])))
+
+                else:
+                    for ignore_stmt in ['ignore ', 'noqa ', 'noqa']:
+                        if ignore_stmt in line:
+                            end_line = min(line_number + 1, len(file))
+                            yield (get_ignore_scope(line, ignore_stmt),
+                                   SourceRange.from_values(
+                                       filename,
+                                       line_number, 1,
+                                       end_line, len(file[end_line-1])))
+                            break
 
         if stop_ignoring is False and start is not None:
             yield (bears,

--- a/tests/processes/ProcessingTest.py
+++ b/tests/processes/ProcessingTest.py
@@ -451,6 +451,28 @@ class ProcessingTest(unittest.TestCase):
             self.assertEqual(test_source_range.end.line, 2)
             self.assertEqual(test_source_range.end.column, 43)
 
+        test_file_dict_n = {'f':
+                            ('# noqa nBear\n',
+                             'n_string = "This string should be ignored"\n')}
+        test_ignore_range_n = list(yield_ignore_ranges(test_file_dict_n))
+        for test_bears, test_source_range in test_ignore_range_n:
+            self.assertEqual(test_bears, ['nbear'])
+            self.assertEqual(test_source_range.start.line, 1)
+            self.assertEqual(test_source_range.start.column, 1)
+            self.assertEqual(test_source_range.end.line, 2)
+            self.assertEqual(test_source_range.end.column, 43)
+
+        test_file_dict_n = {'f':
+                            ('# noqa\n',
+                             'n_string = "This string should be ignored"\n')}
+        test_ignore_range_n = list(yield_ignore_ranges(test_file_dict_n))
+        for test_bears, test_source_range in test_ignore_range_n:
+            self.assertEqual(test_bears, [])
+            self.assertEqual(test_source_range.start.line, 1)
+            self.assertEqual(test_source_range.start.column, 1)
+            self.assertEqual(test_source_range.end.line, 2)
+            self.assertEqual(test_source_range.end.column, 43)
+
         # This case was a bug.
         test_file_dict_single_line = {'f': ('# ignore XBEAR',)}
         test_ignore_range_single_line = list(yield_ignore_ranges(


### PR DESCRIPTION
Some other linters use 'noqa' so the addition of this keyword would make coala backwards compatible.
closes #2533 
