### PR TITLE
LinterTest.py: Fix typo in variable name

### DIFF
--- a/tests/bearlib/abstractions/LinterTest.py
+++ b/tests/bearlib/abstractions/LinterTest.py
@@ -29,7 +29,7 @@ def get_testfile_name(name):
 
 class LinterComponentTest(unittest.TestCase):
 
-    PARAM_TYPERERROR_RE = '[a-z_]+ must be an instance'
+    PARAM_TYPE_ERROR_RE = '[a-z_]+ must be an instance'
 
     # Using `object` instead of an empty class results in inheritance problems
     # inside the linter decorator.
@@ -151,13 +151,13 @@ class LinterComponentTest(unittest.TestCase):
 
     def test_decorator_invalid_parameter_types(self):
         # Provide some invalid severity maps.
-        with self.assertRaisesRegex(TypeError, self.PARAM_TYPERERROR_RE):
+        with self.assertRaisesRegex(TypeError, self.PARAM_TYPE_ERROR_RE):
             linter('some-executable',
                    output_format='regex',
                    output_regex='(?P<severity>)',
                    severity_map=list())(self.EmptyTestLinter)
 
-        with self.assertRaisesRegex(TypeError, self.PARAM_TYPERERROR_RE):
+        with self.assertRaisesRegex(TypeError, self.PARAM_TYPE_ERROR_RE):
             linter('some-executable',
                    output_format='regex',
                    output_regex='(?P<severity>)',
@@ -184,13 +184,13 @@ class LinterComponentTest(unittest.TestCase):
 
         # Other type-error test cases.
 
-        with self.assertRaisesRegex(TypeError, self.PARAM_TYPERERROR_RE):
+        with self.assertRaisesRegex(TypeError, self.PARAM_TYPE_ERROR_RE):
             linter('some-executable',
                    output_format='regex',
                    output_regex='(?P<message>)',
                    result_message=None)(self.EmptyTestLinter)
 
-        with self.assertRaisesRegex(TypeError, self.PARAM_TYPERERROR_RE):
+        with self.assertRaisesRegex(TypeError, self.PARAM_TYPE_ERROR_RE):
             linter('some-executable',
                    output_format='corrected',
                    result_message=list())(self.EmptyTestLinter)
@@ -202,7 +202,7 @@ class LinterComponentTest(unittest.TestCase):
         self.assertEqual(str(cm.exception),
                          'Invalid value for `diff_severity`: 999888777')
 
-        with self.assertRaisesRegex(TypeError, self.PARAM_TYPERERROR_RE):
+        with self.assertRaisesRegex(TypeError, self.PARAM_TYPE_ERROR_RE):
             linter('some-executable',
                    prerequisite_check_command=('command',),
                    prerequisite_check_fail_message=382983)(self.EmptyTestLinter)


### PR DESCRIPTION
Change the variable name PARAM_TYPERERROR_RE to
PARAM_TYPE_ERROR_RE.

Fixes https://github.com/coala/coala/issues/3418

<!--
Thanks for your contribution!

Reviewing pull requests takes a lot of time and we're all volunteers. Please make sure you go through the following checklist and all items before pinging someone for a review.
-->

### Checklist

- [x] I have rebased properly. Please see [our tutorial on rebasing](http://coala.io/git#rebasing).
- [x] I have gone through the [commit guidelines](http://coala.io/commit) and I've followed them.
- [x] I have followed the [guidelines for the commit shortlog](http://coala.io/commit#shortlog).
- [x] I have followed the [guidelines for the commit body](http://coala.io/commit#commit-body).
- [x] I have included the issue URL with the 'Fixes' keyword if the commit fixes a *real bug* and the 'Closes' keyword if it adds a feature or enhancement. For details, check the [issue reference section in our commit guidelines](http://coala.io/commit#issue-reference).
- [x] I have [run all the tests](http://api.coala.io/en/latest/Developers/Executing_Tests.html) and they all pass. If any CI (below) is not green, please fix them. If GitMate issues appear you will have to amend your commits, pushing new commits on top is not sufficient!

### Reviewers

<!--
Please list the Github handles of people you think susceptible to review this PR. Feel free to leave this section blank if you don't know who to tag.
-->

<!--
End note:

As you learn things over your Pull Request please help others on the chat and on PRs to get their stuff right as well!
-->
