### PR TITLE
README.rst: Fix typo "langauge" -> "language"

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -146,7 +146,7 @@ A sample ``.coafile`` will look something like this:
 * The ``bears`` key specifies which bears (plugins) you want to use. We support
   a huge number of languages and you can find the whole list
   `here <https://github.com/coala/bear-docs/blob/master/README.rst>`__.
-  If you don't find your langauge there, we've got some
+  If you don't find your language there, we've got some
   `bears that work for all languages <https://github.com/coala/bear-docs/blob/master/README.rst#all>`__. Or you can file an issue and we would create a bear for you!
 * ``use_spaces`` enforces spaces over tabs in the codebase. ``use_spaces`` is a
   setting for the ``SpaceConsistencyBear``.


### PR DESCRIPTION
There is a change in line 149, changing langauge to language.

Closes https://github.com/coala/coala/issues/2935