### PR TITLE
assertRaisesRegex used in LinterTest.py

### DIFF
--- a/tests/bearlib/abstractions/LinterTest.py
+++ b/tests/bearlib/abstractions/LinterTest.py
@@ -29,6 +29,8 @@ def get_testfile_name(name):
 
 class LinterComponentTest(unittest.TestCase):
 
+    PARAM_TYPERERROR_RE = '[a-z_]+ must be an instance'
+
     # Using `object` instead of an empty class results in inheritance problems
     # inside the linter decorator.
     class EmptyTestLinter:
@@ -144,18 +146,18 @@ class LinterComponentTest(unittest.TestCase):
 
     def test_decorator_generated_default_interface(self):
         uut = linter('some-executable')(self.ManualProcessingTestLinter)
-        with self.assertRaises(NotImplementedError):
+        with self.assertRaisesRegex(NotImplementedError, ''):
             uut.create_arguments('filename', 'content', None)
 
     def test_decorator_invalid_parameter_types(self):
         # Provide some invalid severity maps.
-        with self.assertRaises(TypeError):
+        with self.assertRaisesRegex(TypeError, self.PARAM_TYPERERROR_RE):
             linter('some-executable',
                    output_format='regex',
                    output_regex='(?P<severity>)',
                    severity_map=list())(self.EmptyTestLinter)
 
-        with self.assertRaises(TypeError):
+        with self.assertRaisesRegex(TypeError, self.PARAM_TYPERERROR_RE):
             linter('some-executable',
                    output_format='regex',
                    output_regex='(?P<severity>)',
@@ -182,13 +184,13 @@ class LinterComponentTest(unittest.TestCase):
 
         # Other type-error test cases.
 
-        with self.assertRaises(TypeError):
+        with self.assertRaisesRegex(TypeError, self.PARAM_TYPERERROR_RE):
             linter('some-executable',
                    output_format='regex',
                    output_regex='(?P<message>)',
                    result_message=None)(self.EmptyTestLinter)
 
-        with self.assertRaises(TypeError):
+        with self.assertRaisesRegex(TypeError, self.PARAM_TYPERERROR_RE):
             linter('some-executable',
                    output_format='corrected',
                    result_message=list())(self.EmptyTestLinter)
@@ -200,7 +202,7 @@ class LinterComponentTest(unittest.TestCase):
         self.assertEqual(str(cm.exception),
                          'Invalid value for `diff_severity`: 999888777')
 
-        with self.assertRaises(TypeError):
+        with self.assertRaisesRegex(TypeError, self.PARAM_TYPERERROR_RE):
             linter('some-executable',
                    prerequisite_check_command=('command',),
                    prerequisite_check_fail_message=382983)(self.EmptyTestLinter)


### PR DESCRIPTION
Replaced assertRaises with assertRaisesRegex in LinterTest.py file

I am not confident about the strings used, incase I have done it wrong, please tell me, I will fix it. 

Task: https://codein.withgoogle.com/dashboard/task-instances/4861422196490240/