### PR TITLE
coalib/bearlib/aspects/__init__.py: Fix doc string syntax

### DIFF
--- a/coalib/bearlib/aspects/__init__.py
+++ b/coalib/bearlib/aspects/__init__.py
@@ -58,7 +58,8 @@ class Root(aspectbase, metaclass=aspectclass):
     >>> LineLength('Python', max_line_length="100").tastes
     {'max_line_length': 100}
 
-    If no settings are given, the defaults will be taken>
+    If no settings are given, the defaults will be taken:
+
     >>> LineLength('Python').tastes
     {'max_line_length': 80}
 


### PR DESCRIPTION
This ensures the correct formatting.

Fixes #3329 

