### PR TITLE
DocstringMetadata.py: Remove unneeded space

### DIFF
--- a/coalib/settings/DocstringMetadata.py
+++ b/coalib/settings/DocstringMetadata.py
@@ -57,7 +57,7 @@ class DocstringMetadata:
 
             def concat_doc_parts(old: str, new: str):
                 if new != '' and not old.endswith('\n'):
-                    return old + ' ' + new
+                    return (old + ' ' + new).strip()
 
                 return old + (new if new != '' else '\n')
 

--- a/tests/settings/DocstringMetadataTest.py
+++ b/tests/settings/DocstringMetadataTest.py
@@ -1,6 +1,7 @@
 import unittest
 
 from coalib.settings.DocstringMetadata import DocstringMetadata
+from collections import OrderedDict
 
 
 class DocstringMetadataTest(unittest.TestCase):
@@ -53,6 +54,25 @@ class DocstringMetadataTest(unittest.TestCase):
             ''')
 
         self.assertEqual(str(uut), 'Description of something with params.')
+
+    def test_unneeded_docstring_space(self):
+        uut = DocstringMetadata.from_docstring(
+            """
+            This is a description about some bear which does some amazing
+            things. This is a multiline description for this testcase.
+
+            :param language:
+                The programming language.
+            :param coalang_dir:
+                External directory for coalang file.
+            """)
+
+        expected_output = OrderedDict([('language', ('The programming '
+                                                     'language.')),
+                                       ('coalang_dir', ('External directory '
+                                                        'for coalang file.'))])
+
+        self.assertEqual(uut.param_dict, expected_output)
 
     def check_from_docstring_dataset(self,
                                      docstring,


### PR DESCRIPTION
Ensures that there is no unneeded space after opening parenthesis
while prompting a user for required setting.

Fixes https://github.com/coala/coala/issues/3164

<!--
Thanks for your contribution!

Reviewing pull requests takes a lot of time and we're all volunteers. Please make sure you go through the following checklist and all items before pinging someone for a review.
-->

### Checklist

- [x] I have rebased properly. Please see [our tutorial on rebasing](http://coala.io/git#rebasing).
- [x] I have gone through the [commit guidelines](http://coala.io/commit) and I've followed them.
- [x] I have followed the [guidelines for the commit shortlog](http://coala.io/commit#shortlog).
- [x] I have followed the [guidelines for the commit body](http://coala.io/commit#commit-body).
- [x] I have included the issue URL with the 'Fixes' keyword if the commit fixes a *real bug* and the 'Closes' keyword if it adds a feature or enhancement. For details, check the [issue reference section in our commit guidelines](http://coala.io/commit#issue-reference).
- [x] I have [run all the tests](http://api.coala.io/en/latest/Developers/Executing_Tests.html) and they all pass. If any CI (below) is not green, please fix them. If GitMate issues appear you will have to amend your commits, pushing new commits on top is not sufficient!

### Reviewers

<!--
Please list the Github handles of people you think susceptible to review this PR. Feel free to leave this section blank if you don't know who to tag.
-->

<!--
End note:

As you learn things over your Pull Request please help others on the chat and on PRs to get their stuff right as well!
-->
