### PR TITLE
Fixed grammatical error in Linter Bear docs

### DIFF
--- a/docs/Developers/Writing_Linter_Bears.rst
+++ b/docs/Developers/Writing_Linter_Bears.rst
@@ -283,7 +283,7 @@ documentation together with the metadata attributes:
         """
         Lints your Python files!
 
-        Check for codings standards (like well-formed variable names), detects
+        Checks for coding standards (like well-formed variable names), detects
         semantical errors (like true implementation of declared interfaces or
         membership via type inference), duplicated code.
 
@@ -333,7 +333,7 @@ it should look something like this
         """
         Lints your Python files!
 
-        Check for codings standards (like well-formed variable names), detects
+        Checks for coding standards (like well-formed variable names), detects
         semantical errors (like true implementation of declared interfaces or
         membership via type inference), duplicated code.
 
@@ -382,7 +382,7 @@ gather information by using these values. Our bear now looks like:
       """
       Lints your Python files!
 
-      Check for codings standards (like well-formed variable names), detects
+      Checks for coding standards (like well-formed variable names), detects
       semantical errors (like true implementation of declared interfaces or
       membership via type inference), duplicated code.
 


### PR DESCRIPTION
Writing_Linter_Bears.rst : Changed 'check' to 'checks' (grammatical error)
In this I have changed the Grammatical Error according to the issue given. 
Fixes: https://github.com/coala/documentation/issues/396

### Checklist

- [# ] I have rebased properly. Please see [our tutorial on rebasing](http://coala.io/git#rebasing).
- [ #] I have gone through the [commit guidelines](http://coala.io/commit) and I've followed them.
- [ #] I have followed the [guidelines for the commit shortlog](http://coala.io/commit#shortlog).
- [ #] I have followed the [guidelines for the commit body](http://coala.io/commit#commit-body).
- [# ] I have included the issue URL with the 'Fixes' keyword if the commit fixes a *real bug* and the 'Closes' keyword if it adds a feature or enhancement. For details, check the [issue reference section in our commit guidelines](http://coala.io/commit#issue-reference).
- [#] I have [run all the tests](http://api.coala.io/en/latest/Developers/Executing_Tests.html) and they all pass. If any CI (below) is not green, please fix them. If GitMate issues appear you will have to amend your commits, pushing new commits on top is not sufficient!

