### PR TITLE
deps.sh: Fail if less than 2 circle containers

### DIFF
--- a/.misc/deps.sh
+++ b/.misc/deps.sh
@@ -1,6 +1,11 @@
 set -e
 set -x
 
+if [[ $CIRCLE_NODE_TOTAL < 2 ]]; then
+  echo "ERROR: You must allocate 2 containers for the tests to run properly!"
+  exit 1
+fi
+  
 # Choose the python versions to install deps for
 case $CIRCLE_NODE_INDEX in
  0) dep_versions=( "3.4.3" "3.5.1" ) ;;


### PR DESCRIPTION
Fails the build if it detects less than 2 circle containers because our tests
cannot run on only one container

Closes https://github.com/coala/coala/issues/3352

<!--
Thanks for your contribution!

Reviewing pull requests takes a lot of time and we're all volunteers. Please make sure you go through the following checklist and all items before pinging someone for a review.
-->

### Checklist

- [x] I have rebased properly. Please see [our tutorial on rebasing](http://coala.io/git#rebasing).
- [x] I have gone through the [commit guidelines](http://coala.io/commit) and I've followed them.
- [x] I have followed the [guidelines for the commit shortlog](http://coala.io/commit#shortlog).
- [x] I have followed the [guidelines for the commit body](http://coala.io/commit#commit-body).
- [x] I have included the issue URL with the 'Fixes' keyword if the commit fixes a *real bug* and the 'Closes' keyword if it adds a feature or enhancement. For details, check the [issue reference section in our commit guidelines](http://coala.io/commit#issue-reference).
- [x] I have [run all the tests](http://api.coala.io/en/latest/Developers/Executing_Tests.html) and they all pass. If any CI (below) is not green, please fix them. If GitMate issues appear you will have to amend your commits, pushing new commits on top is not sufficient!

### Reviewers

<!--
Please list the Github handles of people you think susceptible to review this PR. Feel free to leave this section blank if you don't know who to tag.
-->

<!--
End note:

As you learn things over your Pull Request please help others on the chat and on PRs to get their stuff right as well!
-->
