### PR TITLE
OpenEditorAction: Add emacs

### DIFF
--- a/coalib/results/result_actions/OpenEditorAction.py
+++ b/coalib/results/result_actions/OpenEditorAction.py
@@ -43,6 +43,14 @@ KNOWN_EDITORS = {
         'file_arg_template': '+{line},{column} {filename} ',
         'gui': False
     },
+    'emacs': {
+        'file_arg_template': '+{line}:{column} {filename}',
+        'gui': False
+    },
+    'emacsclient': {
+        'file_arg_template': '+{line}:{column} {filename}',
+        'gui': False
+    },
 
     # gui editors
     'atom': {


### PR DESCRIPTION
Add emacs to `KNOWN_EDITORS` in OpenEditorAction.py

Closes https://github.com/coala/coala/issues/3510

