### PR TITLE
Diff.py: Deprecate change_line method

### DIFF
--- a/tests/results/DiffTest.py
+++ b/tests/results/DiffTest.py
@@ -1,4 +1,5 @@
 import json
+import logging
 import unittest
 from unittest.case import SkipTest
 
@@ -54,6 +55,19 @@ class DiffTest(unittest.TestCase):
         self.uut.delete_line(1)
         # Line was deleted, unchangeable
         self.assertRaises(ConflictError, self.uut.change_line, 1, '1', '2')
+
+    def test_capture_warnings(self):
+        """
+        Since this addresses the deprecated method, this testcase is
+        temporary (until the old API is fully removed).
+        """
+        logger = logging.getLogger()
+        with self.assertLogs(logger, 'DEBUG') as log:
+            self.assertEqual(len(self.uut), 0)
+            self.uut.change_line(2, '1', '2')
+        self.assertEqual(log.output, [
+            'DEBUG:root:Use of change_line method is deprecated. Instead '
+            'use modify_line method, without the original_line argument'])
 
     def test_double_changes_with_same_diff(self):
         self.uut.change_line(2, '1', '2')

--- a/tests/results/result_actions/ShowPatchActionTest.py
+++ b/tests/results/result_actions/ShowPatchActionTest.py
@@ -94,7 +94,7 @@ class ShowPatchActionTest(unittest.TestCase):
     def test_apply_with_previous_patches(self):
         with retrieve_stdout() as stdout:
             previous_diffs = {'a': Diff(self.file_dict['a'])}
-            previous_diffs['a'].change_line(2, 'b\n', 'b_changed\n')
+            previous_diffs['a'].modify_line(2, 'b_changed\n')
             self.assertEqual(self.uut.apply_from_section(self.test_result,
                                                          self.file_dict,
                                                          previous_diffs,
@@ -115,7 +115,7 @@ class ShowPatchActionTest(unittest.TestCase):
     def test_apply_with_rename(self):
         with retrieve_stdout() as stdout:
             previous_diffs = {'a': Diff(self.file_dict['a'])}
-            previous_diffs['a'].change_line(2, 'b\n', 'b_changed\n')
+            previous_diffs['a'].modify_line(2, 'b_changed\n')
 
             diff_dict = {'a': Diff(self.file_dict['a'], rename='a.rename'),
                          'b': Diff(self.file_dict['b'], delete=True)}


### PR DESCRIPTION
The use of argument original_line in change_line function
is now deprecated. Another **issue** to be opened on modifying
the relevant changes ( both in coala/coala and coala/coala-bears )

Closes https://github.com/coala/coala/issues/3024

<!--
Thanks for your contribution!

Reviewing pull requests takes a lot of time and we're all volunteers. Please make sure you go through the following checklist and all items before pinging someone for a review.
-->

### Checklist

- [x] I have rebased properly. Please see [our tutorial on rebasing](http://coala.io/git#rebasing).
- [x] I have gone through the [commit guidelines](http://coala.io/commit) and I've followed them.
- [x] I have followed the [guidelines for the commit shortlog](http://coala.io/commit#shortlog).
- [x] I have followed the [guidelines for the commit body](http://coala.io/commit#commit-body).
- [x] I have included the issue URL with the 'Fixes' keyword if the commit fixes a *real bug* and the 'Closes' keyword if it adds a feature or enhancement. For details, check the [issue reference section in our commit guidelines](http://coala.io/commit#issue-reference).
- [x] I have [run all the tests](http://api.coala.io/en/latest/Developers/Executing_Tests.html) and they all pass. If any CI (below) is not green, please fix them. If GitMate issues appear you will have to amend your commits, pushing new commits on top is not sufficient!

### Reviewers

<!--
Please list the Github handles of people you think susceptible to review this PR. Feel free to leave this section blank if you don't know who to tag.
-->

<!--
End note:

As you learn things over your Pull Request please help others on the chat and on PRs to get their stuff right as well!
-->
