### PR TITLE
GoRequirement: Fix Test

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -15,7 +15,7 @@ test:
         parallel: true
     - python setup.py install:
         parallel: true
-    - pip install coala-bears colorama==0.3.6 --pre -U:
+    - pip install coala-bears==0.8 colorama==0.3.6 -U:
         parallel: true
         timeout: 900  # Allow 15 mins
     - coala-ci -L DEBUG:

--- a/tests/bears/requirements/GoRequirementTest.py
+++ b/tests/bears/requirements/GoRequirementTest.py
@@ -7,7 +7,7 @@ from coalib.bears.requirements.GoRequirement import GoRequirement
 class GoRequirementTestCase(unittest.TestCase):
 
     def test_installed_requirement(self):
-        self.assertTrue(GoRequirement('go').is_installed())
+        self.assertTrue(GoRequirement('fmt').is_installed())
 
     def test_not_installed_requirement(self):
         self.assertFalse(GoRequirement('some_bad_package').is_installed())


### PR DESCRIPTION
'go' is not a buildable package and thus fails the install check of
GoRequirement. 'fmt' is the standard formatter that should come with go
and is definitely available even with an empty directory at $GOPATH

Backports 15c346699cd2 to releases/0.8, as this is one of the problems
with the coala/docker-coala-base Travis builds.