### PR TITLE
Constants: Remove unused import

### DIFF
--- a/coalib/coala_dbus.py
+++ b/coalib/coala_dbus.py
@@ -17,6 +17,7 @@ import sys
 
 import dbus
 import dbus.mainloop.glib
+from coalib import BUS_NAME
 from coalib.misc import Constants
 from coalib.output.dbus.DbusServer import DbusServer
 from gi.repository import GLib
@@ -37,7 +38,7 @@ def main():
     # The BusName needs to be saved to a variable, if it is not saved - the
     # Bus will be closed.
     dbus_name = dbus.service.BusName(  # pylint: disable=unused-variable
-        Constants.BUS_NAME,
+        BUS_NAME,
         session_bus)
     DbusServer(session_bus,
                '/org/coala_analyzer/v1',

--- a/coalib/misc/Constants.py
+++ b/coalib/misc/Constants.py
@@ -6,7 +6,6 @@ import re
 
 # Start ignoring PyImportSortBear, PyLintBear as BUS_NAME is imported as a
 # constant from other files.
-from coalib import BUS_NAME
 from coalib import VERSION
 # Stop ignoring
 

--- a/tests/output/dbus/BuildDbusServiceTest.py
+++ b/tests/output/dbus/BuildDbusServiceTest.py
@@ -3,6 +3,7 @@ from distutils.errors import DistutilsOptionError
 
 from setuptools.dist import Distribution
 
+from coalib import BUS_NAME
 from coalib.misc import Constants
 from coalib.misc.ContextManagers import make_temp
 from coalib.output.dbus.BuildDbusService import BuildDbusService
@@ -23,5 +24,5 @@ class BuildDbusServiceTest(unittest.TestCase):
 
             self.assertEqual(
                 result,
-                "[D-BUS Service]\nNames=" + Constants.BUS_NAME +
+                "[D-BUS Service]\nNames=" + BUS_NAME +
                 "\nExec=coala-dbus")


### PR DESCRIPTION

Removes unused DBUS import `BUS_NAME`
and fixed the corresponding tests.

Closes #2902