### PR TITLE
CI: Use coala-bears extra 'alldeps'

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,7 @@ script:
       bash .misc/tests.sh
       python setup.py bdist_wheel
       pip install ./dist/coala-*.whl
-      pip install coala-bears --pre -U
+      pip install coala-bears[alldeps] --pre -U
       # https://github.com/coala/coala-bears/issues/1037
       if [[ "$TRAVIS_PULL_REQUEST" == "false" ]]; then
         python3 -m nltk.downloader punkt maxent_treebank_pos_tagger averaged_perceptron_tagger

--- a/circle.yml
+++ b/circle.yml
@@ -15,7 +15,7 @@ test:
         parallel: true
     - python setup.py install:
         parallel: true
-    - pip install coala-bears --pre -U:
+    - pip install coala-bears[alldeps] --pre -U:
         parallel: true
         timeout: 900  # Allow 15 mins
     - coala --non-interactive:


### PR DESCRIPTION
Before we can remove the python dependencies from
the coala-bears install requirements, the other coala
repositories need to switch to using the 'alldeps'
extra.

Related to https://github.com/coala/coala-bears/issues/1000