### PR TITLE
Globbing: fix copy-paste bug

### DIFF
--- a/coalib/parsing/Globbing.py
+++ b/coalib/parsing/Globbing.py
@@ -248,7 +248,7 @@ def _absolute_flat_glob(pattern):
     else:
         # Patterns ending with a slash should match only directories
         if os.path.isdir(dirname):
-            yield pattern
+            yield dirname
     return
 
 


### PR DESCRIPTION
:bug: [hacktoberfest](https://hacktoberfest.digitalocean.com/)

Greetings,

`pattern` in `yield pattern` looks like a copy-paste defect. The original copy of `yield pattern` is on line [247](https://github.com/coala/coala/blob/master/coalib/parsing/Globbing.py#L247). Should the second instance of `yield pattern` on line [251](https://github.com/coala/coala/blob/master/coalib/parsing/Globbing.py#L251) say `yield dirname` instead?

Signed-off-by: Bryon Gloden, CISSP® cissp@bryongloden.com