### PR TITLE
Bear: Implement default `check_all_deps`

### DIFF
--- a/coalib/bearlib/abstractions/Linter.py
+++ b/coalib/bearlib/abstractions/Linter.py
@@ -212,13 +212,14 @@ def _create_linter(klass, options):
             return options['executable']
 
         @classmethod
-        def check_prerequisites(cls):
+        def check_all_deps(cls):
             """
             Checks whether the linter-tool the bear uses is operational.
 
             :return:
                 True if operational, otherwise a string containing more info.
             """
+
             if shutil.which(cls.get_executable()) is None:
                 return (repr(cls.get_executable()) + ' is not installed.' +
                         (' ' + options['executable_check_fail_info']
@@ -233,7 +234,7 @@ def _create_linter(klass, options):
                         return True
                     except (OSError, CalledProcessError):
                         return options['prerequisite_check_fail_message']
-                return True
+                return super().check_all_deps()
 
         @classmethod
         def _get_create_arguments_metadata(cls):
@@ -688,10 +689,10 @@ def linter(executable: str,
         Information that is provided together with the fail message from the
         normal executable check. By default no additional info is printed.
     :param prerequisite_check_command:
-        A custom command to check for when ``check_prerequisites`` gets
+        A custom command to check for when ``check_all_deps`` gets
         invoked (via ``subprocess.check_call()``). Must be an ``Iterable``.
     :param prerequisite_check_fail_message:
-        A custom message that gets displayed when ``check_prerequisites``
+        A custom message that gets displayed when ``check_all_deps``
         fails while invoking ``prerequisite_check_command``. Can only be
         provided together with ``prerequisite_check_command``.
     :param output_format:

--- a/coalib/bears/Bear.py
+++ b/coalib/bears/Bear.py
@@ -197,7 +197,7 @@ class Bear(Printer, LogPrinterMixin):
         self.timeout = timeout
 
         self.setup_dependencies()
-        cp = type(self).check_prerequisites()
+        cp = type(self).check_all_deps()
         if cp is not True:
             error_string = ('The bear ' + self.name +
                             ' does not fulfill all requirements.')
@@ -316,9 +316,9 @@ class Bear(Printer, LogPrinterMixin):
         """
 
     @classmethod
-    def check_prerequisites(cls):
+    def check_all_deps(cls):
         """
-        Checks whether needed runtime prerequisites of the bear are satisfied.
+        Checks whether needed runtime dependencies of the bear are satisfied.
 
         This function gets executed at construction.
 
@@ -327,16 +327,19 @@ class Bear(Printer, LogPrinterMixin):
         >>> class SomeBear(Bear):
         ...     REQUIREMENTS = {PipRequirement('pip')}
 
-        >>> SomeBear.check_prerequisites()
+        >>> SomeBear.check_all_deps()
         True
 
         >>> class SomeOtherBear(Bear):
         ...     REQUIREMENTS = {PipRequirement('really_bad_package')}
 
-        >>> SomeOtherBear.check_prerequisites()
+        >>> SomeOtherBear.check_all_deps()
         'really_bad_package is not installed. You can install it using ...'
 
-        :return: True if prerequisites are satisfied, else False or a string
+        If you have to add more dependency checks, you probably want to
+        override `check_prerequisites` instead of this method.
+
+        :return: True if all dependencies are present, else False or a string
                  that serves a more detailed description of what's missing.
         """
         for requirement in cls.REQUIREMENTS:
@@ -344,6 +347,17 @@ class Bear(Printer, LogPrinterMixin):
                 return requirement.package + ' is not installed. You can ' + (
                     'install it using ') + (
                     ' '.join(requirement.install_command()))
+        return cls.check_prerequisites()
+
+    @classmethod
+    def check_prerequisites(cls):
+        """
+        Custom method for adding more prerequisite checks before the execution
+        of the bear.
+
+        :return: True if prerequisites are satisfied, else False or a string
+                 that serves a more detailed description of what's missing.
+        """
         return True
 
     def get_config_dir(self):

--- a/coalib/testing/BearTestHelper.py
+++ b/coalib/testing/BearTestHelper.py
@@ -5,12 +5,12 @@ def generate_skip_decorator(bear):
     """
     Creates a skip decorator for a `unittest` module test from a bear.
 
-    `check_prerequisites` is used to determine a test skip.
+    `check_all_deps` is used to determine a test skip.
 
     :param bear: The bear whose prerequisites determine the test skip.
     :return:     A decorator that skips the test if appropriate.
     """
-    result = bear.check_prerequisites()
+    result = bear.check_all_deps()
 
     return (skip(result) if isinstance(result, str)
             else skipIf(not result, '(No reason given.)'))

--- a/tests/bearlib/abstractions/LinterTest.py
+++ b/tests/bearlib/abstractions/LinterTest.py
@@ -211,38 +211,38 @@ class LinterComponentTest(unittest.TestCase):
         uut = linter('some-executable')(self.ManualProcessingTestLinter)
         self.assertEqual(uut.get_executable(), 'some-executable')
 
-    def test_check_prerequisites(self):
+    def test_check_all_deps(self):
         uut = linter(sys.executable)(self.ManualProcessingTestLinter)
-        self.assertTrue(uut.check_prerequisites())
+        self.assertTrue(uut.check_all_deps())
 
         uut = (linter('invalid_nonexisting_programv412')
                (self.ManualProcessingTestLinter))
-        self.assertEqual(uut.check_prerequisites(),
+        self.assertEqual(uut.check_all_deps(),
                          "'invalid_nonexisting_programv412' is not installed.")
 
         uut = (linter('invalid_nonexisting_programv412',
                       executable_check_fail_info="You can't install it.")
                (self.ManualProcessingTestLinter))
-        self.assertEqual(uut.check_prerequisites(),
+        self.assertEqual(uut.check_all_deps(),
                          "'invalid_nonexisting_programv412' is not installed. "
                          "You can't install it.")
 
         uut = (linter(sys.executable,
                       prerequisite_check_command=(sys.executable, '--version'))
                (self.ManualProcessingTestLinter))
-        self.assertTrue(uut.check_prerequisites())
+        self.assertTrue(uut.check_all_deps())
 
         uut = (linter(sys.executable,
                       prerequisite_check_command=('invalid_programv413',))
                (self.ManualProcessingTestLinter))
-        self.assertEqual(uut.check_prerequisites(),
+        self.assertEqual(uut.check_all_deps(),
                          'Prerequisite check failed.')
 
         uut = (linter(sys.executable,
                       prerequisite_check_command=('invalid_programv413',),
                       prerequisite_check_fail_message='NOPE')
                (self.ManualProcessingTestLinter))
-        self.assertEqual(uut.check_prerequisites(), 'NOPE')
+        self.assertEqual(uut.check_all_deps(), 'NOPE')
 
     def test_output_stream(self):
         process_output_mock = Mock()

--- a/tests/bears/BearTest.py
+++ b/tests/bears/BearTest.py
@@ -57,7 +57,7 @@ class BearWithPrerequisites(Bear):
         return []
 
     @classmethod
-    def check_prerequisites(cls):
+    def check_all_deps(cls):
         return cls.prerequisites_fulfilled
 
 
@@ -139,7 +139,7 @@ class BearTest(unittest.TestCase):
                                                         BadTestBear]),
                          set())
 
-    def test_check_prerequisites(self):
+    def test_check_all_deps(self):
         uut = BearWithPrerequisites(self.settings, self.queue, True)
         uut.execute()
         self.check_message(LOG_LEVEL.DEBUG)


### PR DESCRIPTION
This commit adds a default implementation of check_all_deps
for checking all requirements associated with that bear, it
also calls `Bear.check_prerequisite` for custom requirements
handling by the bear developer.

Closes https://github.com/coala/coala/issues/3219
