### PR TITLE
Update requirements to use ~=, properly

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,8 @@
 PyPrint~=0.2.5
-Pygments~=2.1.3
+Pygments~=2.1
 setuptools>=19.2
 # Do *not* use 0.3 which is not backwards compatible to common clang versions
-libclang-py3==0.2
+libclang-py3~=0.2.0
 appdirs~=1.4
 coala_utils~=0.5.1
 colorlog~=2.7

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,7 +1,7 @@
-coverage==4.0.3
-pytest==2.8.7
-pytest-cov==2.2.1
-pytest-env==0.6.0
-pytest-mock==1.1
-pytest-timeout==1.0.0
-pytest-xdist==1.14
+coverage~=4.0
+pytest~=2.8
+pytest-cov~=2.2
+pytest-env~=0.6.0
+pytest-mock~=1.1
+pytest-timeout~=1.0
+pytest-xdist~=1.14


### PR DESCRIPTION
A version spec like ~=0.1 would also install 0.9.5, if it's not
specified as ~=0.1.0.

Discussed at https://gitter.im/coala/coala?at=5838551f8d65e3830e9c369e