### PR TITLE
Writing_Linter_Bears.rst: Link to API documentation

### DIFF
--- a/docs/Developers/Writing_Linter_Bears.rst
+++ b/docs/Developers/Writing_Linter_Bears.rst
@@ -130,8 +130,8 @@ As you can see, the ``output_regex`` parameter consists of named groups. These
 are important to construct a meaningful result that contains the information
 that is printed out.
 
-For the exact list of named groups ``@linter`` recognizes, see the API
-documentation.
+For the exact list of named groups ``@linter`` recognizes, see the `API
+documentation <https://api.coala.io/en/latest/>`_.
 
 For more info generally on regexes, see `Python re module
 <https://docs.python.org/3/library/re.html>`_.


### PR DESCRIPTION
The text "API documentation" links now to
"http://api.coala.io/en/latest/".

Closes coala/documentation#21

<!--
Thanks for your contribution!

Reviewing pull requests takes a lot of time and we're all volunteers. Please make sure you go through the following checklist and all items before pinging someone for a review.
-->

### Checklist

- [x] I have rebased properly. Please see [our tutorial on rebasing](http://coala.io/git#rebasing).
- [x] I have gone through the [commit guidelines](http://coala.io/commit) and I've followed them.
- [x] I have followed the [guidelines for the commit shortlog](http://coala.io/commit#shortlog).
- [x] I have followed the [guidelines for the commit body](http://coala.io/commit#commit-body).
- [x] I have included the issue URL with the 'Fixes' keyword if the commit fixes a *real bug* and the 'Closes' keyword if it adds a feature or enhancement. For details, check the [issue reference section in our commit guidelines](http://coala.io/commit#issue-reference).
- [x] I have [run all the tests](http://api.coala.io/en/latest/Developers/Executing_Tests.html) and they all pass. If any CI (below) is not green, please fix them. If GitMate issues appear you will have to amend your commits, pushing new commits on top is not sufficient!

### Reviewers
@Adrianzatreanu 
@userzimmermann 
<!--
Please list the Github handles of people you think susceptible to review this PR. Feel free to leave this section blank if you don't know who to tag.
-->

<!--
End note:

As you learn things over your Pull Request please help others on the chat and on PRs to get their stuff right as well!
-->
