### PR TITLE
DocumentationComment: fix invalid operations

### DIFF
--- a/coalib/bearlib/languages/documentation/DocumentationComment.py
+++ b/coalib/bearlib/languages/documentation/DocumentationComment.py
@@ -95,7 +95,8 @@ class DocumentationComment:
         parse_mode = self.Description
 
         cur_param = ""
-
+        retval_desc = ""
+        param_desc = ""
         desc = ""
         parsed = []
 


### PR DESCRIPTION
:bug: label: [hacktoberfest](https://hacktoberfest.digitalocean.com/)

Greetings,

It's always good to define string variables, at least to "", because if we try to retrieve its value before it gets assigned any actual (non-garbage) value, then it results in an exception such as a TypeError, e.g. line numbers `124` & `129` of [DocumentationComment.py](https://github.com/coala/coala/blob/master/coalib/bearlib/languages/documentation/DocumentationComment.py#L124).

Signed-off-by: Bryon Gloden, CISSP® cissp@bryongloden.com