### PR TITLE
LineParser.py: Add warning for check of '#'

### DIFF
--- a/coalib/parsing/LineParser.py
+++ b/coalib/parsing/LineParser.py
@@ -2,6 +2,7 @@ from coala_utils.string_processing.StringConverter import StringConverter
 from coala_utils.string_processing import (unescape, convert_to_raw,
                                            position_is_escaped,
                                            unescaped_rstrip)
+import logging
 
 
 class LineParser:
@@ -55,6 +56,20 @@ class LineParser:
         line, comment = self.__separate_by_first_occurrence(
             line,
             self.comment_separators)
+
+        # Comment starting with # should have whitespace after #
+        # Example: C# is the hybrid of C and C++.
+        if '#' in line:
+            start_index = line.index('#')
+            logger = logging.getLogger()
+            if line[start_index + 1] != ' ':
+                logger.warning('The comment line does not have \
+                                 whitespace after #')
+            elif line[start_index - 1] != ' ' \
+                    or line[start_index + 1] != ' ':
+                logger.warning('There is no whitespace either \
+                                 before or after # in comment')
+
         comment = unescape(comment)
         if line == '':
             return '', [], '', comment

--- a/tests/parsing/LineParserTest.py
+++ b/tests/parsing/LineParserTest.py
@@ -1,4 +1,5 @@
 import unittest
+import logging
 
 from coalib.parsing.LineParser import LineParser
 
@@ -13,6 +14,7 @@ class LineParserTest(unittest.TestCase):
         self.check_data_set('\n \n \n')
 
     def test_comment_parsing(self):
+        logger = logging.getLogger()
         self.check_data_set('# comment only$§\n',
                             output_comment='# comment only$§')
         self.check_data_set('   ; comment only  \n',
@@ -20,6 +22,16 @@ class LineParserTest(unittest.TestCase):
         self.check_data_set('   ; \\comment only  \n',
                             output_comment='; comment only')
         self.check_data_set('#', output_comment='#')
+        with self.assertLogs(logger, 'WARNING') as cm:
+            self.check_data_set('##\n',
+                                output_comment='##')
+        self.assertEquals(cm.output, "The comment line does not have \
+                                     whitespace after #")
+        with self.assertLogs(logger, 'WARNING') as cm:
+            self.check_data_set('C#\n',
+                                output_comment='C#')
+        self.assertEquals(cm.output, "There is no whitespace either \
+                                 before or after # in comment")
 
     def test_section_override(self):
         self.check_data_set(r'a.b, \a\.\b\ c=',


### PR DESCRIPTION
There is an addition of warning messages to
display that if comment starting with '#'
have whitespace before or after it.

Closes https://github.com/coala/coala/issues/2926

<!--
Thanks for your contribution!

Reviewing pull requests takes a lot of time and we're all volunteers. Please make sure you go through the following checklist and all items before pinging someone for a review.
-->

### Checklist

- [ ] I have rebased properly. Please see [our tutorial on rebasing](http://coala.io/git#rebasing).
- [ ] I have gone through the [commit guidelines](http://coala.io/commit) and I've followed them.
- [ ] I have followed the [guidelines for the commit shortlog](http://coala.io/commit#shortlog).
- [ ] I have followed the [guidelines for the commit body](http://coala.io/commit#commit-body).
- [ ] I have included the issue URL with the 'Fixes' keyword if the commit fixes a *real bug* and the 'Closes' keyword if it adds a feature or enhancement. For details, check the [issue reference section in our commit guidelines](http://coala.io/commit#issue-reference).
- [ ] I have [run all the tests](http://api.coala.io/en/latest/Developers/Executing_Tests.html) and they all pass. If any CI (below) is not green, please fix them. If GitMate issues appear you will have to amend your commits, pushing new commits on top is not sufficient!

### Reviewers

<!--
Please list the Github handles of people you think susceptible to review this PR. Feel free to leave this section blank if you don't know who to tag.
-->

<!--
End note:

As you learn things over your Pull Request please help others on the chat and on PRs to get their stuff right as well!
-->
