### PR TITLE
result_actions: Write an AspectResultAction

### DIFF
--- a/coalib/results/result_actions/PrintAspectAction.py
+++ b/coalib/results/result_actions/PrintAspectAction.py
@@ -1,0 +1,17 @@
+from coalib.results.Result import Result
+from coalib.results.result_actions.ResultAction import ResultAction
+
+
+class PrintAspectAction(ResultAction):
+
+    @staticmethod
+    def is_applicable(result, original_file_dict, file_diff_dict):
+        return isinstance(result, Result) and (result.aspect is not None)
+
+    def apply(self, result, original_file_dict, file_diff_dict):
+        """
+        Print Aspect Information
+        """
+        print(result.aspect)
+
+        return file_diff_dict

--- a/tests/results/result_actions/PrintAspectActionTest.py
+++ b/tests/results/result_actions/PrintAspectActionTest.py
@@ -1,0 +1,29 @@
+import unittest
+
+from coala_utils.ContextManagers import retrieve_stdout
+from coalib.results.Result import Result
+from coalib.results.result_actions.PrintAspectAction import PrintAspectAction
+from coalib.settings.Section import Section
+from coalib.bearlib.aspects import Root
+
+
+class PrintAspectActionTest(unittest.TestCase):
+
+    def setUp(self):
+        self.utt = PrintAspectAction()
+        self.test_result = Result('origin', 'message', aspect=Root)
+
+    def test_is_applicable(self):
+        self.assertFalse(self.uut.is_applicable(1, None, None))
+        self.assertFalse(self.uut.is_applicable(Result('o', 'm'), None, None))
+        self.assertTrue(self.uut.is_applicable(self.test_result, None, None))
+
+    def test_apply(self):
+        with retrieve_stdout() as stdout:
+            self.assertEqual(self.uut.apply_from_section(self.test_result,
+                                                         {},
+                                                         {},
+                                                         Section('name')),
+                             {})
+            self.assertEqual(stdout.getvalue(),
+                             self.test_result.aspect+'\n')


### PR DESCRIPTION

The ``PrintAspectAction.py`` is an action that prints
information pertaining to the Aspect associated with
a Result.

Fixes https://github.com/coala/coala/issues/2959