### PR TITLE
assert_supported_version: Reject Python 3.3.x

### DIFF
--- a/coalib/__init__.py
+++ b/coalib/__init__.py
@@ -21,7 +21,7 @@ VERSION = get_version()
 __version__ = VERSION
 
 
-def assert_supported_version():  # pragma: no cover
-    if not sys.version_info > (3, 3):
+def assert_supported_version():
+    if sys.version_info < (3, 4):
         print('coala supports only python 3.4 or later.')
         exit(4)

--- a/tests/coalaTest.py
+++ b/tests/coalaTest.py
@@ -5,7 +5,7 @@ import unittest
 import unittest.mock
 from pkg_resources import VersionConflict
 
-from coalib import coala
+from coalib import assert_supported_version, coala
 from coalib.misc.ContextManagers import prepare_file
 from tests.TestUtilities import execute_coala, bear_test_module
 
@@ -29,6 +29,21 @@ class coalaTest(unittest.TestCase):
             self.assertIn('This file has 1 lines.',
                           output,
                           'The output should report count as 1 lines')
+
+    @unittest.mock.patch('sys.version_info', tuple((2, 7, 11)))
+    def test_python_version_27(self):
+        with self.assertRaises(SystemExit):
+            assert_supported_version()
+            self.assertEqual(cm.error_code, 4)
+
+    @unittest.mock.patch('sys.version_info', tuple((3, 3, 6)))
+    def test_python_version_33(self):
+        with self.assertRaises(SystemExit):
+            assert_supported_version()
+            self.assertEqual(cm.error_code, 4)
+
+    def test_python_version_34(self):
+        assert_supported_version()
 
     def test_did_nothing(self):
         retval, output = execute_coala(coala.main, 'coala', '-I',


### PR DESCRIPTION
The logic in 805d8a0c to prevent installation on Python 3.3
was incorrect as Version 3.3.1 is greater than Version 3.3,
so only 3.3.0 was rejected by the current logic.

Fixes https://github.com/coala/coala/issues/3310