### PR TITLE
TravisCI: Remove explicit py upgrade

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,8 +24,6 @@ before_install:
   - sudo apt-get update
   - sudo apt-get install julia
   # https://github.com/coala/coala/issues/3183
-  # https://github.com/coala/coala/issues/3184
-  - pip install -U py==1.4.29 pip
   # Travis automatically installs the `requirements.txt` in "install" stage
   - cp requirements.txt requirements.orig
   - cat test-requirements.txt docs-requirements.txt >> requirements.txt


### PR DESCRIPTION
It is no longer necessary.

Related to https://github.com/coala/coala/issues/3184