### PR TITLE
README.rst: Add min pip version

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -65,6 +65,15 @@ Features
 
 -----
 
+=============
+Prerequisites
+=============
+
+* Python >= 3.4
+* pip >= 8.0
+
+-----
+
 ============
 Installation
 ============
@@ -74,6 +83,9 @@ To install the **latest stable version** run:
 .. code-block:: bash
 
     $ pip3 install coala
+
+Make sure you have Python >= 3.4 and pip >= 8.1 installed as the installation
+may not succeed with lower versions.
 
 |Stable|
 


### PR DESCRIPTION
The installation of coala fails if the pip version is too low. The requirements for Python and pip have been added to make them easy to find.

This is the second pull request (in addition to https://github.com/coala/documentation/pull/238) needed to fix https://github.com/coala/documentation/issues/237