### PR TITLE
Language: Change Language.extensions to tuples

### DIFF
--- a/coalib/bearlib/languages/definitions/CSS.py
+++ b/coalib/bearlib/languages/definitions/CSS.py
@@ -3,7 +3,7 @@ from coalib.bearlib.languages.Language import Language
 
 @Language
 class CSS:
-    extensions = '.css'
+    extensions = '.css',
     multiline_comment_delimiters = {'/*': '*/'}
     string_delimiters = {'"': '"', "'": "'"}
     multiline_string_delimiters = {}

--- a/coalib/bearlib/languages/definitions/CSharp.py
+++ b/coalib/bearlib/languages/definitions/CSharp.py
@@ -5,3 +5,4 @@ from coalib.bearlib.languages.Language import Language
 class CSharp:
     __qualname__ = 'C#'
     aliases = 'CS',
+    extensions = '.cs',

--- a/coalib/bearlib/languages/definitions/Java.py
+++ b/coalib/bearlib/languages/definitions/Java.py
@@ -3,7 +3,7 @@ from coalib.bearlib.languages.Language import Language
 
 @Language
 class Java:
-    extensions = '.java'
+    extensions = '.java',
     comment_delimiter = '//'
     multiline_comment_delimiters = {'/*': '*/'}
     string_delimiters = {'"': '"'}

--- a/coalib/bearlib/languages/definitions/JavaScript.py
+++ b/coalib/bearlib/languages/definitions/JavaScript.py
@@ -4,8 +4,7 @@ from coalib.bearlib.languages.Language import Language
 @Language
 class JavaScript:
     aliases = 'js', 'ecmascript'
-
-    extensions = '.js'
+    extensions = '.js',
     comment_delimiter = '//'
     multiline_comment_delimiters = {'/*': '*/'}
     string_delimiters = {'"': '"', "'": "'"}


### PR DESCRIPTION
The language definitions for CSS, Java and JavaScript used
a single string value for the extensions attribute, as opposed to
tuples used elsewhere where multiple values may be needed,
including the aliases attribute.

Also add attribute extensions to the C# language definition.