### PR TITLE
test-requirements: Put pytest before its plugins

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,8 +1,8 @@
 coverage~=4.0
+pytest~=3.0
 pytest-cov~=2.2
 pytest-env~=0.6.0
 pytest-mock~=1.1
 pytest-timeout~=1.0
 pytest-xdist~=1.14
-pytest~=3.0
 wheel~=0.29


### PR DESCRIPTION
pytest dependencies are higher and more important
than those listed by its plugins.

Closes https://github.com/coala/coala/issues/3184