### PR TITLE
Linter.py: Add missing space after comma

### DIFF
--- a/coalib/bearlib/abstractions/Linter.py
+++ b/coalib/bearlib/abstractions/Linter.py
@@ -700,7 +700,7 @@ def linter(executable: str,
         mapped **case-insensitive**!
 
         - ``RESULT_SEVERITY.MAJOR``: Mapped by ``critical``, ``c``,
-          ``fatal``, ``fail``, ``f``,``error``, ``err`` or ``e``.
+          ``fatal``, ``fail``, ``f``, ``error``, ``err`` or ``e``.
         - ``RESULT_SEVERITY.NORMAL``: Mapped by ``warning``, ``warn`` or ``w``.
         - ``RESULT_SEVERITY.INFO`: Mapped by ``information``, ``info``, ``i``,
           ``note`` or ``suggestion``.


### PR DESCRIPTION
Add space after comma just before "error" in coala.coalib.bearlib.abstraction.Linter.py line 703

closes https://github.com/coala/coala/issues/3088