### PR TITLE
IgnoreResultAction: Add Multiline comment support

### DIFF
--- a/tests/results/result_actions/IgnoreResultActionTest.py
+++ b/tests/results/result_actions/IgnoreResultActionTest.py
@@ -71,9 +71,23 @@ class IgnoreResultActionTest(unittest.TestCase):
 
             # Apply a second patch, old patch has to stay!
             uut.apply(Result.from_values('else', 'msg', f_a, 1),
-                      file_dict, file_diff_dict, 'c')
+                      file_dict, file_diff_dict, 'css')
             self.assertEqual(
                 file_diff_dict[f_a].modified,
-                ['1  // Ignore else\n', '2  // Ignore origin\n', '3\n'])
+                ['1  /* Ignore else */\n', '2  // Ignore origin\n', '3\n'])
             with open(f_a, 'r') as f:
                 self.assertEqual(file_diff_dict[f_a].modified, f.readlines())
+
+            import logging
+            logger = logging.getLogger()
+
+            with unittest.mock.patch('subprocess.call'):
+                with self.assertLogs(logger, 'WARNING') as log:
+                    uut.apply(Result.from_values('else', 'msg', f_a, 1),
+                              file_dict, file_diff_dict, 'dothraki')
+
+                    self.assertEqual(1, len(log.output))
+                    self.assertIn(
+                        'coala does not support Ignore in "dothraki".',
+                        log.output[0]
+                    )


### PR DESCRIPTION
Adds support for using multiline comment delimiters, if the
language does not have singleline delimiters.
If no delimiters are found, emits a warning.

Closes #https://github.com/coala/coala/issues/3441

<!--
Thanks for your contribution!

Reviewing pull requests takes a lot of time and we're all volunteers. Please make sure you go through the following checklist and all items before pinging someone for a review.
-->

### Checklist

- [x] I have rebased properly. Please see [our tutorial on rebasing](http://coala.io/git#rebasing).
- [x] I have gone through the [commit guidelines](http://coala.io/commit) and I've followed them.
- [x] I have followed the [guidelines for the commit shortlog](http://coala.io/commit#shortlog).
- [x] I have followed the [guidelines for the commit body](http://coala.io/commit#commit-body).
- [x] I have included the issue URL with the 'Fixes' keyword if the commit fixes a *real bug* and the 'Closes' keyword if it adds a feature or enhancement. For details, check the [issue reference section in our commit guidelines](http://coala.io/commit#issue-reference).
- [x] I have [run all the tests](http://api.coala.io/en/latest/Developers/Executing_Tests.html) and they all pass. If any CI (below) is not green, please fix them. If GitMate issues appear you will have to amend your commits, pushing new commits on top is not sufficient!

### Reviewers

<!--
Please list the Github handles of people you think susceptible to review this PR. Feel free to leave this section blank if you don't know who to tag.
-->

<!--
End note:

As you learn things over your Pull Request please help others on the chat and on PRs to get their stuff right as well!
-->
