### PR TITLE
Writing_Good_Commits.rst: Fix spacing issues

### DIFF
--- a/docs/Developers/Writing_Good_Commits.rst
+++ b/docs/Developers/Writing_Good_Commits.rst
@@ -139,6 +139,7 @@ More Examples
 ~~~~~~~~~~~~~
 
 Example 1 (fixed bug):
+
 ::
 
     setup: Install .coafile via package_data
@@ -151,6 +152,7 @@ Example 1 (fixed bug):
     Fixes https://github.com/coala/coala/issues/269
 
 Example 2 (implemented feature):
+
 ::
 
     Linter: Output command on debug


### PR DESCRIPTION
This fixes 'Possible title underline, too short for the title'
issues reported by RSTcheckBear on the file.

Closes https://github.com/coala/coala/issues/3147