### PR TITLE
Importers: Allow file_paths as the only param

### DIFF
--- a/coalib/collecting/Importers.py
+++ b/coalib/collecting/Importers.py
@@ -112,10 +112,7 @@ def _iimport_objects(file_paths, names, types, supers, attributes, local):
     :raises Exception: Any exception that is thrown in module code or an
                        ImportError if paths are erroneous.
     """
-    if not file_paths or (not names and
-                          not types and
-                          not supers and
-                          not attributes):
+    if not file_paths:
         return
 
     for file_path in file_paths:

--- a/tests/collecting/ImportersTest.py
+++ b/tests/collecting/ImportersTest.py
@@ -20,7 +20,7 @@ class ImportObjectsTest(unittest.TestCase):
         self.assertEqual(import_objects([]), [])
 
     def test_no_data(self):
-        self.assertEqual(import_objects(self.testfile1_path), [])
+        self.assertEqual(len(import_objects(self.testfile1_path)), 12)
 
     def test_name_import(self):
         self.assertEqual(


### PR DESCRIPTION
### Checklist

- [x] I have rebased properly. Please see [our tutorial on rebasing](http://coala.readthedocs.io/en/latest/Developers/Git_Basics.html#rebasing).
- [x] I have gone through the [commit guidelines](http://coala.readthedocs.io/en/latest/Developers/Writing_Good_Commits.html) and I've followed them.
- [x] I have followed the [guidelines for the commit shortlog](http://docs.coala.io/en/latest/Developers/Writing_Good_Commits.html#shortlog).
- [x] I have followed the [guidelines for the commit body](http://docs.coala.io/en/latest/Developers/Writing_Good_Commits.html#commit-body).
- [x] I have included the issue URL with the 'Fixes' keyword if the commit fixes a *real bug* and the 'Closes' keyword if it adds a feature or enhancement. For details, check the [issue reference section in our commit guidelines](http://docs.coala.io/en/latest/Developers/Writing_Good_Commits.html#issue-reference).
- [x] I have [run all the tests](http://coala.readthedocs.io/en/latest/Developers/Executing_Tests.html) and they all pass. If any CI (below) is not green, please fix them. If GitMate issues appear you will have to amend your commits, pushing new commits on top is not sufficient!

### Reviewers


Make `_iimport_objects()` return all the objects found in the module if the `file_paths` is passed as the only param.

Fixes https://github.com/coala/coala/issues/2400