### PR TITLE
Redesign @linter for Windows compatibility

### DIFF
--- a/coalib/bearlib/abstractions/Linter.py
+++ b/coalib/bearlib/abstractions/Linter.py
@@ -572,7 +572,8 @@ def _create_linter(klass, options):
     # Mixin the linter into the user-defined interface, otherwise
     # `create_arguments` and other methods would be overridden by the
     # default version.
-    result_klass = type(klass.__name__, (klass, LinterBase), {})
+    result_klass = type(klass.__name__, (klass, LinterBase), {
+        '__module__': klass.__module__})
     result_klass.__doc__ = klass.__doc__ or ''
     return result_klass
 


### PR DESCRIPTION
@sils @Makman2 

IMO the only way to solve https://github.com/coala/coala/issues/3323 :

* Define `LinterBase` and `LinterMeta` globally in `Linter` module and not dynamically in `_create_linter` function, because dynamically created classes can't be pickled
* Set `klass.options = options` to make them available as `cls.options` and `self.options` in `LinterBase` methods instead of accessing `options` through the method closures as done in the dynamic class creation approach
* Explicitly derive all `@linter` bears from `LinterBase`:

```python
@linter(...)
class SomeLinterBear(LinterBase):
    ...
```

The above looks ugly, but that can maybe further redesigned with some other way for setting linter options than with `@linter` decorator.

My changes don't break `@linter` bears that don't explicitly derive from `LinterBase`. They will just still be not usable under Windows.
