### PR TITLE
Hold logs as JSON

### DIFF
--- a/coalib/coala.py
+++ b/coalib/coala.py
@@ -13,7 +13,7 @@
 
 from pyprint.ConsolePrinter import ConsolePrinter
 
-from coalib.misc.Constants import configure_logging
+from coalib.output.Logging import configure_logging
 from coalib.output.printers.LogPrinter import LogPrinter
 from coalib.parsing.DefaultArgParser import default_arg_parser
 from coalib.misc.Exceptions import get_exitcode

--- a/coalib/coala_delete_orig.py
+++ b/coalib/coala_delete_orig.py
@@ -2,12 +2,12 @@ import os
 
 from pyprint.ConsolePrinter import ConsolePrinter
 
+from coalib.output.Logging import configure_logging
 from coalib.output.printers.LogPrinter import LogPrinter
 from coalib.parsing import Globbing
 from coalib.settings.ConfigurationGathering import get_config_directory
 from coalib.settings.Section import Section
 from coalib.parsing.Globbing import glob_escape
-from coalib.misc.Constants import configure_logging
 
 
 def main(log_printer=None, section: Section=None):

--- a/coalib/coala_main.py
+++ b/coalib/coala_main.py
@@ -13,7 +13,6 @@ from coalib.settings.ConfigurationGathering import gather_configuration
 from coalib.misc.Caching import FileCache
 from coalib.misc.CachingUtilities import (
     settings_changed, update_settings_db, get_settings_hash)
-from coalib.misc.Constants import configure_logging
 
 
 def do_nothing(*args):
@@ -63,7 +62,6 @@ def run_coala(console_printer=None,
     :return:                        A dictionary containing a list of results
                                     for all analyzed sections as key.
     """
-    configure_logging()
 
     log_printer = (
         LogPrinter(ConsolePrinter(), LOG_LEVEL.DEBUG) if log_printer is None

--- a/coalib/coala_modes.py
+++ b/coalib/coala_modes.py
@@ -44,9 +44,13 @@ def mode_json(args):
     from coalib.coala_main import run_coala
     from coalib.misc.DictUtilities import inverse_dicts
     from coalib.misc.Exceptions import get_exitcode
+    from coalib.output.Logging import configure_json_logging
     from coalib.output.JSONEncoder import create_json_encoder
     from coalib.output.printers.LogPrinter import LogPrinter
     from coalib.settings.ConfigurationGathering import get_filtered_bears
+
+    if args.log_json:
+        log_stream = configure_json_logging()
 
     JSONEncoder = create_json_encoder(use_relpath=args.relpath)
     results = []
@@ -66,6 +70,11 @@ def mode_json(args):
         results, exitcode, _ = run_coala()
 
     retval = {'bears': results} if args.show_bears else {'results': results}
+
+    if args.log_json:
+        retval['logs'] = [json.loads(line) for line in
+                          log_stream.getvalue().splitlines()]
+
     if args.output:
         filename = str(args.output[0])
         with open(filename, 'w+') as fp:

--- a/coalib/misc/Constants.py
+++ b/coalib/misc/Constants.py
@@ -128,39 +128,3 @@ URL_REGEX = re.compile(
     r'(?::\d+)?'  # optional port number
     r'(?:/?|[/?]\S+)$',  # path
     re.IGNORECASE)
-
-
-def configure_logging():
-    """
-    Configures the logging with hard coded dictionary.
-    """
-    import sys
-    import logging.config
-    logging.config.dictConfig({
-        'version': 1,
-        'handlers': {
-            'colored': {
-                'class': 'logging.StreamHandler',
-                'formatter': 'colored',
-                'stream': sys.stderr
-            }
-        },
-        'root': {
-            'level': 'DEBUG',
-            'handlers': ['colored']
-        },
-        'formatters': {
-            'colored': {
-                '()': 'colorlog.ColoredFormatter',
-                'format': '%(log_color)s[%(levelname)s]%(reset)s[%(asctime)s]'
-                          ' %(message)s',
-                'datefmt': '%X',
-                'log_colors': {
-                    'ERROR': 'red',
-                    'WARNING': 'yellow',
-                    'INFO': 'blue',
-                    'DEBUG': 'green'
-                }
-            }
-        }
-    })

--- a/coalib/output/Logging.py
+++ b/coalib/output/Logging.py
@@ -1,3 +1,10 @@
+from datetime import datetime
+import json
+import io
+import logging
+import logging.config
+
+
 def configure_logging():
     """
     Configures the logging with hard coded dictionary.
@@ -33,3 +40,46 @@ def configure_logging():
             }
         }
     })
+
+
+def configure_json_logging():
+    """
+    Configures logging for JSON.
+    :return: Returns a ``StringIO`` that captures the logs as JSON.
+    """
+    stream = io.StringIO()
+
+    logging.config.dictConfig({
+        'version': 1,
+        'handlers': {
+            'json': {
+                'class': 'logging.StreamHandler',
+                'formatter': 'json',
+                'stream': stream
+            }
+        },
+        'root': {
+            'level': 'DEBUG',
+            'handlers': ['json']
+        },
+        'formatters': {
+            'json': {
+                '()': 'coalib.output.Logging.JSONFormatter',
+            }
+        }
+    })
+    return stream
+
+
+class JSONFormatter(logging.Formatter):
+    """
+    JSON formatter for python logging.
+    """
+    @staticmethod
+    def format(record):
+        message = {
+            'timestamp': datetime.utcfromtimestamp(record.created).isoformat(),
+            'message': record.getMessage(),
+            'level': record.levelname,
+        }
+        return json.dumps(message)

--- a/coalib/output/Logging.py
+++ b/coalib/output/Logging.py
@@ -1,0 +1,35 @@
+def configure_logging():
+    """
+    Configures the logging with hard coded dictionary.
+    """
+    import sys
+    import logging.config
+
+    logging.config.dictConfig({
+        'version': 1,
+        'handlers': {
+            'colored': {
+                'class': 'logging.StreamHandler',
+                'formatter': 'colored',
+                'stream': sys.stderr
+            }
+        },
+        'root': {
+            'level': 'DEBUG',
+            'handlers': ['colored']
+        },
+        'formatters': {
+            'colored': {
+                '()': 'colorlog.ColoredFormatter',
+                'format': '%(log_color)s[%(levelname)s]%(reset)s[%(asctime)s]'
+                          ' %(message)s',
+                'datefmt': '%X',
+                'log_colors': {
+                    'ERROR': 'red',
+                    'WARNING': 'yellow',
+                    'INFO': 'blue',
+                    'DEBUG': 'green'
+                }
+            }
+        }
+    })

--- a/coalib/parsing/DefaultArgParser.py
+++ b/coalib/parsing/DefaultArgParser.py
@@ -197,6 +197,11 @@ To run coala without user interaction, run the `coala --non-interactive`,
         help='show bear details for `--show-bears`')
 
     outputs_group.add_argument(
+        '--log-json', const=True, action='store_const',
+        help='output logs as json along with results'
+             ' (must be called with --json)')
+
+    outputs_group.add_argument(
         '-o', '--output', nargs=1, metavar='FILE',
         help='write results to the given file (must be called with --json)')
 

--- a/tests/coalaJSONTest.py
+++ b/tests/coalaJSONTest.py
@@ -106,15 +106,20 @@ class coalaJSONTest(unittest.TestCase):
                                            '-c', os.devnull,
                                            '-b', 'LineCountTestBear',
                                            '-f', re.escape(filename),
+                                           '--log-json',
                                            stdout_only=True)
             execute_coala(coala.main, 'coala', '--json', '-c', os.devnull,
                           '-b', 'LineCountTestBear', '-f', re.escape(filename),
-                          '-o', 'file.json')
+                          '-o', 'file.json', '--log-json')
 
         with open('file.json') as fp:
             data = json.load(fp)
 
         output = json.loads(output)
+        # Remove 'time' key from both as we cant compare them
+        for log_index in range(len(data['logs'])):
+            del data['logs'][log_index]['timestamp']
+            del output['logs'][log_index]['timestamp']
 
         self.assertEqual(data, output)
         os.remove('file.json')

--- a/tests/output/LoggingTest.py
+++ b/tests/output/LoggingTest.py
@@ -1,0 +1,32 @@
+import json
+import logging
+import unittest
+
+from coalib.output.Logging import configure_json_logging
+
+
+class LoggingTest(unittest.TestCase):
+
+    def test_json_logging(self):
+        log_stream = configure_json_logging()
+
+        logging.debug('This is debug log.')
+        logging.info('This is info log.')
+        logging.warning('This is warning log.\n This is continued')
+        logging.error('This is error log.')
+
+        # This is a list of logs dicts.
+        # Each log dict has a `message`, `level` and `time`
+        # We will check message and level for each of the logs
+        logs_list = [json.loads(line)
+                     for line in log_stream.getvalue().splitlines()]
+
+        self.assertEqual(logs_list[0]['message'], 'This is debug log.')
+        self.assertEqual(logs_list[0]['level'], 'DEBUG')
+        self.assertEqual(logs_list[1]['message'], 'This is info log.')
+        self.assertEqual(logs_list[1]['level'], 'INFO')
+        self.assertEqual(logs_list[2]['message'],
+                         'This is warning log.\n This is continued')
+        self.assertEqual(logs_list[2]['level'], 'WARNING')
+        self.assertEqual(logs_list[3]['message'], 'This is error log.')
+        self.assertEqual(logs_list[3]['level'], 'ERROR')


### PR DESCRIPTION
When `coala --json` is run, user should have a option
to get the logs in form of JSON

Closes https://github.com/coala/coala/issues/3037

<!--
Thanks for your contribution!

Reviewing pull requests takes a lot of time and we're all volunteers. Please make sure you go through the following checklist and all items before pinging someone for a review.
-->

### Checklist

- [ ] I have rebased properly. Please see [our tutorial on rebasing](http://coala.io/git#rebasing).
- [ ] I have gone through the [commit guidelines](http://coala.io/commit) and I've followed them.
- [ ] I have followed the [guidelines for the commit shortlog](http://coala.io/commit#shortlog).
- [ ] I have followed the [guidelines for the commit body](http://coala.io/commit#commit-body).
- [ ] I have included the issue URL with the 'Fixes' keyword if the commit fixes a *real bug* and the 'Closes' keyword if it adds a feature or enhancement. For details, check the [issue reference section in our commit guidelines](http://coala.io/commit#issue-reference).
- [ ] I have [run all the tests](http://api.coala.io/en/latest/Developers/Executing_Tests.html) and they all pass. If any CI (below) is not green, please fix them. If GitMate issues appear you will have to amend your commits, pushing new commits on top is not sufficient!

### Reviewers

<!--
Please list the Github handles of people you think susceptible to review this PR. Feel free to leave this section blank if you don't know who to tag.
-->

<!--
End note:

As you learn things over your Pull Request please help others on the chat and on PRs to get their stuff right as well!
-->
