### PR TITLE
setup.py: Move Python version assert after imports

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: python
 python:
+  - 2.7
+  - 3.3
   - 3.4
   - 3.5
   - 3.6-dev
@@ -16,6 +18,8 @@ addons:
       - llvm-toolchain-precise
 
 before_install:
+  - export TRAVIS_PYTHON_VERSION_MAJOR=${TRAVIS_PYTHON_VERSION%.[0-9]}
+  - export TRAVIS_PYTHON_VERSION_MINOR=${TRAVIS_PYTHON_VERSION#[0-9].}
   - sudo add-apt-repository -y ppa:staticfloat/juliareleases
   - sudo apt-get update
   - sudo apt-get install julia
@@ -29,20 +33,24 @@ before_script:
   - julia -e 'Pkg.add("Lint")'
 
 script:
-  - bash .misc/tests.sh
-  - python setup.py install
-  - pip install coala-bears --pre -U
-  # https://github.com/coala/coala-bears/issues/1037
   - >
-    if [[ "$TRAVIS_PULL_REQUEST" == "false" ]]; then
-      python3 -m nltk.downloader punkt maxent_treebank_pos_tagger averaged_perceptron_tagger
+    if [[ $TRAVIS_PYTHON_VERSION_MINOR < 4 || $TRAVIS_PYTHON_VERSION_MAJOR == 2 ]]; then
+      coverage run setup.py install | grep -q 'coala supports only python 3.4 or later'
     else
-      sed -i '/bears = GitCommitBear/d' .coafile
+      bash .misc/tests.sh
+      python setup.py install
+      pip install coala-bears --pre -U
+      # https://github.com/coala/coala-bears/issues/1037
+      if [[ "$TRAVIS_PULL_REQUEST" == "false" ]]; then
+        python3 -m nltk.downloader punkt maxent_treebank_pos_tagger averaged_perceptron_tagger
+      else
+        sed -i '/bears = GitCommitBear/d' .coafile
+      fi
+      coala --non-interactive
+      make -C docs clean
+      python setup.py docs
     fi
-  - coala --non-interactive
   - bash .misc/deploy.coverage.sh
-  - make -C docs clean
-  - python setup.py docs
 
 notifications:
   email: false

--- a/setup.py
+++ b/setup.py
@@ -1,11 +1,5 @@
 #!/usr/bin/env python3
 
-# Start ignoring PyImportSortBear as imports below may yield syntax errors
-from coalib import assert_supported_version, VERSION, get_version
-
-assert_supported_version()
-# Stop ignoring
-
 import datetime
 import locale
 import platform
@@ -14,14 +8,19 @@ from os import getenv
 from subprocess import call
 
 import setuptools.command.build_py
-from coalib.misc.BuildManPage import BuildManPage
 from setuptools import find_packages, setup
 from setuptools.command.test import test as TestCommand
+
+from coalib import VERSION, assert_supported_version, get_version
+from coalib.misc.BuildManPage import BuildManPage
 
 try:
     locale.getlocale()
 except (ValueError, UnicodeError):
     locale.setlocale(locale.LC_ALL, 'en_US.UTF-8')
+
+
+assert_supported_version()
 
 
 class BuildPyCommand(setuptools.command.build_py.build_py):


### PR DESCRIPTION
Avoids pycodestyle import errors.

All of the imports from coalib do not depend on large amounts of coalib.