### PR TITLE
OpenEditorAction: Emit warning for unknown editors

### DIFF
--- a/coalib/results/result_actions/OpenEditorAction.py
+++ b/coalib/results/result_actions/OpenEditorAction.py
@@ -1,3 +1,4 @@
+import logging
 import shlex
 import subprocess
 from os.path import exists
@@ -144,7 +145,19 @@ class OpenEditorAction(ResultAction):
             editor_info = KNOWN_EDITORS[editor.strip()]
         except KeyError:
             # If the editor is unknown fall back to just passing
-            # the filenames
+            # the filenames and emit a warning
+            logging.warning(
+                'The editor "{editor}" is unknown to coala. Files won\'t be'
+                ' opened at the correct positions and other quirks might'
+                ' occur. Consider opening an issue at'
+                ' https://github.com/coala/coala/issues so we'
+                ' can add support for this editor.'
+                ' Supported editors are: {supported}'.format(
+                    editor=editor, supported=', '.join(
+                        sorted(KNOWN_EDITORS.keys())
+                    )
+                )
+            )
             editor_info = {
                 'file_arg_template': '{filename}',
                 'gui': False

--- a/tests/results/result_actions/OpenEditorActionTest.py
+++ b/tests/results/result_actions/OpenEditorActionTest.py
@@ -1,4 +1,5 @@
 import os
+import logging
 import subprocess
 import tempfile
 import unittest
@@ -215,6 +216,22 @@ class OpenEditorActionTest(unittest.TestCase):
                 ['subl', '--wait', '{0}:1:1'.format(self.fa)],
                 stdout=subprocess.PIPE
             )
+
+    def test_unknown_editor_warning(self):
+        logger = logging.getLogger()
+        uut = OpenEditorAction()
+        result_mock = Result.from_values(
+            'test', '', self.fa, line=None, column=None,
+        )
+        with unittest.mock.patch('subprocess.call'):
+            with self.assertLogs(logger, 'WARNING') as log:
+                uut.apply(result_mock, {self.fa: ''}, {}, editor='gouda-edit')
+
+                self.assertEqual(1, len(log.output))
+                self.assertIn(
+                    'The editor "gouda-edit" is unknown to coala.',
+                    log.output[0]
+                )
 
 
 def test_build_editor_call_args_spaced_filename():


### PR DESCRIPTION
If files are to be opened with an editor that is
not known to coala a warning is emitted.

Closes https://github.com/coala/coala/issues/3467

<!--
Thanks for your contribution!

Reviewing pull requests takes a lot of time and we're all volunteers. Please make sure you go through the following checklist and all items before pinging someone for a review.
-->

### Checklist

- [x] I have rebased properly. Please see [our tutorial on rebasing](http://coala.io/git#rebasing).
- [x] I have gone through the [commit guidelines](http://coala.io/commit) and I've followed them.
- [x] I have followed the [guidelines for the commit shortlog](http://coala.io/commit#shortlog).
- [x] I have followed the [guidelines for the commit body](http://coala.io/commit#commit-body).
- [x] I have included the issue URL with the 'Fixes' keyword if the commit fixes a *real bug* and the 'Closes' keyword if it adds a feature or enhancement. For details, check the [issue reference section in our commit guidelines](http://coala.io/commit#issue-reference).
- [x] I have [run all the tests](http://api.coala.io/en/latest/Developers/Executing_Tests.html) and they all pass. If any CI (below) is not green, please fix them. If GitMate issues appear you will have to amend your commits, pushing new commits on top is not sufficient!

### Reviewers

<!--
Please list the Github handles of people you think susceptible to review this PR. Feel free to leave this section blank if you don't know who to tag.
-->

<!--
End note:

As you learn things over your Pull Request please help others on the chat and on PRs to get their stuff right as well!
-->
