### PR TITLE
ResultTest.py: Remove unused variable

### DIFF
--- a/tests/results/ResultTest.py
+++ b/tests/results/ResultTest.py
@@ -149,10 +149,6 @@ class ResultTest(unittest.TestCase):
             "f_a": ["1", "2", "3"],
             "f_b": ["1", "2", "3"]
         }
-        expected_file = {
-            "f_a": ["1", "3_changed"],
-            "f_b": ["1", "2", "3"]
-        }
         diff = Diff(file_dict['f_a'])
         diff.delete_line(2)
         diff.change_line(3, "3", "3_changed")


### PR DESCRIPTION
The variable expected_file is not used in that method.

Fixes https://github.com/coala/coala/issues/2915