### PR TITLE
.coafile: Adds PycodestyleBear

### DIFF
--- a/.coafile
+++ b/.coafile
@@ -17,7 +17,7 @@ language = Python
 preferred_quotation = '
 
 [autopep8]
-bears = PEP8Bear
+bears = PEP8Bear, PycodestyleBear
 
 [linelength]  # Sometimes autopep8 makes too long lines, need to check after!
 bears = LineLengthBear

--- a/coalib/bearlib/abstractions/ExternalBearWrap.py
+++ b/coalib/bearlib/abstractions/ExternalBearWrap.py
@@ -32,7 +32,7 @@ def _prepare_options(options):
             'Invalid keyword arguments provided: ' +
             ', '.join(repr(s) for s in sorted(superfluous_options)))
 
-    if not 'settings' in options:
+    if 'settings' not in options:
         options['settings'] = {}
 
 

--- a/coalib/bearlib/languages/Language.py
+++ b/coalib/bearlib/languages/Language.py
@@ -149,7 +149,7 @@ class LanguageMeta(type, metaclass=LanguageUberMeta):
                 aliases = tuple(sorted(getattr(arg, 'aliases', ())))
                 _attributes = {name: member for name, member in getmembers(arg)
                                if not name.startswith('_')
-                               and not name in forbidden_attributes}
+                               and name not in forbidden_attributes}
 
             Sub.__name__ = arg.__name__
             type(cls).all.append(Sub)

--- a/coalib/coala.py
+++ b/coalib/coala.py
@@ -79,5 +79,6 @@ def main():
 
     return mode_normal(console_printer, log_printer)
 
+
 if __name__ == '__main__':  # pragma: no cover
     main()

--- a/coalib/coala_main.py
+++ b/coalib/coala_main.py
@@ -16,11 +16,6 @@ from coalib.misc.CachingUtilities import (
 from coalib.misc.Constants import configure_logging
 
 
-"""
-do_nothing = lambda *args: True
-"""
-
-
 def do_nothing(*args):
     return True
 

--- a/coalib/coala_main.py
+++ b/coalib/coala_main.py
@@ -15,7 +15,14 @@ from coalib.misc.CachingUtilities import (
     settings_changed, update_settings_db, get_settings_hash)
 from coalib.misc.Constants import configure_logging
 
+
+"""
 do_nothing = lambda *args: True
+"""
+
+
+def do_nothing(*args):
+    return True
 
 
 def run_coala(console_printer=None,

--- a/coalib/collecting/Collectors.py
+++ b/coalib/collecting/Collectors.py
@@ -223,7 +223,7 @@ def filter_capabilities_by_languages(bears, languages):
             language_bears_capabilities.update(
                 {language: (capabilities[0] | bear.can_detect,
                             capabilities[1] | bear.CAN_FIX)}
-                            if language else {})
+                if language else {})
     return language_bears_capabilities
 
 

--- a/coalib/parsing/ConfParser.py
+++ b/coalib/parsing/ConfParser.py
@@ -113,8 +113,7 @@ class ConfParser:
                         Setting(key,
                                 value,
                                 origin,
-                                # Ignore PEP8Bear, Pycodestyle*, it fails to
-                                # format that
+                                # Ignore PEP8Bear, Pycodestyle*, it fails to format that
                                 remove_empty_iter_elements=self.__remove_empty_iter_elements),
                         allow_appending=(keys == []))
                 else:

--- a/coalib/parsing/ConfParser.py
+++ b/coalib/parsing/ConfParser.py
@@ -113,9 +113,9 @@ class ConfParser:
                         Setting(key,
                                 value,
                                 origin,
-                                # Ignore PEP8Bear, it fails to format that
-                                remove_empty_iter_elements=
-                                self.__remove_empty_iter_elements),
+                                # Ignore PEP8Bear, Pycodestyle*, it fails to
+                                # format that
+                                remove_empty_iter_elements=self.__remove_empty_iter_elements),
                         allow_appending=(keys == []))
                 else:
                     self.get_section(
@@ -125,8 +125,7 @@ class ConfParser:
                                     value,
                                     origin,
                                     # Ignore PEP8Bear, it fails to format that
-                                    remove_empty_iter_elements=
-                                    self.__remove_empty_iter_elements),
+                                    remove_empty_iter_elements=self.__remove_empty_iter_elements),
                             allow_appending=(keys == []))
 
     def __init_sections(self):

--- a/coalib/settings/FunctionMetadata.py
+++ b/coalib/settings/FunctionMetadata.py
@@ -133,8 +133,12 @@ class FunctionMetadata:
 
     @staticmethod
     def _get_param(param, section, annotation):
+
+        def functionname(x):
+            return x
+
         if annotation is None:
-            annotation = lambda x: x
+            annotation = functionname
 
         try:
             return annotation(section[param])

--- a/coalib/settings/SectionFilling.py
+++ b/coalib/settings/SectionFilling.py
@@ -80,7 +80,7 @@ def fill_section(section, acquire_settings, log_printer, bears):
     # Strip away existent settings.
     needed_settings = {}
     for setting, help_text in prel_needed_settings.items():
-        if not setting in section:
+        if setting not in section:
             needed_settings[setting] = help_text
 
     # Get missing ones.

--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,8 @@ class BuildDocsCommand(setuptools.command.build_py.build_py):
 
 
 # Generate API documentation only if we are running on readthedocs.io
-on_rtd = getenv('READTHEDOCS', None) != None
+# on_rtd = getenv('READTHEDOCS', None) != None
+on_rtd = True if getenv('READTHEDOCS', None) is not None
 if on_rtd:
     call(BuildDocsCommand.apidoc_command)
     if 'dev' in VERSION:

--- a/tests/bearlib/abstractions/external_bear_wrap_testfiles/test_external_bear.py
+++ b/tests/bearlib/abstractions/external_bear_wrap_testfiles/test_external_bear.py
@@ -10,6 +10,7 @@ from coalib.results.SourceRange import SourceRange
 from coalib.output.JSONEncoder import create_json_encoder
 from coalib.results.RESULT_SEVERITY import RESULT_SEVERITY
 
+
 if __name__ == '__main__':
 
     line = sys.stdin.read()

--- a/tests/coalaTest.py
+++ b/tests/coalaTest.py
@@ -23,9 +23,9 @@ class coalaTest(unittest.TestCase):
                 prepare_file(['#fixme'], None) as (lines, filename):
             retval, output = execute_coala(
                              coala.main,
-                            'coala', '-c', os.devnull,
-                            '-f', re.escape(filename),
-                            '-b', 'LineCountTestBear')
+                             'coala', '-c', os.devnull,
+                             '-f', re.escape(filename),
+                             '-b', 'LineCountTestBear')
             self.assertIn('This file has 1 lines.',
                           output,
                           'The output should report count as 1 lines')

--- a/tests/collecting/importers_test_dir/file_one.py
+++ b/tests/collecting/importers_test_dir/file_one.py
@@ -7,6 +7,7 @@ class test(list):
     def method():
         pass
 
+
 a = [1, 2, 3]
 b = [1, 2, 4]
 

--- a/tests/results/SourcePositionTest.py
+++ b/tests/results/SourcePositionTest.py
@@ -24,13 +24,13 @@ class SourcePositionTest(unittest.TestCase):
         self.assertRegex(
             repr(uut),
             "<SourcePosition object\\(file='.*filename', line=1, "
-                'column=None\\) at 0x[0-9a-fA-F]+>')
+            'column=None\\) at 0x[0-9a-fA-F]+>')
 
         uut = SourcePosition('None', None)
         self.assertRegex(
             repr(uut),
             "<SourcePosition object\\(file='.*None', line=None, column=None\\) "
-                'at 0x[0-9a-fA-F]+>')
+            'at 0x[0-9a-fA-F]+>')
 
     def test_json(self):
         with prepare_file([''], None) as (_, filename):


### PR DESCRIPTION
PycodestyleBear is added to the [autopep8] section of the global .coafile to
run after the PEP8Bear and find problems omitted by the first.

Closes https://github.com/coala/coala/issues/3242

<!--
Thanks for your contribution!

Reviewing pull requests takes a lot of time and we're all volunteers. Please make sure you go through the following checklist and all items before pinging someone for a review.
-->

### Checklist

- [ ] I have rebased properly. Please see [our tutorial on rebasing](http://coala.io/git#rebasing).
- [ ] I have gone through the [commit guidelines](http://coala.io/commit) and I've followed them.
- [ ] I have followed the [guidelines for the commit shortlog](http://coala.io/commit#shortlog).
- [ ] I have followed the [guidelines for the commit body](http://coala.io/commit#commit-body).
- [ ] I have included the issue URL with the 'Fixes' keyword if the commit fixes a *real bug* and the 'Closes' keyword if it adds a feature or enhancement. For details, check the [issue reference section in our commit guidelines](http://coala.io/commit#issue-reference).
- [ ] I have [run all the tests](http://api.coala.io/en/latest/Developers/Executing_Tests.html) and they all pass. If any CI (below) is not green, please fix them. If GitMate issues appear you will have to amend your commits, pushing new commits on top is not sufficient!

### Reviewers

<!--
Please list the Github handles of people you think susceptible to review this PR. Feel free to leave this section blank if you don't know who to tag.
-->

<!--
End note:

As you learn things over your Pull Request please help others on the chat and on PRs to get their stuff right as well!
-->
