### PR TITLE
CliParsingTest.py: Use unittest.asserRaisesRegex

### DIFF
--- a/tests/parsing/CliParsingTest.py
+++ b/tests/parsing/CliParsingTest.py
@@ -55,7 +55,7 @@ class CliParserTest(unittest.TestCase):
 
     def test_check_conflicts(self):
         sections = parse_cli(arg_list=['--save', '--no-config'])
-        with self.assertRaises(SystemExit) as cm:
+        with self.assertRaisesRegex(SystemExit, '2') as cm:
             check_conflicts(sections)
             self.assertEqual(cm.exception.code, 2)
 
@@ -63,11 +63,11 @@ class CliParserTest(unittest.TestCase):
         self.assertTrue(check_conflicts(sections))
 
         sections = parse_cli(arg_list=['--relpath'])
-        with self.assertRaises(SystemExit) as cm:
+        with self.assertRaisesRegex(SystemExit, '2') as cm:
             check_conflicts(sections)
             self.assertEqual(cm.exception.code, 2)
 
         sections = parse_cli(arg_list=['--output', 'iraiseValueError'])
-        with self.assertRaises(SystemExit) as cm:
+        with self.assertRaisesRegex(SystemExit, '2') as cm:
             check_conflicts(sections)
             self.assertEqual(cm.exception.code, 2)


### PR DESCRIPTION
Using unittest.assertRaises should be avoided. unitest.assertRaisesRegex has an extra parameter to check the exception message, and should be used instead. By checking the exception message, the unit test verifies that the exception is precisely the one which was expected, rather than only of the same type as expected.

Related to https://github.com/coala/coala/issues/3374

<!--
Thanks for your contribution!

Reviewing pull requests takes a lot of time and we're all volunteers. Please make sure you go through the following checklist and all items before pinging someone for a review.
-->

### Checklist

- [x] I have rebased properly. Please see [our tutorial on rebasing](http://coala.io/git#rebasing).
- [x] I have gone through the [commit guidelines](http://coala.io/commit) and I've followed them.
- [x] I have followed the [guidelines for the commit shortlog](http://coala.io/commit#shortlog).
- [x] I have followed the [guidelines for the commit body](http://coala.io/commit#commit-body).
- [x] I have included the issue URL with the 'Fixes' keyword if the commit fixes a *real bug* and the 'Closes' keyword if it adds a feature or enhancement. For details, check the [issue reference section in our commit guidelines](http://coala.io/commit#issue-reference).
- [ ] I have [run all the tests](http://api.coala.io/en/latest/Developers/Executing_Tests.html) and they all pass. If any CI (below) is not green, please fix them. If GitMate issues appear you will have to amend your commits, pushing new commits on top is not sufficient!