### PR TITLE
Linter: Use shutil.which for real executable path

### DIFF
--- a/coalib/bearlib/abstractions/Linter.py
+++ b/coalib/bearlib/abstractions/Linter.py
@@ -207,9 +207,9 @@ def _create_linter(klass, options):
             Returns the executable of this class.
 
             :return:
-                The executable name.
+                The full path to the executable file.
             """
-            return options['executable']
+            return shutil.which(options['executable'])
 
         @classmethod
         def check_prerequisites(cls):


### PR DESCRIPTION
@sils @Makman2 

`@linter(executable='...')` causes problems under Windows when executables are `.cmd` or `.bat` files, which is default for node.js tools for example. So I improved `LinterBase.get_executable()` to return the real full executable path with ` shutil.which(options['executable'])`
