### PR TITLE
Allow Bears to use raw files

### DIFF
--- a/coalib/bears/Bear.py
+++ b/coalib/bears/Bear.py
@@ -160,6 +160,16 @@ class Bear(Printer, LogPrinterMixin, metaclass=bearclass):
     [<aspectclass 'Root.Metadata.CommitMessage.Shortlog.ColonExistence'>]
     >>> aspectsCommitBear.aspects['fix']
     [<aspectclass 'Root.Metadata.CommitMessage.Shortlog.TrailingPeriod'>]
+
+    To indicate the bear uses raw files, set ``USE_RAW_FILES`` to True:
+
+    >>> class RawFileBear(Bear):
+    ...     USE_RAW_FILES = True
+    >>> RawFileBear.USE_RAW_FILES
+    True
+
+    However if ``USE_RAW_FILES`` is enabled the Bear is in charge of managing
+    the file (opening the file, closing the file, reading the file, etc).
     """
 
     LANGUAGES = set()
@@ -176,6 +186,7 @@ class Bear(Printer, LogPrinterMixin, metaclass=bearclass):
     ASCIINEMA_URL = ''
     SEE_MORE = ''
     BEAR_DEPS = set()
+    USE_RAW_FILES = False
 
     @classproperty
     def name(cls):

--- a/tests/processes/section_executor_test_files/.coafile
+++ b/tests/processes/section_executor_test_files/.coafile
@@ -1,3 +1,15 @@
+[cli]
 bears = ProcessingGlobalTestBear, ProcessingLocalTestBear
+files = testcode.c
+bear_dirs = .
+
+[mixed]
+bears = ProcessingGlobalTestBear, ProcessingLocalTestBear,
+        ProcessingGlobalTestRawFileBear, ProcessingLocalTestRawFileBear
 files = testcode.c, unreadable
+bear_dirs = .
+
+[raw]
+bears = ProcessingGlobalTestRawFileBear, ProcessingLocalTestRawFileBear
+files = unreadable
 bear_dirs = .

--- a/tests/processes/section_executor_test_files/ProcessingGlobalTestRawFileBear.py
+++ b/tests/processes/section_executor_test_files/ProcessingGlobalTestRawFileBear.py
@@ -1,0 +1,13 @@
+from coalib.bears.GlobalBear import GlobalBear
+from coalib.results.Result import Result
+
+
+class ProcessingGlobalTestRawFileBear(GlobalBear):
+
+    USE_RAW_FILES = True
+
+    def run(self):
+        for filename in self.file_dict:
+            return [Result.from_values('GlobalTestRawBear',
+                                       'test message',
+                                       filename)]

--- a/tests/processes/section_executor_test_files/ProcessingLocalTestRawFileBear.py
+++ b/tests/processes/section_executor_test_files/ProcessingLocalTestRawFileBear.py
@@ -1,0 +1,15 @@
+import time
+
+from coalib.bears.LocalBear import LocalBear
+from coalib.results.Result import Result
+
+
+class ProcessingLocalTestRawFileBear(LocalBear):
+
+    USE_RAW_FILES = True
+
+    def run(self, filename, file):
+        # we need to test that the SectionExecutor holds back the global
+        # results until processing of all local ones is finished
+        time.sleep(0.05)
+        return [Result('LocalTestRawBear', 'test msg')]


### PR DESCRIPTION
Processing allows raw files if the Bear state that it uses raw
files. Bear that uses binary files can't be mixed with Bear that uses
text files. If this is enabled, bears are incharge of doing the file
handling (opening it, closing it, reading it, etc).

Closes https://github.com/coala/coala/issues/3529

<!--
Thanks for your contribution!

Reviewing pull requests takes a lot of time and we're all volunteers. Please make sure you go through the following checklist and all items before pinging someone for a review.
-->

### Checklist

- [x] I have rebased properly. Please see [our tutorial on rebasing](http://coala.io/git#rebasing).
- [x] I have gone through the [commit guidelines](http://coala.io/commit) and I've followed them.
- [x] I have followed the [guidelines for the commit shortlog](http://coala.io/commit#shortlog).
- [x] I have followed the [guidelines for the commit body](http://coala.io/commit#commit-body).
- [x] I have included the issue URL with the 'Fixes' keyword if the commit fixes a *real bug* and the 'Closes' keyword if it adds a feature or enhancement. For details, check the [issue reference section in our commit guidelines](http://coala.io/commit#issue-reference).
- [x] I have [run all the tests](http://api.coala.io/en/latest/Developers/Executing_Tests.html) and they all pass. If any CI (below) is not green, please fix them. If GitMate issues appear you will have to amend your commits, pushing new commits on top is not sufficient!

### Reviewers

<!--
Please list the Github handles of people you think susceptible to review this PR. Feel free to leave this section blank if you don't know who to tag.
-->

<!--
End note:

As you learn things over your Pull Request please help others on the chat and on PRs to get their stuff right as well!
-->
