### PR TITLE
coafile: Raise line length limit to 120

### DIFF
--- a/.coafile
+++ b/.coafile
@@ -4,7 +4,7 @@ ignore =
     tests/bearlib/languages/documentation/documentation_extraction_testdata/*.py,
     tests/collecting/collectors_test_dir/bears/incorrect_bear.py,
 
-max_line_length = 80
+max_line_length = 120
 use_spaces = True
 
 [python]


### PR DESCRIPTION
My suggested policy would be:

 - 80 is good and preferred
 - 100 is okay and no one should really bat an eye at it
 - 120 is bad but justifiable in certain cases, in which cases an ignore comment should be added

Of course, this is just about columns. Having like 10 tokens on one line is still bad and should be avoided, meaning something like this is already bad even though it's just 75 columns:

```python
if result == '{0}'.format(((eggs * float(price)) * people) / len(houses)):
```

Discuss!

**[Argument on arguman](http://en.arguman.org/it-is-best-to-not-enforce-an-80-column-width-limit-in-python/25241)**