### PR TITLE
result_actions: Write an AspectResultAction

### DIFF
--- a/coalib/results/result_actions/PrintAspectAction.py
+++ b/coalib/results/result_actions/PrintAspectAction.py
@@ -1,0 +1,18 @@
+from coalib.results.Result import Result
+from coalib.results.result_actions.ResultAction import ResultAction
+
+
+class PrintAspectAction(ResultAction):
+
+    @staticmethod
+    def is_applicable(result, original_file_dict, file_diff_dict):
+        return isinstance(result, Result) and (result.aspect is not None)
+
+    def apply(self, result, original_file_dict, file_diff_dict):
+        """
+        Print Aspect Information
+        """
+        print(type(result.aspect).__qualname__ + '\n' +
+              type(result.aspect).docs.definition)
+
+        return file_diff_dict

--- a/tests/results/result_actions/PrintAspectActionTest.py
+++ b/tests/results/result_actions/PrintAspectActionTest.py
@@ -1,0 +1,43 @@
+import unittest
+
+from coala_utils.ContextManagers import retrieve_stdout
+from coalib.results.Result import Result
+from coalib.results.result_actions.PrintAspectAction import PrintAspectAction
+from coalib.settings.Section import Section
+from coalib.bearlib.aspects import Root
+
+
+class PrintAspectActionTest(unittest.TestCase):
+
+    def setUp(self):
+        self.uut = PrintAspectAction()
+
+        @Root.subaspect
+        class test_aspect:
+            """
+            This is a test aspect
+            """
+            class docs:
+                example = 'test'
+                example_language = 'test'
+                importance_reason = 'test'
+                fix_suggestions = 'test'
+
+        self.test_aspect = test_aspect('py')
+        self.test_result = Result('origin', 'message', aspect=self.test_aspect)
+
+    def test_is_applicable(self):
+        self.assertFalse(self.uut.is_applicable(1, None, None))
+        self.assertFalse(self.uut.is_applicable(Result('o', 'm'), None, None))
+        self.assertTrue(self.uut.is_applicable(self.test_result, None, None))
+
+    def test_apply(self):
+        with retrieve_stdout() as stdout:
+            self.assertEqual(self.uut.apply_from_section(self.test_result,
+                                                         {},
+                                                         {},
+                                                         Section('name')),
+                             {})
+            self.assertEqual(stdout.getvalue(),
+                             type(self.test_aspect).__qualname__ + '\n' +
+                             type(self.test_aspect).docs.definition + '\n')


### PR DESCRIPTION

The ``PrintAspectAction.py`` is an action that prints
information pertaining to the Aspect associated with
a Result.

Fixes https://github.com/coala/coala/issues/2959