### PR TITLE
Processing.py: Setting for turning off warning

### DIFF
--- a/coalib/parsing/DefaultArgParser.py
+++ b/coalib/parsing/DefaultArgParser.py
@@ -128,6 +128,9 @@ To run coala without user interaction, run the `coala --non-interactive`,
     config_group.add_argument(
         '--flush-cache', const=True, action='store_const',
         help='rebuild the file cache')
+    config_group.add_argument(
+        '--no-autoapply-warn', const=True, action='store_const',
+        help='turn off warning about patches not being auto applicable')
 
     inputs_group = arg_parser.add_argument_group('Inputs')
 

--- a/coalib/processes/Processing.py
+++ b/coalib/processes/Processing.py
@@ -114,7 +114,7 @@ def autoapply_actions(results,
     """
 
     default_actions, invalid_actions = get_default_actions(section)
-
+    no_autoapply_warn = bool(section.get('no_autoapply_warn', False))
     for bearname, actionname in invalid_actions.items():
         log_printer.warn('Selected default action {!r} for bear {!r} does '
                          'not exist. Ignoring action.'.format(actionname,
@@ -140,7 +140,8 @@ def autoapply_actions(results,
 
         applicable = action.is_applicable(result, file_dict, file_diff_dict)
         if applicable is not True:
-            log_printer.warn('{}: {}'.format(result.origin, applicable))
+            if not no_autoapply_warn:
+                log_printer.warn('{}: {}'.format(result.origin, applicable))
             not_processed_results.append(result)
             continue
 

--- a/tests/processes/ProcessingTest.py
+++ b/tests/processes/ProcessingTest.py
@@ -582,6 +582,15 @@ class ProcessingTest_AutoapplyActions(unittest.TestCase):
 
         ApplyPatchAction.is_applicable = old_is_applicable
 
+        self.section.append(Setting(
+            'no_autoapply_warn', True))
+        autoapply_actions(self.results,
+                          {},
+                          {},
+                          self.section,
+                          self.log_printer)
+        self.assertTrue(self.log_queue.empty())
+
     def test_applicable_action(self):
         # Use a result whose action can be successfully applied.
         log_printer = self.log_printer


### PR DESCRIPTION
Added settings for turning off the warning
about patches not being auto applicable
`coala --no-autoapply-warn` turns off
warning

Closes #3392

<!--
Thanks for your contribution!

Reviewing pull requests takes a lot of time and we're all volunteers. Please make sure you go through the following checklist and all items before pinging someone for a review.
-->

### Checklist

- [x] I have rebased properly. Please see [our tutorial on rebasing](http://coala.io/git#rebasing).
- [x] I have gone through the [commit guidelines](http://coala.io/commit) and I've followed them.
- [x] I have followed the [guidelines for the commit shortlog](http://coala.io/commit#shortlog).
- [x] I have followed the [guidelines for the commit body](http://coala.io/commit#commit-body).
- [x] I have included the issue URL with the 'Fixes' keyword if the commit fixes a *real bug* and the 'Closes' keyword if it adds a feature or enhancement. For details, check the [issue reference section in our commit guidelines](http://coala.io/commit#issue-reference).
- [x] I have [run all the tests](http://api.coala.io/en/latest/Developers/Executing_Tests.html) and they all pass. If any CI (below) is not green, please fix them. If GitMate issues appear you will have to amend your commits, pushing new commits on top is not sufficient!

### Reviewers

<!--
Please list the Github handles of people you think susceptible to review this PR. Feel free to leave this section blank if you don't know who to tag.
-->

<!--
End note:

As you learn things over your Pull Request please help others on the chat and on PRs to get their stuff right as well!
-->
