### PR TITLE
Upgrade libclang-py3 from 0.2 to 3.4

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,8 @@
 appdirs~=1.4
 coala_utils~=0.5.1
 colorlog~=2.7
-# Do *not* use 0.3 which is not backwards compatible to common clang versions
-libclang-py3~=0.2.0
+# libclang-py3 version numbering maps to the clang releases
+libclang-py3~=3.4.0
 Pygments~=2.1
 PyPrint~=0.2.5
 setuptools>=19.2


### PR DESCRIPTION
libclang-py3 3.4 retains compatibility with clang 3.4,
being identical source code to libclang-py3 0.2 except
it includes one bug fix.

https://github.com/coala/coala/issues/3187