### PR TITLE
Custom 'not applicable' message for result action

### DIFF
--- a/coalib/output/ConsoleInteraction.py
+++ b/coalib/output/ConsoleInteraction.py
@@ -137,7 +137,7 @@ def acquire_actions_and_apply(console_printer,
     while True:
         actions = []
         for action in cli_actions:
-            if action.is_applicable(result, file_dict, file_diff_dict):
+            if action.is_applicable(result, file_dict, file_diff_dict) is True:
                 actions.append(action)
 
         if actions == []:
@@ -251,7 +251,8 @@ def print_result(console_printer,
     if interactive:
         cli_actions = CLI_ACTIONS
         show_patch_action = ShowPatchAction()
-        if show_patch_action.is_applicable(result, file_dict, file_diff_dict):
+        if show_patch_action.is_applicable(
+                result, file_dict, file_diff_dict) is True:
             diff_size = sum(len(diff) for diff in result.diffs.values())
             if diff_size <= DIFF_EXCERPT_MAX_SIZE:
                 show_patch_action.apply_from_section(result,

--- a/coalib/processes/Processing.py
+++ b/coalib/processes/Processing.py
@@ -138,10 +138,9 @@ def autoapply_actions(results,
                 not_processed_results.append(result)
                 continue
 
-        if not action.is_applicable(result, file_dict, file_diff_dict):
-            log_printer.warn('Selected default action {!r} for bear {!r} is '
-                             'not applicable. Action not applied.'.format(
-                                 action.get_metadata().name, result.origin))
+        applicable = action.is_applicable(result, file_dict, file_diff_dict)
+        if applicable is not True:
+            log_printer.warn('{}: {}'.format(result.origin, applicable))
             not_processed_results.append(result)
             continue
 

--- a/coalib/results/result_actions/IgnoreResultAction.py
+++ b/coalib/results/result_actions/IgnoreResultAction.py
@@ -6,19 +6,22 @@ from os.path import exists
 from os.path import isfile
 import shutil
 
+from coala_utils.decorators import enforce_signature
+
 
 class IgnoreResultAction(ResultAction):
 
     SUCCESS_MESSAGE = 'An ignore comment was added to your source code.'
 
     @staticmethod
-    def is_applicable(result, original_file_dict, file_diff_dict):
+    @enforce_signature
+    def is_applicable(result: Result, original_file_dict, file_diff_dict):
         """
         For being applicable, the result has to point to a number of files
         that have to exist i.e. have not been previously deleted.
         """
 
-        if not isinstance(result, Result) or len(result.affected_code) == 0:
+        if len(result.affected_code) == 0:
             return False
 
         filenames = set(src.renamed_file(file_diff_dict)

--- a/coalib/results/result_actions/IgnoreResultAction.py
+++ b/coalib/results/result_actions/IgnoreResultAction.py
@@ -22,11 +22,14 @@ class IgnoreResultAction(ResultAction):
         """
 
         if len(result.affected_code) == 0:
-            return False
+            return 'The result is not associated with any source code.'
 
         filenames = set(src.renamed_file(file_diff_dict)
                         for src in result.affected_code)
-        return any(exists(filename) for filename in filenames)
+        if any(exists(filename) for filename in filenames):
+            return True
+        return ("The result is associated with source code that doesn't "
+                'seem to exist.')
 
     def apply(self, result, original_file_dict, file_diff_dict, language: str,
               no_orig: bool=False):

--- a/coalib/results/result_actions/OpenEditorAction.py
+++ b/coalib/results/result_actions/OpenEditorAction.py
@@ -8,6 +8,7 @@ from coalib.results.result_actions.ResultAction import ResultAction
 
 from coala_utils.decorators import enforce_signature
 
+
 EDITOR_ARGS = {
     'subl': '--wait',
     'gedit': '-s',
@@ -29,12 +30,16 @@ class OpenEditorAction(ResultAction):
         For being applicable, the result has to point to a number of files
         that have to exist i.e. have not been previously deleted.
         """
+
         if not len(result.affected_code) > 0:
-            return False
+            return 'The result is not associated with any source code.'
 
         filenames = set(src.renamed_file(file_diff_dict)
                         for src in result.affected_code)
-        return all(exists(filename) for filename in filenames)
+        if not all(exists(filename) for filename in filenames):
+            return ("The result is associated with source code that doesn't "
+                    'seem to exist.')
+        return True
 
     def apply(self, result, original_file_dict, file_diff_dict, editor: str):
         """

--- a/coalib/results/result_actions/OpenEditorAction.py
+++ b/coalib/results/result_actions/OpenEditorAction.py
@@ -6,6 +6,8 @@ from coalib.results.Diff import Diff
 from coalib.results.Result import Result
 from coalib.results.result_actions.ResultAction import ResultAction
 
+from coala_utils.decorators import enforce_signature
+
 EDITOR_ARGS = {
     'subl': '--wait',
     'gedit': '-s',
@@ -21,12 +23,13 @@ class OpenEditorAction(ResultAction):
     SUCCESS_MESSAGE = 'Changes saved successfully.'
 
     @staticmethod
-    def is_applicable(result, original_file_dict, file_diff_dict):
+    @enforce_signature
+    def is_applicable(result: Result, original_file_dict, file_diff_dict):
         """
         For being applicable, the result has to point to a number of files
         that have to exist i.e. have not been previously deleted.
         """
-        if not isinstance(result, Result) or not len(result.affected_code) > 0:
+        if not len(result.affected_code) > 0:
             return False
 
         filenames = set(src.renamed_file(file_diff_dict)

--- a/coalib/results/result_actions/PrintAspectAction.py
+++ b/coalib/results/result_actions/PrintAspectAction.py
@@ -9,7 +9,9 @@ class PrintAspectAction(ResultAction):
     @staticmethod
     @enforce_signature
     def is_applicable(result: Result, original_file_dict, file_diff_dict):
-        return result.aspect is not None
+        if result.aspect is None:
+            return 'There is no aspect associated with the result.'
+        return True
 
     def apply(self, result, original_file_dict, file_diff_dict):
         """

--- a/coalib/results/result_actions/PrintAspectAction.py
+++ b/coalib/results/result_actions/PrintAspectAction.py
@@ -1,12 +1,15 @@
 from coalib.results.Result import Result
 from coalib.results.result_actions.ResultAction import ResultAction
 
+from coala_utils.decorators import enforce_signature
+
 
 class PrintAspectAction(ResultAction):
 
     @staticmethod
-    def is_applicable(result, original_file_dict, file_diff_dict):
-        return isinstance(result, Result) and (result.aspect is not None)
+    @enforce_signature
+    def is_applicable(result: Result, original_file_dict, file_diff_dict):
+        return result.aspect is not None
 
     def apply(self, result, original_file_dict, file_diff_dict):
         """

--- a/coalib/results/result_actions/PrintDebugMessageAction.py
+++ b/coalib/results/result_actions/PrintDebugMessageAction.py
@@ -1,12 +1,15 @@
 from coalib.results.Result import Result
 from coalib.results.result_actions.ResultAction import ResultAction
 
+from coala_utils.decorators import enforce_signature
+
 
 class PrintDebugMessageAction(ResultAction):
 
     @staticmethod
-    def is_applicable(result, original_file_dict, file_diff_dict):
-        return isinstance(result, Result) and result.debug_msg != ''
+    @enforce_signature
+    def is_applicable(result: Result, original_file_dict, file_diff_dict):
+        return result.debug_msg != ''
 
     def apply(self, result, original_file_dict, file_diff_dict):
         """

--- a/coalib/results/result_actions/PrintDebugMessageAction.py
+++ b/coalib/results/result_actions/PrintDebugMessageAction.py
@@ -9,7 +9,9 @@ class PrintDebugMessageAction(ResultAction):
     @staticmethod
     @enforce_signature
     def is_applicable(result: Result, original_file_dict, file_diff_dict):
-        return result.debug_msg != ''
+        if result.debug_msg != '':
+            return True
+        return 'There is no debug message.'
 
     def apply(self, result, original_file_dict, file_diff_dict):
         """

--- a/coalib/results/result_actions/PrintMoreInfoAction.py
+++ b/coalib/results/result_actions/PrintMoreInfoAction.py
@@ -1,12 +1,15 @@
 from coalib.results.Result import Result
 from coalib.results.result_actions.ResultAction import ResultAction
 
+from coala_utils.decorators import enforce_signature
+
 
 class PrintMoreInfoAction(ResultAction):
 
     @staticmethod
-    def is_applicable(result, original_file_dict, file_diff_dict):
-        return isinstance(result, Result) and result.additional_info != ''
+    @enforce_signature
+    def is_applicable(result: Result, original_file_dict, file_diff_dict):
+        return result.additional_info != ''
 
     def apply(self, result, original_file_dict, file_diff_dict):
         """

--- a/coalib/results/result_actions/PrintMoreInfoAction.py
+++ b/coalib/results/result_actions/PrintMoreInfoAction.py
@@ -9,7 +9,9 @@ class PrintMoreInfoAction(ResultAction):
     @staticmethod
     @enforce_signature
     def is_applicable(result: Result, original_file_dict, file_diff_dict):
-        return result.additional_info != ''
+        if result.additional_info != '':
+            return True
+        return 'There is no additional info.'
 
     def apply(self, result, original_file_dict, file_diff_dict):
         """

--- a/coalib/results/result_actions/ResultAction.py
+++ b/coalib/results/result_actions/ResultAction.py
@@ -17,7 +17,7 @@ class ResultAction:
         """
         Checks whether the Action is valid for the result type.
 
-        Returns ``True`` by default.
+        Returns ``True`` or a string containing the not_applicable message.
 
         :param result:             The result from the coala run to check if an
                                    Action is applicable.

--- a/coalib/results/result_actions/ShowPatchAction.py
+++ b/coalib/results/result_actions/ShowPatchAction.py
@@ -67,8 +67,9 @@ class ShowPatchAction(ResultAction):
     @staticmethod
     @enforce_signature
     def is_applicable(result: Result, original_file_dict, file_diff_dict):
+
         if not result.diffs:
-            return False
+            return 'This result has no patch attached.'
 
         try:
             # Needed so the addition is run for all patches -> ConflictError
@@ -79,9 +80,13 @@ class ShowPatchAction(ResultAction):
                              file_diff_dict[filename]):
                     nonempty_patches = True
 
-            return nonempty_patches
-        except ConflictError:
-            return False
+            if nonempty_patches:
+                return True
+            return 'The given patches do not change anything anymore.'
+
+        except ConflictError as ce:
+            return ('Two or more patches conflict with '
+                    'each other: {}'.format(str(ce)))
 
     def apply(self,
               result,

--- a/coalib/results/result_actions/ShowPatchAction.py
+++ b/coalib/results/result_actions/ShowPatchAction.py
@@ -7,6 +7,8 @@ from coalib.results.Diff import ConflictError
 from coalib.results.Result import Result
 from coalib.results.result_actions.ResultAction import ResultAction
 
+from coala_utils.decorators import enforce_signature
+
 
 def format_line(line, real_nr='', sign='|', mod_nr='', symbol='', ):
     return '|{:>4}{}{:>4}|{:1}{}'.format(real_nr,
@@ -63,8 +65,9 @@ class ShowPatchAction(ResultAction):
     SUCCESS_MESSAGE = 'Displayed patch successfully.'
 
     @staticmethod
-    def is_applicable(result, original_file_dict, file_diff_dict):
-        if not isinstance(result, Result) or not result.diffs:
+    @enforce_signature
+    def is_applicable(result: Result, original_file_dict, file_diff_dict):
+        if not result.diffs:
             return False
 
         try:

--- a/tests/output/ConsoleInteractionTest.py
+++ b/tests/output/ConsoleInteractionTest.py
@@ -128,10 +128,13 @@ class ConsoleInteractionTest(unittest.TestCase):
                                          ('test', [SomeglobalBear])])
 
         self.old_open_editor_applicable = OpenEditorAction.is_applicable
-        OpenEditorAction.is_applicable = staticmethod(lambda *args: False)
+        OpenEditorAction.is_applicable = staticmethod(
+            lambda *args: 'OpenEditorAction cannot be applied')
 
         self.old_apply_patch_applicable = ApplyPatchAction.is_applicable
-        ApplyPatchAction.is_applicable = staticmethod(lambda *args: False)
+        ApplyPatchAction.is_applicable = staticmethod(
+            lambda *args: 'ApplyPatchAction cannot be applied')
+
         self.lexer = TextLexer()
         self.lexer.add_filter(VisibleWhitespaceFilter(
             spaces='•',
@@ -347,7 +350,7 @@ class ConsoleInteractionTest(unittest.TestCase):
 
                 def apply(*args, **kwargs):
                     ApplyPatchAction.is_applicable = staticmethod(
-                        lambda *args: False)
+                        lambda *args: 'ApplyPatchAction cannot be applied.')
 
             old_applypatch_is_applicable = ApplyPatchAction.is_applicable
             ApplyPatchAction.is_applicable = staticmethod(lambda *args: True)

--- a/tests/processes/ProcessingTest.py
+++ b/tests/processes/ProcessingTest.py
@@ -563,7 +563,9 @@ class ProcessingTest_AutoapplyActions(unittest.TestCase):
         # Use a result where no default action is supplied for and another one
         # where the action is not applicable.
         old_is_applicable = ApplyPatchAction.is_applicable
-        ApplyPatchAction.is_applicable = lambda *args: False
+        ApplyPatchAction.is_applicable = (
+            lambda *args: 'The ApplyPatchAction cannot be applied'
+        )
 
         self.section.append(Setting(
             'default_actions',
@@ -575,8 +577,7 @@ class ProcessingTest_AutoapplyActions(unittest.TestCase):
                                 self.log_printer)
         self.assertEqual(ret, self.results)
         self.assertEqual(self.log_queue.get().message,
-                         "Selected default action 'ApplyPatchAction' for bear "
-                         "'YBear' is not applicable. Action not applied.")
+                         'YBear: The ApplyPatchAction cannot be applied')
         self.assertTrue(self.log_queue.empty())
 
         ApplyPatchAction.is_applicable = old_is_applicable

--- a/tests/results/result_actions/ApplyPatchActionTest.py
+++ b/tests/results/result_actions/ApplyPatchActionTest.py
@@ -156,14 +156,24 @@ class ApplyPatchActionTest(unittest.TestCase):
 
         conflict_result = Result('', '', diffs={'f': diff})
         # Applying the same diff twice will result in a conflict
-        self.assertFalse(
-            ApplyPatchAction.is_applicable(conflict_result, {}, {'f': diff}))
+        self.assertIn(
+            'Two or more patches conflict with each other: ',
+            ApplyPatchAction.is_applicable(conflict_result, {}, {'f': diff})
+        )
 
     def test_is_applicable_empty_patch(self):
-        empty_patch_result = Result('', '', diffs={})
-        self.assertFalse(
-            ApplyPatchAction.is_applicable(empty_patch_result, {}, {}))
+        diff = Diff([], rename='new_name')
+        result = Result('', '', diffs={'f': diff})
+
+        # Two renames donot result in any change
+        self.assertEqual(
+            ApplyPatchAction.is_applicable(result, {}, {'f': diff}),
+            'The given patches do not change anything anymore.'
+        )
 
     def test_is_applicable_without_patch(self):
         result = Result('', '')
-        self.assertFalse(ApplyPatchAction.is_applicable(result, {}, {}))
+        self.assertEqual(
+            ApplyPatchAction.is_applicable(result, {}, {}),
+            'This result has no patch attached.'
+        )

--- a/tests/results/result_actions/IgnoreResultActionTest.py
+++ b/tests/results/result_actions/IgnoreResultActionTest.py
@@ -9,12 +9,29 @@ from coalib.results.result_actions.IgnoreResultAction import IgnoreResultAction
 class IgnoreResultActionTest(unittest.TestCase):
 
     def test_is_applicable(self):
-        with self.assertRaises(TypeError):
+
+        with self.assertRaises(TypeError) as context:
             IgnoreResultAction.is_applicable('str', {}, {})
 
-        self.assertFalse(IgnoreResultAction.is_applicable(
-            Result.from_values('origin', 'msg', "file doesn't exist", 2),
-            {}, {}))
+        self.assertEqual(
+            IgnoreResultAction.is_applicable(
+                Result.from_values('origin', 'msg', "file doesn't exist", 2),
+                {},
+                {}
+            ),
+            "The result is associated with source code that doesn't "
+            'seem to exist.'
+        )
+
+        self.assertEqual(
+            IgnoreResultAction.is_applicable(
+                Result('', ''),
+                {},
+                {}
+            ),
+            'The result is not associated with any source code.'
+        )
+
         with make_temp() as f_a:
             self.assertTrue(IgnoreResultAction.is_applicable(
                 Result.from_values('origin', 'msg', f_a, 2), {}, {}))

--- a/tests/results/result_actions/IgnoreResultActionTest.py
+++ b/tests/results/result_actions/IgnoreResultActionTest.py
@@ -9,7 +9,9 @@ from coalib.results.result_actions.IgnoreResultAction import IgnoreResultAction
 class IgnoreResultActionTest(unittest.TestCase):
 
     def test_is_applicable(self):
-        self.assertFalse(IgnoreResultAction.is_applicable('str', {}, {}))
+        with self.assertRaises(TypeError):
+            IgnoreResultAction.is_applicable('str', {}, {})
+
         self.assertFalse(IgnoreResultAction.is_applicable(
             Result.from_values('origin', 'msg', "file doesn't exist", 2),
             {}, {}))

--- a/tests/results/result_actions/OpenEditorActionTest.py
+++ b/tests/results/result_actions/OpenEditorActionTest.py
@@ -147,10 +147,18 @@ class OpenEditorActionTest(unittest.TestCase):
         result2 = Result.from_values('', '', '')
         result3 = Result.from_values('', '', 'file')
         invalid_result = ''
-        self.assertFalse(OpenEditorAction.is_applicable(result1, None, {}))
+
+        self.assertEqual(
+            OpenEditorAction.is_applicable(result1, None, {}),
+            'The result is not associated with any source code.')
+
         self.assertTrue(OpenEditorAction.is_applicable(result2, None, {}))
+
         # Check non-existent file
-        self.assertFalse(OpenEditorAction.is_applicable(result3, None, {}))
+        self.assertEqual(
+            OpenEditorAction.is_applicable(result3, None, {}),
+            "The result is associated with source code that doesn't "
+            'seem to exist.')
 
         with self.assertRaises(TypeError):
             OpenEditorAction.is_applicable(invalid_result, None, {})

--- a/tests/results/result_actions/OpenEditorActionTest.py
+++ b/tests/results/result_actions/OpenEditorActionTest.py
@@ -152,8 +152,8 @@ class OpenEditorActionTest(unittest.TestCase):
         # Check non-existent file
         self.assertFalse(OpenEditorAction.is_applicable(result3, None, {}))
 
-        self.assertFalse(
-            OpenEditorAction.is_applicable(invalid_result, None, {}))
+        with self.assertRaises(TypeError):
+            OpenEditorAction.is_applicable(invalid_result, None, {})
 
     def test_environ_editor(self):
         old_environ = os.environ

--- a/tests/results/result_actions/PrintAspectActionTest.py
+++ b/tests/results/result_actions/PrintAspectActionTest.py
@@ -27,7 +27,8 @@ class PrintAspectActionTest(unittest.TestCase):
         self.test_result = Result('origin', 'message', aspect=self.test_aspect)
 
     def test_is_applicable(self):
-        self.assertFalse(self.uut.is_applicable(1, None, None))
+        with self.assertRaises(TypeError):
+            self.uut.is_applicable(1, None, None)
         self.assertFalse(self.uut.is_applicable(Result('o', 'm'), None, None))
         self.assertTrue(self.uut.is_applicable(self.test_result, None, None))
 

--- a/tests/results/result_actions/PrintAspectActionTest.py
+++ b/tests/results/result_actions/PrintAspectActionTest.py
@@ -29,7 +29,11 @@ class PrintAspectActionTest(unittest.TestCase):
     def test_is_applicable(self):
         with self.assertRaises(TypeError):
             self.uut.is_applicable(1, None, None)
-        self.assertFalse(self.uut.is_applicable(Result('o', 'm'), None, None))
+
+        self.assertEqual(
+            'There is no aspect associated with the result.',
+            self.uut.is_applicable(Result('o', 'm'), None, None))
+
         self.assertTrue(self.uut.is_applicable(self.test_result, None, None))
 
     def test_apply(self):

--- a/tests/results/result_actions/PrintDebugMessageActionTest.py
+++ b/tests/results/result_actions/PrintDebugMessageActionTest.py
@@ -14,7 +14,9 @@ class PrintDebugMessageActionTest(unittest.TestCase):
         self.test_result = Result('origin', 'message', debug_msg='DEBUG MSG')
 
     def test_is_applicable(self):
-        self.assertFalse(self.uut.is_applicable(1, None, None))
+        with self.assertRaises(TypeError):
+            self.uut.is_applicable(1, None, None)
+
         self.assertFalse(self.uut.is_applicable(Result('o', 'm'), None, None))
         self.assertTrue(self.uut.is_applicable(self.test_result, None, None))
 

--- a/tests/results/result_actions/PrintDebugMessageActionTest.py
+++ b/tests/results/result_actions/PrintDebugMessageActionTest.py
@@ -17,7 +17,11 @@ class PrintDebugMessageActionTest(unittest.TestCase):
         with self.assertRaises(TypeError):
             self.uut.is_applicable(1, None, None)
 
-        self.assertFalse(self.uut.is_applicable(Result('o', 'm'), None, None))
+        self.assertEqual(
+            self.uut.is_applicable(Result('o', 'm'), None, None),
+            'There is no debug message.'
+        )
+
         self.assertTrue(self.uut.is_applicable(self.test_result, None, None))
 
     def test_apply(self):

--- a/tests/results/result_actions/PrintMoreInfoActionTest.py
+++ b/tests/results/result_actions/PrintMoreInfoActionTest.py
@@ -16,11 +16,12 @@ class PrintMoreInfoActionTest(unittest.TestCase):
             additional_info='A lot of additional information can be found here')
 
     def test_is_applicable(self):
-
         with self.assertRaises(TypeError):
             self.uut.is_applicable(1, None, None)
-
-        self.assertFalse(self.uut.is_applicable(Result('o', 'm'), None, None))
+        self.assertEqual(
+            self.uut.is_applicable(Result('o', 'm'), None, None),
+            'There is no additional info.'
+        )
         self.assertTrue(self.uut.is_applicable(self.test_result, None, None))
 
     def test_apply(self):

--- a/tests/results/result_actions/PrintMoreInfoActionTest.py
+++ b/tests/results/result_actions/PrintMoreInfoActionTest.py
@@ -16,7 +16,10 @@ class PrintMoreInfoActionTest(unittest.TestCase):
             additional_info='A lot of additional information can be found here')
 
     def test_is_applicable(self):
-        self.assertFalse(self.uut.is_applicable(1, None, None))
+
+        with self.assertRaises(TypeError):
+            self.uut.is_applicable(1, None, None)
+
         self.assertFalse(self.uut.is_applicable(Result('o', 'm'), None, None))
         self.assertTrue(self.uut.is_applicable(self.test_result, None, None))
 

--- a/tests/results/result_actions/ShowPatchActionTest.py
+++ b/tests/results/result_actions/ShowPatchActionTest.py
@@ -24,13 +24,27 @@ class ShowPatchActionTest(unittest.TestCase):
         self.section.append(Setting('colored', 'false'))
 
     def test_is_applicable(self):
+        diff = Diff([], rename='new_name')
+        result = Result('', '', diffs={'f': diff})
+
+        # Two renames donot result in any change
+        self.assertEqual(
+            self.uut.is_applicable(result, {}, {'f': diff}),
+            'The given patches do not change anything anymore.'
+        )
+
         with self.assertRaises(TypeError):
             self.uut.is_applicable(1, None, None)
 
-        self.assertFalse(self.uut.is_applicable(Result('o', 'm'), None, None))
+        self.assertEqual(
+            self.uut.is_applicable(Result('o', 'm'), None, None),
+            'This result has no patch attached.')
+
         self.assertTrue(self.uut.is_applicable(self.test_result, {}, {}))
-        self.assertFalse(self.uut.is_applicable(self.test_result, {},
-                                                self.diff_dict))
+
+        self.assertIn(
+            'Two or more patches conflict with each other: ',
+            self.uut.is_applicable(self.test_result, {}, self.diff_dict))
 
     def test_apply(self):
         with retrieve_stdout() as stdout:

--- a/tests/results/result_actions/ShowPatchActionTest.py
+++ b/tests/results/result_actions/ShowPatchActionTest.py
@@ -24,7 +24,9 @@ class ShowPatchActionTest(unittest.TestCase):
         self.section.append(Setting('colored', 'false'))
 
     def test_is_applicable(self):
-        self.assertFalse(self.uut.is_applicable(1, None, None))
+        with self.assertRaises(TypeError):
+            self.uut.is_applicable(1, None, None)
+
         self.assertFalse(self.uut.is_applicable(Result('o', 'm'), None, None))
         self.assertTrue(self.uut.is_applicable(self.test_result, {}, {}))
         self.assertFalse(self.uut.is_applicable(self.test_result, {},


### PR DESCRIPTION
This commit changes the is_applicable method to return
the 'not_applicable' message when the result action is not applicable.

It also change the message type from:
Selected default action `PatchAction` for bear `Bear`
is not applicable.

To:
`Bear`: `Custom not_applicable message`

Closes https://github.com/coala/coala/issues/3169
