### PR TITLE
Add source_lines as --format placeholder

### DIFF
--- a/coalib/output/ConsoleInteraction.py
+++ b/coalib/output/ConsoleInteraction.py
@@ -292,6 +292,7 @@ def print_diffs_info(diffs, printer):
 def print_results_formatted(log_printer,
                             section,
                             result_list,
+                            file_dict,
                             *args):
     """
     Prints results through the format string from the format setting done by
@@ -329,6 +330,8 @@ def print_results_formatted(log_printer,
 
             for range in result.affected_code:
                 format_args['affected_code'] = range
+                format_args['source_lines'] = range.affected_source(file_dict)
+
                 print(format_str.format(file=range.start.file,
                                         line=range.start.line,
                                         end_line=range.end.line,

--- a/coalib/parsing/DefaultArgParser.py
+++ b/coalib/parsing/DefaultArgParser.py
@@ -100,7 +100,7 @@ To run coala without user interaction, run the `coala --non-interactive`,
              '"Message: {message}"; possible placeholders: '
              'id, origin, file, line, end_line, column, end_column, '
              'severity, severity_str, message, message_base, '
-             'message_arguments, affected_code')
+             'message_arguments, affected_code, source_lines')
 
     config_group = arg_parser.add_argument_group('Configuration')
 

--- a/coalib/results/SourceRange.py
+++ b/coalib/results/SourceRange.py
@@ -120,6 +120,47 @@ class SourceRange(TextRange):
                                        tr.end.line,
                                        tr.end.column)
 
+    @enforce_signature
+    def affected_source(self, file_dict: dict):
+        r"""
+        Tells which lines are affected in a specified file within a given range.
+
+        >>> from os.path import abspath
+        >>> sr = SourceRange.from_values('file_name', start_line=2, end_line=2)
+        >>> sr.affected_source({
+        ...     abspath('file_name'): ('def fun():\n', '    x = 2  \n')
+        ... })
+        ('    x = 2  \n',)
+
+        If more than one line is affected.
+
+        >>> sr = SourceRange.from_values('file_name', start_line=2, end_line=3)
+        >>> sr.affected_source({
+        ...     abspath('file_name'): ('def fun():\n',
+        ...                            '    x = 2  \n', '    print(x)  \n')
+        ... })
+        ('    x = 2  \n', '    print(x)  \n')
+
+        If the file indicated at the source range is not in the `file_dict` or
+        the lines are not given, this will return `None`:
+
+        >>> sr = SourceRange.from_values('file_name_not_present',
+        ...     start_line=2, end_line=2)
+        >>> sr.affected_source({abspath('file_name'):
+        ...     ('def fun():\n', '    x = 2  \n')})
+
+        :param file_dict:
+            It is a dictionary where the file names are the keys and
+            the contents of the files are the values(which is of type tuple).
+        :return:
+            A tuple of affected lines in the specified file.
+            If the file is not affected or the file is not present in
+            ``file_dict`` return ``None``.
+        """
+        if self.start.file in file_dict and self.start.line and self.end.line:
+            # line number starts from 1, index starts from 0
+            return file_dict[self.start.file][self.start.line - 1:self.end.line]
+
     def __json__(self, use_relpath=False):
         _dict = get_public_members(self)
         if use_relpath:

--- a/tests/output/ConsoleInteractionTest.py
+++ b/tests/output/ConsoleInteractionTest.py
@@ -802,7 +802,7 @@ class PrintFormattedResultsTest(unittest.TestCase):
             print_results_formatted(self.logger,
                                     self.section,
                                     [Result('1', '2', affected_code)],
-                                    None,
+                                    {},
                                     None)
             self.assertRegex(stdout.getvalue(), expected_string)
 
@@ -836,3 +836,16 @@ class PrintFormattedResultsTest(unittest.TestCase):
                                 None,
                                 None,
                                 None)
+
+    def test_source_lines(self):
+        self.section.append(Setting(key='format', value='{source_lines}'))
+        affected_code = (SourceRange.from_values('file', 2, end_line=2),)
+        with retrieve_stdout() as stdout:
+            print_results_formatted(
+                self.logger,
+                self.section,
+                [Result('SpaceConsistencyBear', message='msg',
+                        affected_code=affected_code)],
+                {abspath('file'): ('def fun():\n', '    pass  \n')})
+            self.assertEqual(stdout.getvalue(),
+                             "('    pass  \\n',)\n")


### PR DESCRIPTION
ConsoleInteraction.py: source_lines is added
for --format placeholder to know about affected
lines of a file.
    
Closes https://github.com/coala/coala/issues/3155
