### PR TITLE
Linter.py: Add Missing backtick

### DIFF
--- a/coalib/bearlib/abstractions/Linter.py
+++ b/coalib/bearlib/abstractions/Linter.py
@@ -702,7 +702,7 @@ def linter(executable: str,
         - ``RESULT_SEVERITY.MAJOR``: Mapped by ``critical``, ``c``,
           ``fatal``, ``fail``, ``f``, ``error``, ``err`` or ``e``.
         - ``RESULT_SEVERITY.NORMAL``: Mapped by ``warning``, ``warn`` or ``w``.
-        - ``RESULT_SEVERITY.INFO`: Mapped by ``information``, ``info``, ``i``,
+        - ``RESULT_SEVERITY.INFO``: Mapped by ``information``, ``info``, ``i``,
           ``note`` or ``suggestion``.
 
         A ``ValueError`` is raised when the named group ``severity`` is not


### PR DESCRIPTION
Linter.py: Add Missing backtick on line 705,
                 https://github.com/coala/coala/blob/master/coalib/bearlib/abstractions/Linter.py#L705
This is syntactically correct .
Fixes https://github.com/coala/coala/issues/3089