### PR TITLE
Result.py: Modify docstring definition of diffs

### DIFF
--- a/coalib/results/Result.py
+++ b/coalib/results/Result.py
@@ -60,8 +60,8 @@ class Result:
             A message which may help the user find out why this result was
             yielded.
         :param diffs:
-            A dictionary with filenames as key and a sequence of ``Diff``
-            objects associated with them as values.
+            A dictionary with filename as key and ``Diff`` object
+            associated with it as value.
         :param confidence:
             A number between 0 and 100 describing the likelihood of this result
             being a real issue.
@@ -137,8 +137,8 @@ class Result:
             A message which may help the user find out why this result was
             yielded.
         :param diffs:
-            A dictionary with filenames as key and a sequence of ``Diff``
-            objects associated with them as values.
+            A dictionary with filename as key and ``Diff`` object
+            associated with it as value.
         :param confidence:
             A number between 0 and 100 describing the likelihood of this result
             being a real issue.

--- a/coalib/results/Result.py
+++ b/coalib/results/Result.py
@@ -208,8 +208,8 @@ class Result:
         :param file_dict: A dictionary containing all files with filename as
                           key and all lines a value. Will be modified.
         """
-        for filename in self.diffs:
-            file_dict[filename] = self.diffs[filename].modified
+        for filename, diff in self.diffs.items():
+            file_dict[filename] = diff.modified
 
     def __add__(self, other):
         """


### PR DESCRIPTION
It modifies docstring param definition of diffs
as it was confusing. There should be only one
diff object attached with a particular filename.
Also, it modifies Result.apply code to make it
more readable.

Fixes https://github.com/coala/coala/issues/3034

<!--
Thanks for your contribution!

Reviewing pull requests takes a lot of time and we're all volunteers. Please make sure you go through the following checklist and all items before pinging someone for a review.
-->

### Checklist

- [x] I have rebased properly. Please see [our tutorial on rebasing](http://coala.io/git#rebasing).
- [x] I have gone through the [commit guidelines](http://coala.io/commit) and I've followed them.
- [x] I have followed the [guidelines for the commit shortlog](http://coala.io/commit#shortlog).
- [x] I have followed the [guidelines for the commit body](http://coala.io/commit#commit-body).
- [x] I have included the issue URL with the 'Fixes' keyword if the commit fixes a *real bug* and the 'Closes' keyword if it adds a feature or enhancement. For details, check the [issue reference section in our commit guidelines](http://coala.io/commit#issue-reference).
- [x] I have [run all the tests](http://api.coala.io/en/latest/Developers/Executing_Tests.html) and they all pass. If any CI (below) is not green, please fix them. If GitMate issues appear you will have to amend your commits, pushing new commits on top is not sufficient!

### Reviewers

<!--
Please list the Github handles of people you think susceptible to review this PR. Feel free to leave this section blank if you don't know who to tag.
-->

<!--
End note:

As you learn things over your Pull Request please help others on the chat and on PRs to get their stuff right as well!
-->
