### PR TITLE
WIP: aspectclasses

### DIFF
--- a/coalib/bearlib/aspectclasses/Metadata.py
+++ b/coalib/bearlib/aspectclasses/Metadata.py
@@ -1,0 +1,239 @@
+from coalib.bearlib.aspectclasses import Root, Taste
+
+
+@Root.subaspect
+class Metadata:
+    """
+    This describes any aspect that is related to metadata that is not
+    inside your source code.
+    """
+
+
+@Metadata.subaspect
+class CommitMessage:
+    """
+    Your commit message is important documentation associated with your
+    source code. It can help you to identify bugs (e.g. through
+    `git bisect`) or find missing information about unknown source code
+    (through `git blame`).
+
+    Commit messages are also sometimes used to generate - or write
+    manually - release notes.
+    """
+
+
+@CommitMessage.subaspect
+class Emptiness:
+    """
+    Your commit message serves as important documentation for your source
+    code.
+    """
+    class docs:
+        example = "(no text at all)"
+        example_language = "English"
+        importance_reason = """
+        An empty commit message shows the lack of documentation for your
+        change.
+        """
+        fix_suggestions = "Write a commit message."
+
+
+@CommitMessage.subaspect
+class Shortlog:
+    """
+    Your commit shortlog is the first line of your commit message. It is
+    the most crucial part and summarizes the change in the shortest possible
+    manner.
+    """
+
+
+@Shortlog.subaspect
+class ColonExistence:
+    """
+    Some projects force to use colons in the commit message shortlog
+    (first line).
+    """
+    class docs:
+        example = """
+        FIX: Describe change further
+        context: Describe change further
+        """
+        example_language = "English"
+        importance_reason = """
+        The colon can be a useful separator for a context (e.g. a filename) so
+        the commit message makes more sense to the reader or a classification
+        (e.g. FIX, ...) or others. Some projects prefer not using colons
+        specifically: consistency is key.
+        """
+        fix_suggestions = """
+        Add or remove the colon according to the commit message guidelines.
+        """
+
+    shortlog_colon = Taste[bool](
+        "Whether or not the shortlog has to contain a colon.",
+        (True, False), default=True)
+
+
+@Shortlog.subaspect
+class TrailingPeriod:
+    """
+    Some projects force not to use trailing periods in the commit
+    message shortlog (first line).
+    """
+    class docs:
+        example = """
+        Describe change.
+        Describe change
+        """
+        example_language = "English"
+        importance_reason = """
+        Consistency is key to make messages more readable. Removing a trailing
+        period can also make the message shorter by a character.
+        """
+        fix_suggestions = """
+        Add or remove the trailing period according to the commit message
+        guidelines.
+        """
+
+    shortlog_period = Taste[bool](
+        "Whether or not the shortlog has to contain a trailing period.",
+        (True, False), default=False)
+
+
+@Shortlog.subaspect
+class Tense:
+    """
+    Most projects have a convention on which tense to use in the commit
+    shortlog (the first line of the commit message).
+    """
+    class docs:
+        example = """
+        Add file
+        Adding file
+        Added file
+        """
+        example_language = "English"
+        importance_reason = """
+        Consistency is key to make messages more readable.
+        """
+        fix_suggestions = """
+        Rephrase the shortlog into the right tense.
+        """
+
+    shortlog_tense = Taste[str](
+        "The tense of the shortlog.",
+        ("imperative", "present continuous", "past"),
+        default="imperative")
+
+
+@Shortlog.subaspect
+class Length:
+    """
+    The length of your commit message shortlog (first line).
+    """
+    class docs:
+        example = """
+        Some people just write very long commit messages. Too long. "
+        Even full sentences. And more of them, too!
+        """
+        example_language = "English"
+        importance_reason = """
+        A good commit message should be quick to read and concise. Also, git
+        and platforms like GitHub do cut away everything beyond 72, sometimes
+        even 50 characters making any longer message unreadable.
+        """
+        fix_suggestions = """
+        Try to compress your message:
+
+        - Using imperative tense usually saves a character or two
+        - Omitting a trailing period saves another character
+        - Leave out unneeded words or details
+        - Use common abbreviations like w/, w/o or &.
+        """
+
+    max_shortlog_length = Taste[int](
+        "The maximal number of characters the shortlog may contain.",
+        (50, 72, 80), default=72)
+
+
+@Shortlog.subaspect
+class FirstCharacter:
+    """
+    The first character of your commit message shortlog (first line) usually
+    should be upper or lower case consistently.
+
+    If the commit message contains a colon, only the first character after
+    the colon will be checked.
+    """
+    class docs:
+        example = """
+        Add coverage pragma
+        Compatability: Add coverage pragma
+        add coverage pragma
+        Compatability: add coverage pragma
+        """
+        example_language = "English"
+        importance_reason = """
+        Consistent commit messages are easier to read through.
+        """
+        fix_suggestions = """
+        Convert your first character to upper/lower case. If your message starts
+        with an identifier, consider rephrasing. Usually starting with a verb is
+        a good idea.
+        """
+
+    shortlog_starts_upper_case = Taste[bool](
+        "Whether or not the shortlog (first line) of a commit message should "
+        "start with an upper case letter consistently.",
+        (True, False), default=True)
+
+
+@CommitMessage.subaspect
+class Body:
+    """
+    Your commit body may contain an elaborate description of your commit.
+    """
+
+
+@Body.subaspect
+class Existence:
+    """
+    Forces the commit message body to exist (nonempty).
+    """
+    class docs:
+        example = """
+        aspects: Add CommitMessage.Body
+        """
+        example_language = "English"
+        importance_reason = """
+        Having a nonempty commit body is important if you consistently want
+        elaborate documentation on all commits.
+        """
+        fix_suggestions = """
+        Write a commit message with a body.
+        """
+
+
+@Body.subaspect
+class Length:
+    """
+    The length of your commit message body lines.
+    """
+    class docs:
+        example = """
+        Some people just write very long commit messages. Too long.
+        Way too much actually. If they would just break their lines!
+        """
+        example_language = "English"
+        importance_reason = """
+        Git and platforms like GitHub usually break everything beyond 72
+        characters, making a message containing longer lines hard to read.
+        """
+        fix_suggestions = """
+        Simply break your lines right before you hit the border.
+        """
+
+    max_body_length = Taste[int](
+        "The maximal number of characters the body may contain in one line. "
+        "The newline character at each line end does not count to that length.",
+        (50, 72, 80), default=72)

--- a/coalib/bearlib/aspectclasses/__init__.py
+++ b/coalib/bearlib/aspectclasses/__init__.py
@@ -1,0 +1,44 @@
+from .base import aspectbase
+from .meta import aspectclass
+from .taste import Taste
+
+__all__ = ['Root', 'Taste', 'aspectclass']
+
+
+class Root(aspectbase, metaclass=aspectclass):
+    """
+    The root aspectclass.
+
+    Define sub-aspectclasses with class-bound ``.subaspect`` decorator.
+    Definition string is taken from doc-string of decorated class.
+    Remaining docs are taken from a nested ``docs`` class.
+    Tastes are defined as class attributes that are instances of
+    :class:`coalib.bearlib.aspectclasses.Taste`.
+
+    >>> @Root.subaspect
+    ... class Formatting:
+    ...     \"""
+    ...     A parent aspect for code formatting aspects...
+    ...     \"""
+
+    >>> @Formatting.subaspect
+    ... class LineLength:
+    ...     \"""
+    ...     This aspect controls the length of a line...
+    ...     \"""
+    ...     class docs:
+    ...        example = "..."
+    ...        example_language = "..."
+    ...        importance_reason = "..."
+    ...        fix_suggestions = "..."
+    ...
+    ...     max_line_length = Taste[int](
+    ...         "Maximum length allowed for a line.",
+    ...         (80, 90, 120), default=80)
+
+    >>> Root.Formatting.LineLength
+    <aspectclass 'Root.Formatting.LineLength'>
+    """
+    parent = None
+
+    _tastes = {}

--- a/coalib/bearlib/aspectclasses/base.py
+++ b/coalib/bearlib/aspectclasses/base.py
@@ -1,0 +1,53 @@
+class aspectbase:
+    """
+    Base class for aspectclasses with common features for their instances.
+
+    Derived classes must use
+    :class:`coalib.bearlib.aspectclasses.meta.aspectclass` as metaclass.
+    This is automatically handled by
+    :meth:`coalib.bearlib.aspectclasses.meta.aspectclass.subaspect` decorator.
+    """
+
+    def __init__(self, **taste_values):
+        """
+        Instantiate an aspectclass with specific `taste_values`,
+        including parent tastes.
+
+        All values will be casted to the related taste cast types.
+
+        Non-given tastes will get their default values.
+        """
+        for name, taste in type(self).tastes.items():
+            value = taste.cast_type(
+                taste_values.pop(name, taste.default))
+            self.__dict__[name] = value
+
+    @property
+    def tastes(self):
+        """
+        Get a dictionary of all taste names mapped to their
+        specific values, including parent tastes.
+        """
+        return {name: self.__dict__[name] for name in type(self).tastes}
+
+    def __getattr__(self, name):
+        """
+        Get the specific values from parent aspect tastes.
+
+        Own taste values are retrieved via descriptor
+        :meth:`coalib.bearlib.aspectclasses.Taste.__get__`.
+        """
+        if name in type(self).tastes.items():
+            return self.__dict__[name]
+
+        raise AttributeError(
+            "aspectclass instance %s has no attribute or taste "
+            "named %s" % (repr(self), repr(name)))
+
+    def __setattr__(self, name, value):
+        """
+        Don't allow taste value manipulations after instantiation
+        of aspectclasses.
+        """
+        raise AttributeError(
+            "can't set attributes of aspectclass instances")

--- a/coalib/bearlib/aspectclasses/docs.py
+++ b/coalib/bearlib/aspectclasses/docs.py
@@ -1,0 +1,39 @@
+from inspect import cleandoc
+
+from coala_utils.decorators import (
+    enforce_signature, generate_consistency_check)
+
+
+@generate_consistency_check('definition', 'example', 'example_language',
+                            'importance_reason', 'fix_suggestions')
+class Documentation:
+    """
+    This class contains documentation about an aspectclass.
+    The documentation is consistent if all members are given:
+
+    >>> Documentation('defined').check_consistency()
+    False
+    >>> Documentation('definition', 'example',
+    ...               'example_language', 'importance',
+    ...               'fix').check_consistency()
+    True
+    """
+
+    @enforce_signature
+    def __init__(self, definition: str='', example: str='',
+                 example_language: str='', importance_reason: str='',
+                 fix_suggestions: str=''):
+        """
+        Contains documentation for an aspectclass.
+
+        :param definition:        What is this about?
+        :param example:           An example in a well known language.
+        :param example_language:  The language used for the example.
+        :param importance_reason: A reason why this aspect is important.
+        :param fix_suggestions:   Suggestions on how this can be fixed.
+        """
+        self.definition = cleandoc(definition)
+        self.example = cleandoc(example)
+        self.example_language = cleandoc(example_language)
+        self.importance_reason = cleandoc(importance_reason)
+        self.fix_suggestions = cleandoc(fix_suggestions)

--- a/coalib/bearlib/aspectclasses/meta.py
+++ b/coalib/bearlib/aspectclasses/meta.py
@@ -1,0 +1,70 @@
+from inspect import getmembers
+
+from .base import aspectbase
+from .docs import Documentation
+from .taste import Taste
+
+
+class aspectclass(type):
+    """
+    Metaclass for aspectclasses.
+
+    Root aspectclass is :class:`coalib.bearlib.aspectclasses.Root`.
+    """
+    def __init__(cls, clsname, bases, clsattrs):
+        """
+        Initializes the ``.subaspects`` dict on new aspectclasses.
+        """
+        cls.subaspects = {}
+
+    @property
+    def tastes(cls):
+        """
+        Get a dictionary of all taste names mapped to their
+        :class:`coalib.bearlib.aspectclasses.Taste` instances.
+        """
+        result = dict(cls._tastes)
+        if cls.parent:
+            result.update(cls.parent.tastes)
+        return result
+
+    def subaspect(cls, subcls):
+        """
+        The sub-aspectclass decorator.
+
+        See :class:`coalib.bearlib.aspectclasses.Root` for description
+        and usage.
+        """
+        aspectname = subcls.__name__
+
+        docs = getattr(subcls, 'docs', None)
+        aspectdocs = Documentation(subcls.__doc__, **{
+            attr: getattr(docs, attr, '') for attr in [
+                'example',
+                'example_language',
+                'importance_reason',
+                'fix_suggestions',
+            ]})
+
+        subtastes = {}
+        # search for tastes int the sub-aspectclass
+        for name, member in getmembers(subcls):
+            if isinstance(member, Taste):
+                subtastes[name] = member
+
+        class Sub(subcls, aspectbase, metaclass=aspectclass):
+            __module__ = subcls.__module__
+
+            parent = cls
+
+            docs = aspectdocs
+            _tastes = subtastes
+
+        Sub.__name__ = aspectname
+        Sub.__qualname__ = '%s.%s' % (cls.__qualname__, aspectname)
+        cls.subaspects[aspectname] = Sub
+        setattr(cls, aspectname, Sub)
+        return Sub
+
+    def __repr__(cls):
+        return "<%s %s>" % (type(cls).__name__, repr(cls.__qualname__))

--- a/coalib/bearlib/aspectclasses/taste.py
+++ b/coalib/bearlib/aspectclasses/taste.py
@@ -1,0 +1,58 @@
+from coala_utils.decorators import enforce_signature
+
+
+class TasteMeta(type):
+    """
+    Metaclass for :class:`coalib.bearlib.aspectclasses.Taste`
+
+    Allows defining taste cast type via :meth:`.__getitem__`, like::
+
+       Taste[int](...)
+    """
+    def __getitem__(cls, _cast_type):
+        class Taste(cls):
+            cast_type = _cast_type
+
+        Taste.__name__ = Taste.__qualname__ = "%s[%s]" % (
+            cls.__name__, _cast_type.__name__)
+        return Taste
+
+
+class Taste(metaclass=TasteMeta):
+    """
+    Defines tastes in aspectclass definitions.
+
+    See :class:`coalib.bearlib.aspectclasses.Root` for usage.
+    """
+    cast_type = str
+
+    @enforce_signature
+    def __init__(self, description: str="", suggested_values: tuple=(),
+                 default=None):
+        """
+        No need to specify name an cast type:
+
+        The taste name is defined by the taste's attribute name in an
+        aspectclass definition.
+
+        The value cast type is defined via indexing on class level.
+        """
+        self.description = description
+        self.suggested_values = suggested_values
+        self.default = default
+
+    def __get__(self, obj, owner=None):
+        """
+        Descriptor interface for accessing tastes in aspectclasses.
+
+        Returns `self` when accessed from an aspectclass and its specific
+        taste value from an aspectclass instance.
+        """
+        if obj is not None:
+            # ==> access from instance
+            # ==> return specific aspect taste value
+            return obj.__dict__[self.name]
+
+        if owner is not None:
+            # ==> access from class
+            return self

--- a/setup.cfg
+++ b/setup.cfg
@@ -15,7 +15,7 @@ testpaths =
     tests
 python_files = *Test.py
 python_classes = *Test
-python_functions = *_test
+# python_functions = *_test
 timeout = 35
 addopts =
     --color=yes

--- a/tests/bearlib/aspectclasses/BaseTest.py
+++ b/tests/bearlib/aspectclasses/BaseTest.py
@@ -1,0 +1,19 @@
+from coalib.bearlib.aspectclasses import aspectclass
+from coalib.bearlib.aspectclasses.base import aspectbase
+
+import pytest
+
+
+class AspectBaseTest:
+    """
+    aspectbase is just a mixin base class for new aspectclasses
+    and is therefore only usable works with a derived aspectclass
+    and therefore doesn't use the aspectclass meta for itself
+    """
+
+    def test_class(self):
+        assert not isinstance(aspectbase, aspectclass)
+
+    def test_init_needs_aspectclass(self):
+        with pytest.raises(AttributeError) as exc:
+            aspectbase()

--- a/tests/bearlib/aspectclasses/ClassTest.py
+++ b/tests/bearlib/aspectclasses/ClassTest.py
@@ -1,0 +1,33 @@
+from coalib.bearlib.aspectclasses import aspectclass
+
+import pytest
+
+
+class AspectClassTest:
+
+    def test_subaspect_without_definition(self, RootAspect):
+        with pytest.raises(TypeError):
+            @RootAspect.subaspect
+            class SubAspect:
+                pass
+
+    def test_subaspect_without_docs(self, RootAspect):
+        @RootAspect.subaspect
+        class SubAspect:
+            """
+            Definition
+            """
+
+        assert not SubAspect.docs.check_consistency()
+
+    def test_subaspect_without_enough_docs(self, RootAspect):
+        @RootAspect.subaspect
+        class SubAspect:
+            """
+            Description
+            """
+
+            class docs:
+                example = "Example"
+
+        assert not SubAspect.docs.check_consistency()

--- a/tests/bearlib/aspectclasses/RootTest.py
+++ b/tests/bearlib/aspectclasses/RootTest.py
@@ -1,0 +1,18 @@
+from coalib.bearlib.aspectclasses import Root, aspectclass
+from coalib.bearlib.aspectclasses.base import aspectbase
+
+
+class RootTest:
+
+    def test_class(self):
+        assert isinstance(Root, aspectclass)
+        assert issubclass(Root, aspectbase)
+
+    def test_subaspects(self):
+        assert isinstance(Root.subaspects, dict)
+
+    def test_parent(self):
+        assert Root.parent is None
+
+    def test_tastes(self):
+        assert Root.tastes == {}

--- a/tests/bearlib/aspectclasses/SubTest.py
+++ b/tests/bearlib/aspectclasses/SubTest.py
@@ -1,0 +1,18 @@
+from coalib.bearlib.aspectclasses import aspectclass
+from coalib.bearlib.aspectclasses.base import aspectbase
+
+
+class SubAspectTest:
+
+    def test_class(self, SubAspect):
+        assert isinstance(SubAspect, aspectclass)
+        assert issubclass(SubAspect, aspectbase)
+
+    def test_tastes_recreation(self, SubAspect):
+        assert SubAspect.tastes is not SubAspect.tastes
+
+    def test_tastes_items(self, SubAspect, SubAspect_tastes):
+        tastes = SubAspect.tastes
+        for name, taste in SubAspect_tastes.items():
+            assert taste is tastes.pop(name)
+        assert not tastes

--- a/tests/bearlib/aspectclasses/TasteTest.py
+++ b/tests/bearlib/aspectclasses/TasteTest.py
@@ -1,0 +1,30 @@
+from coalib.bearlib.aspectclasses import Taste
+from coalib.bearlib.aspectclasses.taste import TasteMeta
+
+
+class TasteTest:
+
+    def test_class(self):
+        assert isinstance(Taste, TasteMeta)
+
+    def test_class__getitem__(self):
+        typed = Taste[int]
+        assert typed.cast_type is int
+        assert typed.__name__ == typed.__qualname__ == "Taste[int]"
+
+    def test__init__defaults(self):
+        taste = Taste()
+        assert taste.description is ""
+        assert taste.suggested_values is ()
+        assert taste.default is None
+
+    def test__get__(
+            self, SubAspect, SubAspect_tastes, SubAspect_taste_values
+    ):
+        using_default_values = SubAspect()
+        using_custom_values = SubAspect(**SubAspect_taste_values)
+        for name, taste in SubAspect_tastes.items():
+            assert getattr(SubAspect, name) is taste
+            assert getattr(using_default_values, name) == taste.default
+            assert getattr(using_custom_values, name) \
+                == SubAspect_taste_values[name]

--- a/tests/bearlib/aspectclasses/conftest.py
+++ b/tests/bearlib/aspectclasses/conftest.py
@@ -1,0 +1,77 @@
+from coalib.bearlib.aspectclasses import Taste, aspectclass
+from coalib.bearlib.aspectclasses.base import aspectbase
+
+import pytest
+
+
+@pytest.fixture
+def RootAspect():
+    """
+    An exclusive Root aspectclass for unit tests.
+    """
+    class RootAspect(aspectbase, metaclass=aspectclass):
+        parent = None
+
+        _tastes = {}
+
+    return RootAspect
+
+
+@pytest.fixture
+def SubAspect_tastes():
+    """
+    Taste definitions for an exclusive SubAspect class for unit tests.
+    """
+    return {
+        'salty': Taste[str](
+            "The saltiness", ("high", "low"), default="low"),
+        'sweet': Taste[int](
+            "The sweetness", (1, 23, 45), default=23),
+        'sour': Taste[bool](
+            "Is it sour?", (True, False), default=False),
+    }
+
+
+@pytest.fixture
+def SubAspect_taste_values():
+    """
+    Taste definitions for an exclusive SubAspect class for unit tests.
+    """
+    return {
+        'salty': "high",
+        'sweet': 45,
+        'sour': True,
+    }
+
+
+@pytest.fixture
+def SubAspect_docs():
+    """
+    Docs definitions for an exclusive SubAspect class for unit tests.
+    """
+    class docs:
+        example = "An example"
+        example_language = "The example language"
+        importance_reason = "The reason of importance"
+        fix_suggestions = "Suggestions for fixing"
+
+    return docs
+
+
+@pytest.fixture
+def SubAspect(RootAspect, SubAspect_docs, SubAspect_tastes):
+    """
+    An exclusive SubAspect class for unit tests.
+    """
+    @RootAspect.subaspect
+    class SubAspect:
+        """
+        Definition
+        """
+        docs = SubAspect_docs
+
+        salty = SubAspect_tastes['salty']
+        sweet = SubAspect_tastes['sweet']
+        sour = SubAspect_tastes['sour']
+
+    return SubAspect


### PR DESCRIPTION
Replacement for #2968 

As discussed with Lasse @ PyCon.DE in Munich:

Aspect classes offer a nicer way to define aspects and their subaspects and provide an additional instantiation level for filling aspects with specific taste values. The doc strings and included **Root.Metadata...** `aspectclass` definitions show how it works...

Reviewers

@sils 
@Makman2 
