### PR TITLE
Add --debug flag and internal debug arguments

### DIFF
--- a/coalib/bears/Bear.py
+++ b/coalib/bears/Bear.py
@@ -273,14 +273,17 @@ class Bear(Printer, LogPrinterMixin, metaclass=bearclass):
 
         return self.run(*args, **kwargs)
 
-    def execute(self, *args, **kwargs):
+    def execute(self, *args, debug=False, **kwargs):
         name = self.name
         try:
             self.debug('Running bear {}...'.format(name))
             # If it's already a list it won't change it
             result = self.run_bear_from_section(args, kwargs)
             return [] if result is None else list(result)
-        except (Exception, SystemExit):
+        except (Exception, SystemExit) as exc:
+            if debug and not isinstance(exc, SystemExit):
+                raise
+
             if self.kind() == BEAR_KIND.LOCAL:
                 self.warn('Bear {} failed to run on file {}. Take a look '
                           'at debug messages (`-V`) for further '

--- a/coalib/coala.py
+++ b/coalib/coala.py
@@ -11,7 +11,12 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+import logging
+import sys
+
 from pyprint.ConsolePrinter import ConsolePrinter
+
+from dependency_management.requirements.PipRequirement import PipRequirement
 
 from coalib.output.Logging import configure_logging
 from coalib.output.printers.LogPrinter import LogPrinter
@@ -19,15 +24,26 @@ from coalib.parsing.DefaultArgParser import default_arg_parser
 from coalib.misc.Exceptions import get_exitcode
 
 
-def main():
+def main(debug=False):
     configure_logging()
 
+    args = None  # to have args variable in except block when parse_args fails
     try:
         console_printer = ConsolePrinter()
         log_printer = LogPrinter(console_printer)
         # Note: We parse the args here once to check whether to show bears or
         # not.
         args = default_arg_parser().parse_args()
+        if args.debug:
+            req_ipdb = PipRequirement('ipdb')
+            if not req_ipdb.is_installed():
+                logging.error('--debug flag requires ipdb. '
+                              'You can install it with:\n%s',
+                              ' '.join(req_ipdb.install_command()))
+                sys.exit(13)
+
+        if debug or args.debug:
+            args.log_level = 'DEBUG'
 
         # Defer imports so if e.g. --help is called they won't be run
         from coalib.coala_modes import (
@@ -39,7 +55,7 @@ def main():
         configure_logging(not args.no_color)
 
         if args.json:  # needs to be checked in order to display bears in json
-            return mode_json(args)
+            return mode_json(args, debug=debug)
 
         if args.show_bears:
             from coalib.settings.ConfigurationGathering import (
@@ -70,15 +86,24 @@ def main():
             return 0
 
     except BaseException as exception:  # pylint: disable=broad-except
+        if not isinstance(exception, SystemExit):
+            if args and args.debug:
+                import ipdb
+                with ipdb.launch_ipdb_on_exception():
+                    raise
+
+            if debug:
+                raise
+
         return get_exitcode(exception, log_printer)
 
     if args.format:
-        return mode_format()
+        return mode_format(args, debug=debug)
 
     if args.non_interactive:
-        return mode_non_interactive(console_printer, args)
+        return mode_non_interactive(console_printer, args, debug=debug)
 
-    return mode_normal(console_printer, log_printer)
+    return mode_normal(console_printer, log_printer, args, debug=debug)
 
 
 if __name__ == '__main__':  # pragma: no cover

--- a/coalib/coala_ci.py
+++ b/coalib/coala_ci.py
@@ -4,13 +4,13 @@ import sys
 from coalib.coala import main as coala_main
 
 
-def main():
+def main(debug=False):
     logging.warning('Use of `coala-ci` binary is deprecated, use '
                     '`coala --non-interactive` instead.')
 
     sys.argv.append('--non-interactive')
 
-    return coala_main()
+    return coala_main(debug=debug)
 
 
 if __name__ == '__main__':  # pragma: no cover

--- a/coalib/coala_format.py
+++ b/coalib/coala_format.py
@@ -4,13 +4,13 @@ import sys
 from coalib.coala import main as coala_main
 
 
-def main():
+def main(debug=False):
     logging.warning('Use of `coala-format` binary is deprecated, use '
                     '`coala --format` instead.')
 
     sys.argv.append('--format')
 
-    return coala_main()
+    return coala_main(debug=debug)
 
 
 if __name__ == '__main__':  # pragma: no cover

--- a/coalib/coala_json.py
+++ b/coalib/coala_json.py
@@ -4,13 +4,13 @@ import sys
 from coalib.coala import main as coala_main
 
 
-def main():
+def main(debug=False):
     logging.warning('Use of `coala-json` binary is deprecated, use '
                     'coala --json` instead.')
 
     sys.argv.append('--json')
 
-    return coala_main()
+    return coala_main(debug=debug)
 
 
 if __name__ == '__main__':  # pragma: no cover

--- a/coalib/coala_modes.py
+++ b/coalib/coala_modes.py
@@ -1,4 +1,4 @@
-def mode_normal(console_printer, log_printer):
+def mode_normal(console_printer, log_printer, args, debug=False):
     import functools
 
     from coalib.coala_main import run_coala
@@ -14,12 +14,14 @@ def mode_normal(console_printer, log_printer):
         acquire_settings=acquire_settings,
         print_section_beginning=partial_print_sec_beg,
         nothing_done=nothing_done,
-        console_printer=console_printer)
+        console_printer=console_printer,
+        args=args,
+        debug=debug)
 
     return exitcode
 
 
-def mode_non_interactive(console_printer, args):
+def mode_non_interactive(console_printer, args, debug=False):
     import functools
 
     from coalib.coala_main import run_coala
@@ -33,12 +35,14 @@ def mode_non_interactive(console_printer, args):
         print_results=print_results_no_input,
         print_section_beginning=partial_print_sec_beg,
         force_show_patch=True,
-        console_printer=console_printer)
+        console_printer=console_printer,
+        args=args,
+        debug=debug)
 
     return exitcode
 
 
-def mode_json(args):
+def mode_json(args, debug=False):
     import json
 
     from coalib.coala_main import run_coala
@@ -67,7 +71,7 @@ def mode_json(args):
         except BaseException as exception:  # pylint: disable=broad-except
             return get_exitcode(exception)
     else:
-        results, exitcode, _ = run_coala()
+        results, exitcode, _ = run_coala(args=args, debug=debug)
 
     retval = {'bears': results} if args.show_bears else {'results': results}
 
@@ -93,10 +97,10 @@ def mode_json(args):
     return 0 if args.show_bears else exitcode
 
 
-def mode_format():
+def mode_format(args, debug=False):
     from coalib.coala_main import run_coala
     from coalib.output.ConsoleInteraction import print_results_formatted
 
     _, exitcode, _ = run_coala(
-            print_results=print_results_formatted)
+            print_results=print_results_formatted, args=args, debug=debug)
     return exitcode

--- a/coalib/output/Interactions.py
+++ b/coalib/output/Interactions.py
@@ -23,4 +23,4 @@ def fail_acquire_settings(log_printer, settings_names_dict, section):
             msg += '{} (from {}) - {}'.format(name, setting[1], setting[0])
 
         log_printer.err(msg)
-        raise AssertionError
+        raise AssertionError(msg)

--- a/coalib/parsing/CliParsing.py
+++ b/coalib/parsing/CliParsing.py
@@ -10,6 +10,7 @@ from coalib.settings.Section import Section, append_to_sections
 def parse_cli(arg_list=None,
               origin=os.getcwd(),
               arg_parser=None,
+              args=None,
               key_value_delimiters=('=', ':'),
               comment_seperators=(),
               key_delimiters=(',',),
@@ -23,6 +24,7 @@ def parse_cli(arg_list=None,
                                         paths given as argument.
     :param arg_parser:                  Instance of ArgParser that is used to
                                         parse none-setting arguments.
+    :param args:                        Alternative pre-parsed CLI arguments.
     :param key_value_delimiters:        Delimiters to separate key and value
                                         in setting arguments where settings are
                                         being defined.
@@ -39,7 +41,14 @@ def parse_cli(arg_list=None,
                                         as keys and the sections themselves
                                         as value.
     """
-    arg_parser = default_arg_parser() if arg_parser is None else arg_parser
+    assert not (arg_list and args), (
+        'Either call parse_cli() with an arg_list of CLI arguments or '
+        'with pre-parsed args, but not with both.')
+
+    if args is None:
+        arg_parser = default_arg_parser() if arg_parser is None else arg_parser
+        args = arg_parser.parse_args(arg_list)
+
     origin += os.path.sep
     sections = OrderedDict(cli=Section('cli'))
     line_parser = LineParser(key_value_delimiters,
@@ -49,8 +58,7 @@ def parse_cli(arg_list=None,
                              section_override_delimiters,
                              key_value_append_delimiters)
 
-    for arg_key, arg_value in sorted(
-            vars(arg_parser.parse_args(arg_list)).items()):
+    for arg_key, arg_value in sorted(vars(args).items()):
         if arg_key == 'settings' and arg_value is not None:
             parse_custom_settings(sections,
                                   arg_value,

--- a/coalib/parsing/DefaultArgParser.py
+++ b/coalib/parsing/DefaultArgParser.py
@@ -230,6 +230,13 @@ To run coala without user interaction, run the `coala --non-interactive`,
         '-n', '--no-orig', const=True, action='store_const',
         help="don't create .orig backup files before patching")
 
+    misc_group.add_argument(
+        '--debug', const=True, action='store_const',
+        help='run coala in debug mode, starting ipdb, '
+             'which must be separately installed, '
+             'on unexpected internal exceptions '
+             '(implies --verbose)')
+
     try:
         # Auto completion should be optional, because of somewhat complicated
         # setup.

--- a/coalib/processes/BearRunning.py
+++ b/coalib/processes/BearRunning.py
@@ -76,7 +76,8 @@ def validate_results(message_queue, timeout, result_list, name, args, kwargs):
     return result_list
 
 
-def run_bear(message_queue, timeout, bear_instance, *args, **kwargs):
+def run_bear(message_queue, timeout, bear_instance, *args, debug=False,
+             **kwargs):
     """
     This method is responsible for executing the instance of a bear. It also
     reports or logs errors if any occur during the execution of that bear
@@ -101,8 +102,11 @@ def run_bear(message_queue, timeout, bear_instance, *args, **kwargs):
     name = bear_instance.name
 
     try:
-        result_list = bear_instance.execute(*args, **kwargs)
-    except (Exception, SystemExit):
+        result_list = bear_instance.execute(*args, debug=debug, **kwargs)
+    except (Exception, SystemExit) as exc:
+        if debug and not isinstance(exc, SystemExit):
+            raise
+
         send_msg(message_queue,
                  timeout,
                  LOG_LEVEL.ERROR,
@@ -162,7 +166,8 @@ def run_local_bear(message_queue,
                    local_result_list,
                    file_dict,
                    bear_instance,
-                   filename):
+                   filename,
+                   debug=False):
     """
     Runs an instance of a local bear. Checks if bear_instance is of type
     LocalBear and then passes it to the run_bear to execute.
@@ -194,7 +199,8 @@ def run_local_bear(message_queue,
 
     kwargs = {'dependency_results':
               get_local_dependency_results(local_result_list,
-                                           bear_instance)}
+                                           bear_instance),
+              'debug': debug}
     return run_bear(message_queue,
                     timeout,
                     bear_instance,
@@ -206,7 +212,8 @@ def run_local_bear(message_queue,
 def run_global_bear(message_queue,
                     timeout,
                     global_bear_instance,
-                    dependency_results):
+                    dependency_results,
+                    debug=False):
     """
     Runs an instance of a global bear. Checks if bear_instance is of type
     GlobalBear and then passes it to the run_bear to execute.
@@ -237,7 +244,8 @@ def run_global_bear(message_queue,
 
         return None
 
-    kwargs = {'dependency_results': dependency_results}
+    kwargs = {'dependency_results': dependency_results,
+              'debug': debug}
     return run_bear(message_queue,
                     timeout,
                     global_bear_instance,
@@ -250,7 +258,8 @@ def run_local_bears_on_file(message_queue,
                             local_bear_list,
                             local_result_dict,
                             control_queue,
-                            filename):
+                            filename,
+                            debug=False):
     """
     This method runs a list of local bears on one file.
 
@@ -293,7 +302,8 @@ def run_local_bears_on_file(message_queue,
                                 local_result_list,
                                 file_dict,
                                 bear_instance,
-                                filename)
+                                filename,
+                                debug=debug)
         if result is not None:
             local_result_list.extend(result)
 
@@ -382,7 +392,8 @@ def run_local_bears(filename_queue,
                     file_dict,
                     local_bear_list,
                     local_result_dict,
-                    control_queue):
+                    control_queue,
+                    debug=False):
     """
     Run local bears on all the files given.
 
@@ -414,7 +425,8 @@ def run_local_bears(filename_queue,
                                     local_bear_list,
                                     local_result_dict,
                                     control_queue,
-                                    filename)
+                                    filename,
+                                    debug=debug)
             task_done(filename_queue)
     except queue.Empty:
         return
@@ -425,7 +437,8 @@ def run_global_bears(message_queue,
                      global_bear_queue,
                      global_bear_list,
                      global_result_dict,
-                     control_queue):
+                     control_queue,
+                     debug=False):
     """
     Run all global bears.
 
@@ -455,7 +468,8 @@ def run_global_bears(message_queue,
                                      global_bear_list,
                                      global_result_dict))
             bearname = bear.__class__.__name__
-            result = run_global_bear(message_queue, timeout, bear, dep_results)
+            result = run_global_bear(message_queue, timeout, bear, dep_results,
+                                     debug=debug)
             if result:
                 global_result_dict[bearname] = result
                 control_queue.put((CONTROL_ELEMENT.GLOBAL, bearname))
@@ -475,7 +489,8 @@ def run(file_name_queue,
         global_result_dict,
         message_queue,
         control_queue,
-        timeout=0):
+        timeout=0,
+        debug=False):
     """
     This is the method that is actually runs by processes.
 
@@ -532,7 +547,8 @@ def run(file_name_queue,
                         file_dict,
                         local_bear_list,
                         local_result_dict,
-                        control_queue)
+                        control_queue,
+                        debug=debug)
         control_queue.put((CONTROL_ELEMENT.LOCAL_FINISHED, None))
 
         run_global_bears(message_queue,
@@ -540,7 +556,9 @@ def run(file_name_queue,
                          global_bear_queue,
                          global_bear_list,
                          global_result_dict,
-                         control_queue)
+                         control_queue,
+                         debug=debug)
         control_queue.put((CONTROL_ELEMENT.GLOBAL_FINISHED, None))
     except (OSError, KeyboardInterrupt):  # pragma: no cover
-        pass
+        if debug:
+            raise

--- a/coalib/processes/DebugProcessing.py
+++ b/coalib/processes/DebugProcessing.py
@@ -1,0 +1,76 @@
+"""
+Replacement for ``multiprocessing`` library in coala's debug mode.
+"""
+
+import sys
+import queue
+from functools import partial
+
+from coalib.processes.communication.LogMessage import LogMessage
+
+__all__ = ['Manager', 'Process', 'Queue']
+
+
+class Manager:
+    """
+    A debug replacement for ``multiprocessing.Manager``, just offering
+    ``builtins.dict`` as ``.dict`` member.
+    """
+
+    def __init__(self):
+        """
+        Just add ``dict`` as instance member.
+        """
+        self.dict = dict
+
+
+class Process(partial):
+    """
+    A debug replacement for ``multiprocessing.Process``, running the callable
+    target without any process parallelization or threading.
+    """
+
+    def __new__(cls, target, kwargs):
+        """
+        Just pass the arguments to underlying ``functools.partial``.
+        """
+        return partial.__new__(cls, target, **kwargs)
+
+    def start(self):
+        """
+        Just call the underlying ``functools.partial`` instaed of any thread
+        or parallel process creation.
+        """
+        return self()
+
+
+class Queue(queue.Queue):
+    """
+    A debug replacement for ``multiprocessing.Queue``, directly processing
+    any incoming :class:`coalib.processes.communication.LogMessage.LogMessage`
+    instances (if the queue was instantiated from a function with a local
+    ``log_printer``).
+    """
+
+    def __init__(self):
+        """
+        Gets local ``log_printer`` from function that created this instance.
+        """
+        super().__init__()
+        # same kind of HACK as can be found in collections.namedtuple for
+        # setting .__module__ of created classes
+        self.log_printer = sys._getframe(1).f_locals.get('log_printer')
+
+    def put(self, item):
+        """
+        Add `item` to queue.
+
+        Except `item` is an instance of
+        :class:`coalib.processes.communication.LogMessage.LogMessage` and
+        there is a ``self.log_printer``. Then `item` is just sent to logger
+        instead.
+        """
+        if self.log_printer is not None and isinstance(item, LogMessage):
+            self.log_printer.log_message(item)
+        else:
+            super().put(item)

--- a/coalib/settings/ConfigurationGathering.py
+++ b/coalib/settings/ConfigurationGathering.py
@@ -136,18 +136,22 @@ def warn_config_absent(sections, argument, log_printer):
     return False
 
 
-def load_configuration(arg_list, log_printer, arg_parser=None):
+def load_configuration(arg_list, log_printer, arg_parser=None, args=None):
     """
     Parses the CLI args and loads the config file accordingly, taking
     default_coafile and the users .coarc into account.
 
-    :param arg_list:    The list of command line arguments.
+    :param arg_list:    The list of CLI arguments.
     :param log_printer: The LogPrinter object for logging.
+    :param arg_parser:  An ``argparse.ArgumentParser`` instance used for
+                        parsing the CLI arguments.
+    :param arg_list:    Alternative pre-parsed CLI arguments.
     :return:            A tuple holding (log_printer: LogPrinter, sections:
                         dict(str, Section), targets: list(str)). (Types
                         indicated after colon.)
     """
-    cli_sections = parse_cli(arg_list=arg_list, arg_parser=arg_parser)
+    cli_sections = parse_cli(arg_list=arg_list, arg_parser=arg_parser,
+                             args=args)
     check_conflicts(cli_sections)
 
     if (
@@ -340,7 +344,8 @@ def get_filtered_bears(languages, log_printer, arg_parser=None):
 def gather_configuration(acquire_settings,
                          log_printer,
                          arg_list=None,
-                         arg_parser=None):
+                         arg_parser=None,
+                         args=None):
     """
     Loads all configuration files, retrieves bears and all needed
     settings, saves back if needed and warns about non-existent targets.
@@ -369,6 +374,7 @@ def gather_configuration(acquire_settings,
     :param arg_list:         CLI args to use
     :param arg_parser:       Instance of ArgParser that is used to parse
                              none-setting arguments.
+    :param args:             Alernative pre-parsed CLI arguments.
     :return:                 A tuple with the following contents:
 
                              -  A dictionary with the sections
@@ -378,10 +384,12 @@ def gather_configuration(acquire_settings,
                                 section
                              -  The targets list
     """
-    # Note: arg_list can also be []. Hence we cannot use
-    # `arg_list = arg_list or default_list`
-    arg_list = sys.argv[1:] if arg_list is None else arg_list
-    sections, targets = load_configuration(arg_list, log_printer, arg_parser)
+    if args is None:
+        # Note: arg_list can also be []. Hence we cannot use
+        # `arg_list = arg_list or default_list`
+        arg_list = sys.argv[1:] if arg_list is None else arg_list
+    sections, targets = load_configuration(arg_list, log_printer, arg_parser,
+                                           args=args)
     local_bears, global_bears = fill_settings(sections,
                                               acquire_settings,
                                               log_printer)

--- a/tests/TestUtilities.py
+++ b/tests/TestUtilities.py
@@ -6,12 +6,14 @@ import unittest.mock
 from coala_utils.ContextManagers import retrieve_stdout, retrieve_stderr
 
 
-def execute_coala(func, binary, *args):
+def execute_coala(func, binary, *args, debug=False):
     """
     Executes the main function with the given argument string from given module.
 
     :param function:    A main function from coala_json, coala_ci module etc.
     :param binary:      A binary to execute coala test
+    :param debug:       Run main function with ``debug=True`` and re-raise any
+                        exception coming back.
     :return:            A tuple holding a return value as first element,
                         a stdout output as second element and a stderr output
                         as third element if stdout_only is False.
@@ -19,7 +21,7 @@ def execute_coala(func, binary, *args):
     sys.argv = [binary] + list(args)
     with retrieve_stdout() as stdout:
         with retrieve_stderr() as stderr:
-            retval = func()
+            retval = func(debug=debug)
             return (retval, stdout.getvalue(), stderr.getvalue())
 
 

--- a/tests/coalaDebugFlagTest.py
+++ b/tests/coalaDebugFlagTest.py
@@ -1,0 +1,130 @@
+import os
+import re
+import sys
+
+import unittest
+from unittest.mock import MagicMock, patch
+
+from coalib import coala
+from coala_utils.ContextManagers import prepare_file
+
+from tests.TestUtilities import execute_coala, bear_test_module
+
+
+# patch gets strangely lost when only defined in method or with context where
+# actually needed
+@patch('coalib.coala_modes.mode_json')
+class coalaDebugFlagTest(unittest.TestCase):
+
+    def setUp(self):
+        self.old_argv = sys.argv
+
+    def pipReqIsInstalledMock(self):
+        """
+        Prepare a patch for ``PipRequirement.is_installed`` method that
+        always returns ``True``, used for faking an installed ipdb.
+        """
+        return patch('dependency_management.requirements.PipRequirement.'
+                     'PipRequirement.is_installed', lambda self: True)
+
+    def pipReqIsNotInstalledMock(self):
+        """
+        Prepare a patch for ``PipRequirement.is_installed`` method that
+        always returns ``False``, used for faking a not installed ipdb.
+        """
+        return patch('dependency_management.requirements.PipRequirement.'
+                     'PipRequirement.is_installed', lambda self: False)
+
+    def ipdbMock(self):
+        """
+        Prepare a mocked ``ipdb`` module with a mocked
+        ``launch_ipdb_on_exception`` function, which is used in
+        ``coala --debug`` mode to open and ``ipdb>`` prompt when unexpected
+        exceptions occur
+        """
+        mock = MagicMock()
+
+        def __exit__(self, *exc_info):
+            """
+            Make mocked ``ipdb.launch_ipdb_on_exception()`` context just
+            reraise the exception.
+            """
+            raise
+
+        mock.launch_ipdb_on_exception.__enter__ = None
+        mock.launch_ipdb_on_exception.__exit__ = __exit__
+        return mock
+
+    def tearDown(self):
+        sys.argv = self.old_argv
+
+    def test_no_ipdb(self, mocked_mode_json):
+        mocked_mode_json.side_effect = None
+        with bear_test_module(), \
+                prepare_file(['#fixme  '], None) as (lines, filename), \
+                self.pipReqIsNotInstalledMock():
+            # additionally use RaiseTestBear to verify independency from
+            # failing bears
+            status, stdout, stderr = execute_coala(
+                coala.main, 'coala', '--debug', '--json',
+                '-c', os.devnull,
+                '-f', re.escape(filename),
+                '-b', 'RaiseTestBear')
+        assert status == 13
+        assert not stdout
+        assert '--debug flag requires ipdb.' in stderr
+
+    def test_bear__init__raises(self, mocked_mode_json):
+        mocked_mode_json.side_effect = None
+        mocked_ipdb = self.ipdbMock()
+        with bear_test_module(), \
+                prepare_file(['#fixme  '], None) as (lines, filename), \
+                self.pipReqIsInstalledMock(), \
+                patch.dict('sys.modules', ipdb=mocked_ipdb), \
+                self.assertRaisesRegex(
+                    RuntimeError,
+                    r'^The bear ErrorTestBear does not fulfill all '
+                    r"requirements\. 'I_do_not_exist' is not installed\.$"):
+            execute_coala(
+                coala.main, 'coala', '--debug',
+                '-c', os.devnull,
+                '-f', re.escape(filename),
+                '-b', 'ErrorTestBear')
+
+        mocked_ipdb.launch_ipdb_on_exception.assert_called_once_with()
+
+    def test_bear_run_raises(self, mocked_mode_json):
+        mocked_mode_json.side_effect = None
+        mocked_ipdb = self.ipdbMock()
+        with bear_test_module(), \
+                prepare_file(['#fixme  '], None) as (lines, filename), \
+                self.pipReqIsInstalledMock(), \
+                patch.dict('sys.modules', ipdb=mocked_ipdb), \
+                self.assertRaisesRegex(
+                    RuntimeError, r"^That's all the RaiseTestBear can do\.$"):
+            execute_coala(
+                coala.main, 'coala', '--debug',
+                '-c', os.devnull,
+                '-f', re.escape(filename),
+                '-b', 'RaiseTestBear')
+
+        mocked_ipdb.launch_ipdb_on_exception.assert_called_once_with()
+
+    def test_coala_main_mode_json_launches_ipdb(self, mocked_mode_json):
+        mocked_mode_json.side_effect = RuntimeError('Mocked mode_json fails.')
+        mocked_ipdb = self.ipdbMock()
+        with bear_test_module(), \
+                prepare_file(['#fixme  '], None) as (lines, filename), \
+                self.pipReqIsInstalledMock(), \
+                patch.dict('sys.modules', ipdb=mocked_ipdb), \
+                self.assertRaisesRegex(RuntimeError,
+                                       r'^Mocked mode_json fails\.$'):
+            # additionally use RaiseTestBear to verify independency from
+            # failing bears
+            execute_coala(
+                coala.main, 'coala', '--debug', '--json',
+                '-c', os.devnull,
+                '-f', re.escape(filename),
+                '-b', 'RaiseTestBear')
+
+        mocked_ipdb.launch_ipdb_on_exception.assert_called_once_with()

--- a/tests/coalaDebugTest.py
+++ b/tests/coalaDebugTest.py
@@ -1,0 +1,101 @@
+import os
+import re
+import sys
+
+import unittest
+from unittest.mock import patch
+
+from coalib.coala_main import run_coala
+from coalib.output.printers.LogPrinter import LogPrinter
+from coalib import coala
+from pyprint.ConsolePrinter import ConsolePrinter
+from coala_utils.ContextManagers import prepare_file
+from coalib.output.Logging import configure_logging
+
+from tests.TestUtilities import execute_coala, bear_test_module
+
+
+class coalaDebugTest(unittest.TestCase):
+
+    def setUp(self):
+        self.old_argv = sys.argv
+
+    def tearDown(self):
+        sys.argv = self.old_argv
+
+    def test_coala_main_bear__init__raises(self):
+        with bear_test_module(), \
+                prepare_file(['#fixme  '], None) as (lines, filename), \
+                self.assertRaisesRegex(
+                    RuntimeError,
+                    r'^The bear ErrorTestBear does not fulfill all '
+                    r"requirements\. 'I_do_not_exist' is not installed\.$"):
+            execute_coala(
+                coala.main, 'coala',
+                '-c', os.devnull,
+                '-f', re.escape(filename),
+                '-b', 'ErrorTestBear',
+                debug=True)
+
+    def test_run_coala_bear__init__raises(self):
+        configure_logging()
+        with bear_test_module(), \
+                prepare_file(['#fixme  '], None) as (lines, filename), \
+                self.assertRaisesRegex(
+                    RuntimeError,
+                    r'^The bear ErrorTestBear does not fulfill all '
+                    r"requirements. 'I_do_not_exist' is not installed.$"):
+            run_coala(
+                console_printer=ConsolePrinter(),
+                log_printer=LogPrinter(),
+                arg_list=(
+                    '-c', os.devnull,
+                    '-f', re.escape(filename),
+                    '-b', 'ErrorTestBear'
+                ),
+                debug=True)
+
+    def test_coala_main_bear_run_raises(self):
+        with bear_test_module(), \
+                prepare_file(['#fixme  '], None) as (lines, filename), \
+                self.assertRaisesRegex(
+                    RuntimeError, r"^That's all the RaiseTestBear can do\.$"):
+            execute_coala(
+                coala.main, 'coala',
+                '-c', os.devnull,
+                '-f', re.escape(filename),
+                '-b', 'RaiseTestBear',
+                debug=True)
+
+    def test_run_coala_bear_run_raises(self):
+        configure_logging()
+        with bear_test_module(), \
+                prepare_file(['#fixme  '], None) as (lines, filename), \
+                self.assertRaisesRegex(
+                    RuntimeError, r"^That's all the RaiseTestBear can do\.$"):
+            run_coala(
+                console_printer=ConsolePrinter(),
+                log_printer=LogPrinter(),
+                arg_list=(
+                    '-c', os.devnull,
+                    '-f', re.escape(filename),
+                    '-b', 'RaiseTestBear'
+                ),
+                debug=True)
+
+    @patch('coalib.coala_modes.mode_json')
+    def test_coala_main_mode_json_raises(self, mocked_mode_json):
+        mocked_mode_json.side_effect = RuntimeError('Mocked mode_json fails.')
+
+        with bear_test_module(), \
+                prepare_file(['#fixme  '], None) as (lines, filename), \
+                self.assertRaisesRegex(RuntimeError,
+                                       r'^Mocked mode_json fails\.$'):
+            # additionally use RaiseTestBear to verify independency from
+            # failing bears
+            execute_coala(
+                coala.main, 'coala', '--json',
+                '-c', os.devnull,
+                '-f', re.escape(filename),
+                '-b', 'RaiseTestBear',
+                debug=True)

--- a/tests/coalaJSONTest.py
+++ b/tests/coalaJSONTest.py
@@ -71,7 +71,7 @@ class coalaJSONTest(unittest.TestCase):
                 coala.main, 'coala', '--json', '-B', '-I')
             self.assertEqual(retval, 0)
             output = json.loads(stdout)
-            self.assertEqual(len(output['bears']), 7)
+            self.assertEqual(len(output['bears']), 8)
             self.assertFalse(stderr)
 
     def test_show_language_bears(self):

--- a/tests/coalaTest.py
+++ b/tests/coalaTest.py
@@ -53,9 +53,10 @@ class coalaTest(unittest.TestCase):
     def test_python_version_34(self):
         assert_supported_version()
 
-    def test_did_nothing(self):
+    def test_did_nothing(self, debug=False):
         retval, stdout, stderr = execute_coala(coala.main, 'coala', '-I',
-                                               '-S', 'cli.enabled=false')
+                                               '-S', 'cli.enabled=false',
+                                               debug=debug)
         self.assertEqual(retval, 2)
         self.assertIn('Did you forget to give the `--files`', stderr)
         self.assertFalse(stdout)
@@ -63,36 +64,49 @@ class coalaTest(unittest.TestCase):
         retval, stdout, stderr = execute_coala(coala.main, 'coala', '-I',
                                                '-b', 'JavaTestBear', '-f',
                                                '*.java',
-                                               '-S', 'cli.enabled=false')
+                                               '-S', 'cli.enabled=false',
+                                               debug=debug)
         self.assertEqual(retval, 2)
         self.assertIn('Nothing to do.', stderr)
         self.assertFalse(stdout)
 
-    def test_show_all_bears(self):
+    def test_did_nothing_debug(self):
+        self.test_did_nothing(debug=True)
+
+    def test_show_all_bears(self, debug=False):
         with bear_test_module():
             retval, stdout, stderr = execute_coala(
-                coala.main, 'coala', '-B', '-I')
+                coala.main, 'coala', '-B', '-I', debug=debug)
             self.assertEqual(retval, 0)
-            # 7 bears plus 1 line holding the closing colour escape sequence.
-            self.assertEqual(len(stdout.strip().splitlines()), 8)
+            # 8 bears plus 1 line holding the closing colour escape sequence.
+            self.assertEqual(len(stdout.strip().splitlines()), 9)
             self.assertFalse(stderr)
 
-    def test_show_language_bears(self):
+    def test_show_all_bears_debug(self):
+        return self.test_show_all_bears(debug=True)
+
+    def test_show_language_bears(self, debug=False):
         with bear_test_module():
             retval, stdout, stderr = execute_coala(
-                coala.main, 'coala', '-B', '-l', 'java', '-I')
+                coala.main, 'coala', '-B', '-l', 'java', '-I', debug=debug)
             self.assertEqual(retval, 0)
             # 2 bears plus 1 line holding the closing colour escape sequence.
             self.assertEqual(len(stdout.splitlines()), 3)
             self.assertFalse(stderr)
 
-    def test_show_capabilities_with_supported_language(self):
+    def test_show_language_bears_debug(self):
+        self.test_show_language_bears(debug=True)
+
+    def test_show_capabilities_with_supported_language(self, debug=False):
         with bear_test_module():
             retval, stdout, stderr = execute_coala(
-                coala.main, 'coala', '-p', 'R', '-I')
+                coala.main, 'coala', '-p', 'R', '-I', debug=debug)
             self.assertEqual(retval, 0)
             self.assertEqual(len(stdout.splitlines()), 2)
             self.assertFalse(stderr)
+
+    def test_show_capabilities_with_supported_language_debug(self):
+        self.test_show_capabilities_with_supported_language(debug=True)
 
     @unittest.mock.patch('coalib.parsing.DefaultArgParser.get_all_bears_names')
     @unittest.mock.patch('coalib.collecting.Collectors.icollect_bears')
@@ -129,7 +143,7 @@ class coalaTest(unittest.TestCase):
             self.assertIn('pip install "msg2"', stderr)
             self.assertIn('No bears to show.', stdout)
 
-    def test_run_coala_no_autoapply(self):
+    def test_run_coala_no_autoapply(self, debug=False):
         with bear_test_module(), \
                 prepare_file(['#fixme  '], None) as (lines, filename):
             self.assertEqual(
@@ -144,7 +158,8 @@ class coalaTest(unittest.TestCase):
                         '--apply-patches',
                         '-S', 'use_spaces=yeah'
                     ),
-                    autoapply=False
+                    autoapply=False,
+                    debug=debug
                 )[0]['cli'])
             )
 
@@ -159,9 +174,13 @@ class coalaTest(unittest.TestCase):
                         '-b', 'SpaceConsistencyTestBear',
                         '--apply-patches',
                         '-S', 'use_spaces=yeah'
-                    )
+                    ),
+                    debug=debug
                 )[0]['cli'])
             )
+
+    def test_run_coala_no_autoapply_debug(self):
+        self.test_run_coala_no_autoapply(debug=True)
 
     def test_logged_error_causes_non_zero_exitcode(self):
         configure_logging()

--- a/tests/collecting/CollectorsTest.py
+++ b/tests/collecting/CollectorsTest.py
@@ -316,7 +316,8 @@ class CollectorsTests(unittest.TestCase):
                  'JavaTestBear',
                  'SpaceConsistencyTestBear',
                  'TestBear',
-                 'ErrorTestBear'})
+                 'ErrorTestBear',
+                 'RaiseTestBear'})
 
     def test_get_all_bears_names(self):
         with bear_test_module():
@@ -330,4 +331,5 @@ class CollectorsTests(unittest.TestCase):
                  'JavaTestBear',
                  'SpaceConsistencyTestBear',
                  'TestBear',
-                 'ErrorTestBear'})
+                 'ErrorTestBear',
+                 'RaiseTestBear'})

--- a/tests/test_bears/RaiseTestBear.py
+++ b/tests/test_bears/RaiseTestBear.py
@@ -1,0 +1,16 @@
+from coalib.bears.LocalBear import LocalBear
+
+
+class RaiseTestBear(LocalBear):
+    """
+    Just raises a ``RuntimeError`` when run.
+    """
+    @staticmethod
+    def create_arguments(filename, file, config_file):
+        return ()
+
+    def run(self, filename, file):
+        """
+        Just raise ``RuntimeError``.
+        """
+        raise RuntimeError("That's all the RaiseTestBear can do.")


### PR DESCRIPTION
@sils @Makman2 

Instead of the ERROR output from https://github.com/coala/coala/issues/3322 you can now get this:

```
> coala --debug
Executing section Default...
PicklingError("Can't pickle <PycodestyleBear linter class (wrapping 'pycodestyle')>: attribute lookup PycodestyleBear on coalib.bearlib.abstractions.Linter failed",)
> c:\users\zimmermann\miniconda3\envs\coala\lib\multiprocessing\reduction.py(59)dump()
     57 def dump(obj, file, protocol=None):
     58     '''Replacement for pickle.dump() using ForkingPickler.'''
---> 59     ForkingPickler(file, protocol).dump(obj)
     60
     61 #

ipdb> Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "C:\Users\Zimmermann\Miniconda3\envs\coala\lib\multiprocessing\spawn.py", line 106, in spawn_main
    exitcode = _main(fd)
  File "C:\Users\Zimmermann\Miniconda3\envs\coala\lib\multiprocessing\spawn.py", line 116, in _main
    self = pickle.load(from_parent)
EOFError: Ran out of input
ipdb>
```

And by calling `coalib.coala.main(debug=True)`, the https://github.com/coala/bearsh is now able to:

```
In [2]: %PycodestyleBear setup.py
Executing section Default...
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "C:\Users\Zimmermann\Miniconda3\envs\coala\lib\multiprocessing\spawn.py", line 106, in spawn_main
    exitcode = _main(fd)
  File "C:\Users\Zimmermann\Miniconda3\envs\coala\lib\multiprocessing\spawn.py", line 116, in _main
    self = pickle.load(from_parent)
EOFError: Ran out of input
---------------------------------------------------------------------------
PicklingError                             Traceback (most recent call last)
<ipython-input-2-a1efc0afb543> in <module>()
----> 1 get_ipython().magic('PycodestyleBear setup.py')

C:\Users\Zimmermann\Miniconda3\envs\coala\lib\site-packages\IPython\core\interactiveshell.py in magic(self, arg_s)
   2156         magic_name, _, magic_arg_s = arg_s.partition(' ')
   2157         magic_name = magic_name.lstrip(prefilter.ESC_MAGIC)
-> 2158         return self.run_line_magic(magic_name, magic_arg_s)
   2159
   2160     #-------------------------------------------------------------------------

C:\Users\Zimmermann\Miniconda3\envs\coala\lib\site-packages\IPython\core\interactiveshell.py in run_line_magic(self, magic_name, line)
   2077                 kwargs['local_ns'] = sys._getframe(stack_depth).f_locals
   2078             with self.builtin_trap:
-> 2079                 result = fn(*args,**kwargs)
   2080             return result
   2081

C:\Users\Zimmermann\Projects\coala\shell\bearsh\__init__.py in magic(arg_str, _bearname)
     36                             ','.join(arg_str.split())]
     37             try:
---> 38                 main(debug=True)
     39             finally:
     40                 sys.argv = _argv

c:\users\zimmermann\projects\coala\lib\coalib\coala.py in main(debug)
     85         return mode_format(debug=debug)
     86
---> 87     return mode_normal(console_printer, log_printer, args, debug=debug)
     88
     89 if __name__ == '__main__':  # pragma: no cover

c:\users\zimmermann\projects\coala\lib\coalib\coala_modes.py in mode_normal(console_printer, log_printer, args, debug)
     17         console_printer=console_printer,
     18         args=args,
---> 19         debug=debug)
     20
     21     return exitcode

c:\users\zimmermann\projects\coala\lib\coalib\coala_main.py in run_coala(console_printer, log_printer, print_results, acquire_settings, print_section_beginning, nothing_done, force_show_patch, arg_parser, arg_list, args, debug)
    108                 cache=cache,
    109                 log_printer=log_printer,
--> 110                 console_printer=console_printer)
    111             yielded, yielded_unfixed, results[section_name] = (
    112                 simplify_section_result(section_result))

c:\users\zimmermann\projects\coala\lib\coalib\processes\Processing.py in execute_section(section, global_bear_list, local_bear_list, print_results, cache, log_printer, console_printer)
    699
    700     for runner in processes:
--> 701         runner.start()
    702
    703     try:

C:\Users\Zimmermann\Miniconda3\envs\coala\lib\multiprocessing\process.py in start(self)
    103                'daemonic processes are not allowed to have children'
    104         _cleanup()
--> 105         self._popen = self._Popen(self)
    106         self._sentinel = self._popen.sentinel
    107         _children.add(self)

C:\Users\Zimmermann\Miniconda3\envs\coala\lib\multiprocessing\context.py in _Popen(process_obj)
    210     @staticmethod
    211     def _Popen(process_obj):
--> 212         return _default_context.get_context().Process._Popen(process_obj)
    213
    214 class DefaultContext(BaseContext):

C:\Users\Zimmermann\Miniconda3\envs\coala\lib\multiprocessing\context.py in _Popen(process_obj)
    311         def _Popen(process_obj):
    312             from .popen_spawn_win32 import Popen
--> 313             return Popen(process_obj)
    314
    315     class SpawnContext(BaseContext):

C:\Users\Zimmermann\Miniconda3\envs\coala\lib\multiprocessing\popen_spawn_win32.py in __init__(self, process_obj)
     64             try:
     65                 reduction.dump(prep_data, to_child)
---> 66                 reduction.dump(process_obj, to_child)
     67             finally:
     68                 context.set_spawning_popen(None)

C:\Users\Zimmermann\Miniconda3\envs\coala\lib\multiprocessing\reduction.py in dump(obj, file, protocol)
     57 def dump(obj, file, protocol=None):
     58     '''Replacement for pickle.dump() using ForkingPickler.'''
---> 59     ForkingPickler(file, protocol).dump(obj)
     60
     61 #

PicklingError: Can't pickle <PycodestyleBear linter class (wrapping 'pycodestyle')>: attribute lookup PycodestyleBear on coalib.bearlib.abstractions.Linter failed

In [3]: %debug
> c:\users\zimmermann\miniconda3\envs\coala\lib\multiprocessing\reduction.py(59)dump()
     57 def dump(obj, file, protocol=None):
     58     '''Replacement for pickle.dump() using ForkingPickler.'''
---> 59     ForkingPickler(file, protocol).dump(obj)
     60
     61 #

ipdb>
```

Which is also related to https://github.com/coala/coala/issues/3283
