### PR TITLE
Change TLD from .org to .io

### DIFF
--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -6,12 +6,12 @@ Reviewing pull requests takes a lot of time and we're all volunteers. Please mak
 
 ### Checklist
 
-- [ ] I have rebased properly. Please see [our tutorial on rebasing](http://coala.readthedocs.io/en/latest/Developers/Git_Basics.html#rebasing).
-- [ ] I have gone through the [commit guidelines](http://coala.readthedocs.io/en/latest/Developers/Writing_Good_Commits.html) and I've followed them.
-- [ ] I have followed the [guidelines for the commit shortlog](http://docs.coala.io/en/latest/Developers/Writing_Good_Commits.html#shortlog).
-- [ ] I have followed the [guidelines for the commit body](http://docs.coala.io/en/latest/Developers/Writing_Good_Commits.html#commit-body).
-- [ ] I have included the issue URL with the 'Fixes' keyword if the commit fixes a *real bug* and the 'Closes' keyword if it adds a feature or enhancement. For details, check the [issue reference section in our commit guidelines](http://docs.coala.io/en/latest/Developers/Writing_Good_Commits.html#issue-reference).
-- [ ] I have [run all the tests](http://coala.readthedocs.io/en/latest/Developers/Executing_Tests.html) and they all pass. If any CI (below) is not green, please fix them. If GitMate issues appear you will have to amend your commits, pushing new commits on top is not sufficient!
+- [ ] I have rebased properly. Please see [our tutorial on rebasing](http://coala.io/git#rebasing).
+- [ ] I have gone through the [commit guidelines](http://coala.io/commit) and I've followed them.
+- [ ] I have followed the [guidelines for the commit shortlog](http://coala.io/commit#shortlog).
+- [ ] I have followed the [guidelines for the commit body](http://coala.io/commit#commit-body).
+- [ ] I have included the issue URL with the 'Fixes' keyword if the commit fixes a *real bug* and the 'Closes' keyword if it adds a feature or enhancement. For details, check the [issue reference section in our commit guidelines](http://coala.io/commit#issue-reference).
+- [ ] I have [run all the tests](http://api.coala.io/en/latest/Developers/Executing_Tests.html) and they all pass. If any CI (below) is not green, please fix them. If GitMate issues appear you will have to amend your commits, pushing new commits on top is not sufficient!
 
 ### Reviewers
 

--- a/README.rst
+++ b/README.rst
@@ -7,7 +7,7 @@ coala: Linting and fixing code for all languages
 your code, regardless of the programming languages you use.**
 
 With coala, users can create
-`rules and standards <http://coala.readthedocs.io/en/latest/Users/coafile.html>`__
+`rules and standards <http://docs.coala.io/en/latest/Users/coafile.html>`__
 to be followed in the source
 code. coala has an **user-friendly interface** that is completely customizable.
 It can be used in any environment and is completely modular.
@@ -31,7 +31,7 @@ To see what coala can do for your language, run:
 .. Start ignoring LineLengthBear
 
 ======================================= ================================================ ================================================= ====================================================== =========================================================
-`Official Website <http://coala.io/>`__ `Documentation <https://coala.readthedocs.io>`__  `Twitter <https://twitter.com/coala_analyzer>`__ `Facebook <https://www.facebook.com/coalaAnalyzer/>`__ `Video Demo <https://asciinema.org/a/42968?autoplay=1>`__
+`Official Website <http://coala.io/>`__ `Documentation <https://docs.coala.io>`__  `Twitter <https://twitter.com/coala_analyzer>`__ `Facebook <https://www.facebook.com/coalaAnalyzer/>`__ `Video Demo <https://asciinema.org/a/42968?autoplay=1>`__
 ======================================= ================================================ ================================================= ====================================================== =========================================================
 
 .. Stop ignoring
@@ -103,7 +103,7 @@ for bears. To install it, run:
     $ pip3 install cib
 
 For usage instructions, consult
-`this link <http://coala.readthedocs.io/en/latest/Developers/Bear_Installation_Tool.html>`__.
+`this link <http://api.coala.io/en/latest/Developers/Bear_Installation_Tool.html>`__.
 
 |PyPI| |Windows| |Linux|
 
@@ -151,7 +151,7 @@ Store the file in the project's root directory and run coala:
     $ coala
 
 Please read our
-`coafile specification <http://coala.readthedocs.io/en/latest/Users/coafile.html>`__
+`coafile specification <http://docs.coala.io/en/latest/Users/coafile.html>`__
 to learn more.
 
 Using command-line arguments
@@ -198,7 +198,7 @@ Getting Involved
 ================
 
 If you would like to be a part of the coala community, you can check out our
-`Getting In Touch <http://coala.readthedocs.io/en/latest/Help/Getting_In_Touch.html>`__
+`Getting In Touch <http://docs.coala.io/en/latest/Help/Getting_In_Touch.html>`__
 page or ask us at our active Gitter channel, where we have maintainers from
 all over the world. We appreciate any help!
 
@@ -251,7 +251,7 @@ License
    :target: https://scrutinizer-ci.com/g/coala-analyzer/coala/?branch=master
 .. |codecov.io| image:: https://img.shields.io/codecov/c/github/coala/coala/master.svg?label=branch%20coverage
    :target: https://codecov.io/github/coala/coala?branch=master
-.. |Documentation Status| image:: https://readthedocs.org/projects/coala/badge/?version=latest
+.. |Documentation Status| image:: https://docs.coala.io/projects/coala/badge/?version=latest
    :target: http://coala.rtfd.org/
 .. |AGPL| image:: https://img.shields.io/github/license/coala/coala.svg
    :target: https://www.gnu.org/licenses/agpl-3.0.html

--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -135,26 +135,26 @@ coala 0.8.0 - grizzly
 
 ::
 
-                   -                         
-                 `Ns      :s-               
-            .     mMd`     :Nd.             
-           :h     /ss/`     +md.            
-           dN`    :NMMMy`  .ymmy. -+`       
-           dM+    dMMMMMm`.NMMMMN. +Mo      
-        `  -sddy: yMMMMMM/+MMMMMMo  dMo     
-       s/  +MMMMMy.dMMMMM-:MMMMMM+ -yhs`    
-      .Ms  /MMMMMMo /hdh:  oMMMMh`+MMMMm.   
-      -MN.  hMMMMMh  `/osssoos+-  dMMMMMs   
-       oyhho.+mMMm:+dMMMMMMMMMm+  sMMMMMs   
-       mMMMMMy``` dMMMMMMMMMMMMMh.`sMMMh`   
-       yMMMMMMy  `MMMMMMMMMMMMMMMMy:..`     
-       `yMMMMMd  yMMMMMMMMMMMMMMMMMMMMNh+`  
-         .ohhs-+mMMMMMMMMMMMMMMMMMMMMMMMMd  
-            .yMMMMMMMMMMMMMMMMMMMMMMMMMMMh  
-            mMMMMMMMMMMMMMMMMMMMMMMMMMMMh`  
-            yMMMMMMMMMMMMMMMNhssssyyyso-    
-             /dMMMMMMMMMNy+.                
-               ./syhys/-                    
+                   -
+                 `Ns      :s-
+            .     mMd`     :Nd.
+           :h     /ss/`     +md.
+           dN`    :NMMMy`  .ymmy. -+`
+           dM+    dMMMMMm`.NMMMMN. +Mo
+        `  -sddy: yMMMMMM/+MMMMMMo  dMo
+       s/  +MMMMMy.dMMMMM-:MMMMMM+ -yhs`
+      .Ms  /MMMMMMo /hdh:  oMMMMh`+MMMMm.
+      -MN.  hMMMMMh  `/osssoos+-  dMMMMMs
+       oyhho.+mMMm:+dMMMMMMMMMm+  sMMMMMs
+       mMMMMMy``` dMMMMMMMMMMMMMh.`sMMMh`
+       yMMMMMMy  `MMMMMMMMMMMMMMMMy:..`
+       `yMMMMMd  yMMMMMMMMMMMMMMMMMMMMNh+`
+         .ohhs-+mMMMMMMMMMMMMMMMMMMMMMMMMd
+            .yMMMMMMMMMMMMMMMMMMMMMMMMMMMh
+            mMMMMMMMMMMMMMMMMMMMMMMMMMMMh`
+            yMMMMMMMMMMMMMMMNhssssyyyso-
+             /dMMMMMMMMMNy+.
+               ./syhys/-
 
 
 For this release, we have had 46 developers from around the world contributing
@@ -256,7 +256,7 @@ Below are some of the important changes introduced for this release:
 - A complete overhaul to the README page with a focus on design and
   readability.
 
-- A new `FAQ page <http://coala.readthedocs.io/en/latest/Users/FAQ.html>`_ has
+- A new `FAQ page <http://docs.coala.io/en/latest/Users/FAQ.html>`_ has
   been created.
 
 - Various other documentation pages have been improved with new resources,
@@ -311,7 +311,7 @@ listed are especially lots of internal improvements and documentation fixes.
 
 New Features:
 
-- `Shell Autocompletion <http://coala.readthedocs.io/en/latest/Users/Tutorials/Shell_Autocompletion.html>`_
+- `Shell Autocompletion <http://docs.coala.io/en/latest/Users/Tutorials/Shell_Autocompletion.html>`_
 - Patches are shown without prompting the user if small enough, otherwise
   diffstats.
 - Bears have metadata and can be browsed. Browse the
@@ -502,7 +502,7 @@ New features:
 -  Actions that are not applicable multiple times are not shown after applying
    them anymore. (https://github.com/coala-analyzer/coala/issues/1064)
 -  Documentation about how to add coala as a pre commit hook has been added:
-   http://coala.readthedocs.org/en/latest/Users/Git_Hooks.html
+   http://docs.coala.io/en/latest/Users/Git_Hooks.html
 -  Actions emit a success message now that is shown to the user and improves
    usability and intuitivity of actions.
 -  A warning is emitted if a bear or file glob does not match any bears or
@@ -578,7 +578,7 @@ For bear writers:
 Notable internal changes:
 
 -  API documentation is now available at
-   http://coala.readthedocs.org/en/latest/API/modules.html
+   http://api.coala.io
 -  coala switched to PyTest. Our old own framework is no longer maintained.
    (https://github.com/coala-analyzer/coala/issues/875)
 -  As always loads of refactorings to make the code more stable, readable and
@@ -715,7 +715,7 @@ This release features the following feature changes:
 -  Changed logging API in Bears (now: debug/warn/err).
 -  clang python bindings were added to the bearlib.
 -  Exitcodes were organized and documented.
-   (http://coala.readthedocs.org/en/latest/Users/Exit_Codes.html)
+   (http://docs.coala.io/en/latest/Users/Exit_Codes.html)
 -  Handling of EOF/Keyboard Interrupt was improved.
 -  Console output is now colored.
 -  Bears can now easily convert settings to typed lists or dicts.
@@ -736,7 +736,7 @@ This release features the following feature changes:
 -  The StringProcessing libary is there to help bear writers deal with
    regexes and similar things.
 -  A new glob syntax was introduced and documented.
-   (http://coala.readthedocs.org/en/latest/Users/Glob_Patterns.html)
+   (http://docs.coala.io/en/latest/Users/Glob_Patterns.html)
 -  The ``--apply-changes`` argument was removed as its concept does not
    fit anymore.
 -  Bears can now return any iterable. This makes it possible to

--- a/docs/Developers/Git_Basics.rst
+++ b/docs/Developers/Git_Basics.rst
@@ -186,7 +186,7 @@ You are awesome!
     to sync your local fork with the remote repository before sending
     a pull request.
 
-    More information regarding syncing can be found `here <http://coala.readthedocs.io/en/latest/Developers/Git_Basics.html#rebasing>`_.
+    More information regarding syncing can be found `here <http://coala.io/git#rebasing>`_.
 
 Follow-up
 ---------

--- a/docs/Developers/Writing_Documentation.rst
+++ b/docs/Developers/Writing_Documentation.rst
@@ -4,9 +4,9 @@ Writing Documentation
 This document gives a short introduction on how to write documentation
 for the coala project.
 
-Documentation is written in reStructuredText and rendered by readthedocs.org to
-our lovely users. You can view the current documentation on
-http://coala.rtfd.org.
+Documentation is written in reStructuredText and rendered by `Read the Docs
+<https://readthedocs.io>`_ to our lovely users.
+You can view the current user documentation on http://docs.coala.io.
 
 After getting the coala source code (see `Installation
 Instructions`_), you can start hacking on

--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,7 @@ class BuildDocsCommand(setuptools.command.build_py.build_py):
         call(self.doc_command)
 
 
-# Generate API documentation only if we are running on readthedocs.org
+# Generate API documentation only if we are running on readthedocs.io
 on_rtd = getenv('READTHEDOCS', None) != None
 if on_rtd:
     call(BuildDocsCommand.apidoc_command)


### PR DESCRIPTION
Changed all instances of 'readthedocs.org' to 'readthedocs.io' and to 'api.coala.io' in case of Developers Section.
Reason: Moved the docs to the new url.

Closes https://github.com/coala/coala/issues/2085 

Ping! @sils 
