### PR TITLE
CabalRequirement.py: Create CabalRequirement for Haskell packages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,8 @@ before_install:
   - sudo add-apt-repository -y ppa:staticfloat/juliareleases
   - sudo apt-get update
   - sudo apt-get install julia
+  - sudo apt-get install cabal-install
+  - cabal update
   # https://github.com/coala/coala/issues/3183
   # https://github.com/coala/coala/issues/3184
   - pip install -U py==1.4.29 pip

--- a/coalib/bears/requirements/CabalRequirement.py
+++ b/coalib/bears/requirements/CabalRequirement.py
@@ -1,0 +1,36 @@
+from coalib.bears.requirements.PackageRequirement import PackageRequirement
+from coalib.misc.Shell import call_without_output
+
+
+class CabalRequirement(PackageRequirement):
+    """
+    This class is a subclass of ``PackageRequiment``, It specifies the proper
+    type for ``cabal`` packages automatically and provide a function to check
+    for the requirment.
+    """
+
+    def __init__(self, package, version=''):
+        """
+        Constructs a new ``CabalRequirment``, using the ``PackageRequirment``
+        constructor.
+
+        >>> cr = CabalRequirement('setuptools', '19.2')
+        >>> cr.type
+        'cabal'
+        >>> cr.package
+        'setuptools'
+        >>> cr.version
+        '19.2'
+
+        :param package: A string with the name of the package to be installed.
+        :param version: A version string. Leave empty to specify latest version.
+        """
+        PackageRequirement.__init__(self, 'cabal', package, version)
+
+    def is_installed(self):
+        """
+        Checks if the dependency is installed.
+
+        :param return: True if dependency is installed, false otherwise.
+        """
+        return not call_without_output(('cabal', 'info', self.package))

--- a/tests/bears/requirements/CabalRequirementTest.py
+++ b/tests/bears/requirements/CabalRequirementTest.py
@@ -1,0 +1,13 @@
+import unittest
+import shutil
+from coalib.bears.requirements.CabalRequirement import CabalRequirement
+
+
+@unittest.skipIf(shutil.which('cabal') is None, 'Cabal is not installed.')
+class CabalRequirementTestCase(unittest.TestCase):
+
+    def test_installed_requirement(self):
+        self.assertTrue(CabalRequirement('cabal').is_installed())
+
+    def test_not_installed_requirement(self):
+        self.assertFalse(CabalRequirement('some_bad_package').is_installed())


### PR DESCRIPTION
coalib/bears/requirements/ has lots of package managers,
but not one for Haskell

Closes: https://github.com/coala/coala/issues/3237

<!--
Thanks for your contribution!

Reviewing pull requests takes a lot of time and we're all volunteers. Please make sure you go through the following checklist and all items before pinging someone for a review.
-->

### Checklist

- [ ] I have rebased properly. Please see [our tutorial on rebasing](http://coala.io/git#rebasing).
- [ ] I have gone through the [commit guidelines](http://coala.io/commit) and I've followed them.
- [ ] I have followed the [guidelines for the commit shortlog](http://coala.io/commit#shortlog).
- [ ] I have followed the [guidelines for the commit body](http://coala.io/commit#commit-body).
- [ ] I have included the issue URL with the 'Fixes' keyword if the commit fixes a *real bug* and the 'Closes' keyword if it adds a feature or enhancement. For details, check the [issue reference section in our commit guidelines](http://coala.io/commit#issue-reference).
- [ ] I have [run all the tests](http://api.coala.io/en/latest/Developers/Executing_Tests.html) and they all pass. If any CI (below) is not green, please fix them. If GitMate issues appear you will have to amend your commits, pushing new commits on top is not sufficient!

### Reviewers

<!--
Please list the Github handles of people you think susceptible to review this PR. Feel free to leave this section blank if you don't know who to tag.
-->

<!--
End note:

As you learn things over your Pull Request please help others on the chat and on PRs to get their stuff right as well!
-->
