### PR TITLE
BearTest.py: Add timestamp test to verify caching

### DIFF
--- a/tests/bears/BearTest.py
+++ b/tests/bears/BearTest.py
@@ -1,6 +1,6 @@
 import multiprocessing
 import unittest
-from os.path import abspath, join
+from os.path import abspath, isfile, join, getmtime
 import shutil
 
 from coalib.bears.Bear import Bear
@@ -31,6 +31,9 @@ class TestBear(Bear):
         self.print('set', 'up', delimiter='=')
         self.err('teardown')
         self.err()
+
+    def tear_down(self):
+        shutil.rmtree(self.data_dir)
 
 
 class TypedTestBear(Bear):
@@ -185,9 +188,12 @@ class BearTest(unittest.TestCase):
         url = 'https://google.com'
         filename = 'google.html'
         uut = TestBear(self.settings, None)
-        result_filename = uut.download_cached_file(url, filename)
+        self.assertFalse(isfile(join(uut.data_dir, filename)))
         expected_filename = join(uut.data_dir, filename)
-        self.assertEqual(result_filename, expected_filename)
         result_filename = uut.download_cached_file(url, filename)
         self.assertEqual(result_filename, expected_filename)
-        shutil.rmtree(uut.data_dir)
+        expected_time = getmtime(join(uut.data_dir, filename))
+        result_filename = uut.download_cached_file(url, filename)
+        self.assertEqual(result_filename, expected_filename)
+        result_time = getmtime(join(uut.data_dir, filename))
+        self.assertEqual(result_time, expected_time)


### PR DESCRIPTION
<!--
Thanks for your contribution!

Reviewing pull requests takes a lot of time and we're all volunteers. Please make sure you go through the following checklist and all items before pinging someone for a review.
-->

### Checklist

- [x] I have rebased properly. Please see [our tutorial on rebasing](http://coala.readthedocs.io/en/latest/Developers/Git_Basics.html#rebasing).
- [x] I have gone through the [commit guidelines](http://coala.readthedocs.io/en/latest/Developers/Writing_Good_Commits.html) and I've followed them.
- [x] I have followed the [guidelines for the commit shortlog](http://docs.coala.io/en/latest/Developers/Writing_Good_Commits.html#shortlog).
- [x] I have followed the [guidelines for the commit body](http://docs.coala.io/en/latest/Developers/Writing_Good_Commits.html#commit-body).
- [x] I have included the issue URL with the 'Fixes' keyword if the commit fixes a *real bug* and the 'Closes' keyword if it adds a feature or enhancement. For details, check the [issue reference section in our commit guidelines](http://docs.coala.io/en/latest/Developers/Writing_Good_Commits.html#issue-reference).
- [x] I have [run all the tests](http://coala.readthedocs.io/en/latest/Developers/Executing_Tests.html) and they all pass. If any CI (below) is not green, please fix them. If GitMate issues appear you will have to amend your commits, pushing new commits on top is not sufficient!

### Reviewers

<!--
Please list the Github handles of people you think susceptible to review this PR. Feel free to leave this section blank if you don't know who to tag.
-->

<!--
End note:

As you learn things over your Pull Request please help others on the chat and on PRs to get their stuff right as well!
-->
Implements @userzimmermann 's suggestions on last merge
Verify that test_download_cached_file is caching the file
by verifyign that the first run time matches the second run.
Also verify that the file does not exisist when starting.
Add tear_down to TestBear class to delete its data directory
when it's work is done