### PR TITLE
Result.py: Add message arguments

### DIFF
--- a/coalib/output/ConsoleInteraction.py
+++ b/coalib/output/ConsoleInteraction.py
@@ -334,6 +334,7 @@ def print_results_formatted(log_printer,
                                         column=None,
                                         end_column=None,
                                         severity_str=severity_str,
+                                        message=result.message,
                                         **format_args))
                 continue
 
@@ -345,6 +346,7 @@ def print_results_formatted(log_printer,
                                         column=range.start.column,
                                         end_column=range.end.column,
                                         severity_str=severity_str,
+                                        message=result.message,
                                         **format_args))
         except KeyError as exception:
             log_printer.log_exception(

--- a/coalib/parsing/DefaultArgParser.py
+++ b/coalib/parsing/DefaultArgParser.py
@@ -99,7 +99,8 @@ To run coala without user interaction, run the `coala --non-interactive`,
         help='output results with a custom format string, e.g. '
              '"Message: {message}"; possible placeholders: '
              'id, origin, file, line, end_line, column, end_column, '
-             'severity, severity_str, message, affected_code')
+             'severity, severity_str, message, message_base, '
+             'message_arguments, affected_code')
 
     config_group = arg_parser.add_argument_group('Configuration')
 

--- a/coalib/results/Result.py
+++ b/coalib/results/Result.py
@@ -20,7 +20,8 @@ from coalib.results.SourceRange import SourceRange
                    'severity',
                    'confidence',
                    'origin',
-                   'message',
+                   'message_base',
+                   'message_arguments',
                    'aspect',
                    'additional_info',
                    'debug_msg')
@@ -29,6 +30,22 @@ class Result:
     A result is anything that has an origin and a message.
 
     Optionally it might affect a file.
+
+    Result messages can also have arguments. The message is python
+    style formatted with these arguments.
+
+    >>> r = Result('origin','{arg1} and {arg2}', \
+           message_arguments={'arg1': 'foo', 'arg2': 'bar'})
+    >>> r.message
+    'foo and bar'
+
+    Message arguments may be changed later. The result message
+    will also reflect these changes.
+
+    >>> r.message_arguments = {'arg1': 'spam', 'arg2': 'eggs'}
+    >>> r.message
+    'spam and eggs'
+
     """
 
     @enforce_signature
@@ -41,12 +58,15 @@ class Result:
                  debug_msg='',
                  diffs: (dict, None)=None,
                  confidence: int=100,
-                 aspect: (aspectbase, None)=None):
+                 aspect: (aspectbase, None)=None,
+                 message_arguments: dict={}):
         """
         :param origin:
             Class name or creator object of this object.
         :param message:
-            Message to show with this result.
+            Base message to show with this result.
+        :param message_arguments:
+            Arguments to be provided to the base message
         :param affected_code:
             A tuple of SourceRange objects pointing to related positions in the
             source code.
@@ -72,6 +92,9 @@ class Result:
             the leafs exactly your result belongs to.)
         :raises ValueError:
             Raised when confidence is not between 0 and 100.
+        :raises KeyError:
+            Raised when message_base can not be formatted with
+            message_arguments.
         """
         origin = origin or ''
         if not isinstance(origin, str):
@@ -80,7 +103,9 @@ class Result:
             raise ValueError('severity is not a valid RESULT_SEVERITY')
 
         self.origin = origin
-        self.message = message
+        self.message_base = message
+        self.message_arguments = message_arguments
+        self.message_base.format(**self.message_arguments)
         self.debug_msg = debug_msg
         self.additional_info = additional_info
         # Sorting is important for tuple comparison
@@ -92,6 +117,14 @@ class Result:
         self.diffs = diffs
         self.id = uuid.uuid4().int
         self.aspect = aspect
+
+    @property
+    def message(self):
+        return self.message_base.format(**self.message_arguments)
+
+    @message.setter
+    def message(self, value: str):
+        self.message_base = value
 
     @classmethod
     @enforce_signature
@@ -108,7 +141,8 @@ class Result:
                     debug_msg='',
                     diffs: (dict, None)=None,
                     confidence: int=100,
-                    aspect: (aspectbase, None)=None):
+                    aspect: (aspectbase, None)=None,
+                    message_arguments: dict={}):
         """
         Creates a result with only one SourceRange with the given start and end
         locations.
@@ -116,7 +150,9 @@ class Result:
         :param origin:
             Class name or creator object of this object.
         :param message:
-            Message to show with this result.
+            Base message to show with this result.
+        :param message_arguments:
+            Arguments to be provided to the base message
         :param file:
             The related file.
         :param line:
@@ -162,7 +198,8 @@ class Result:
                    debug_msg=debug_msg,
                    diffs=diffs,
                    confidence=confidence,
-                   aspect=aspect)
+                   aspect=aspect,
+                   message_arguments=message_arguments)
 
     def to_string_dict(self):
         """
@@ -181,6 +218,8 @@ class Result:
                    'additional_info',
                    'debug_msg',
                    'message',
+                   'message_base',
+                   'message_arguments',
                    'origin',
                    'confidence']
 

--- a/tests/coalaJSONTest.py
+++ b/tests/coalaJSONTest.py
@@ -39,6 +39,9 @@ class coalaJSONTest(unittest.TestCase):
             output = json.loads(output)
             self.assertEqual(output['results']['default'][0]['message'],
                              'This file has 1 lines.')
+            self.assertEqual(output['results']['default'][0]
+                             ['message_arguments'],
+                             {})
             self.assertNotEqual(retval, 0,
                                 'coala-json must return nonzero when '
                                 'results found')

--- a/tests/results/ResultTest.py
+++ b/tests/results/ResultTest.py
@@ -30,6 +30,13 @@ class ResultTest(unittest.TestCase):
         with self.assertRaises(ValueError):
             Result('o', 'm', confidence=101)
 
+    def test_message_arguments(self):
+        uut = Result('origin', '{msg}', message_arguments={'msg': 'msg'})
+        self.assertEqual(uut.message, 'msg')
+
+        with self.assertRaises(KeyError):
+            Result('origin', '{msg}')
+
     def test_string_dict(self):
         uut = Result(None, '')
         output = uut.to_string_dict()
@@ -41,10 +48,13 @@ class ResultTest(unittest.TestCase):
                                   'severity': 'NORMAL',
                                   'debug_msg': '',
                                   'additional_info': '',
-                                  'confidence': '100'})
+                                  'confidence': '100',
+                                  'message_base': '',
+                                  'message_arguments': '{}'})
 
         uut = Result.from_values(origin='origin',
-                                 message='msg',
+                                 message='{test} msg',
+                                 message_arguments={'test': 'test'},
                                  file='file',
                                  line=2,
                                  severity=RESULT_SEVERITY.INFO,
@@ -54,13 +64,15 @@ class ResultTest(unittest.TestCase):
         output = uut.to_string_dict()
         self.assertEqual(output, {'id': str(uut.id),
                                   'origin': 'origin',
-                                  'message': 'msg',
+                                  'message': 'test msg',
                                   'file': abspath('file'),
                                   'line_nr': '2',
                                   'severity': 'INFO',
                                   'debug_msg': 'dbg',
                                   'additional_info': 'hi!',
-                                  'confidence': '50'})
+                                  'confidence': '50',
+                                  'message_base': '{test} msg',
+                                  'message_arguments': '{\'test\': \'test\'}'})
 
         uut = Result.from_values(origin='o', message='m', file='f', line=5)
         output = uut.to_string_dict()


### PR DESCRIPTION
Result message is split into massage_base
and message_arguments for easier grouping.

Closes https://github.com/coala/coala/issues/3156