### PR TITLE
WIP Processing.py: delay execution

### DIFF
--- a/coalib/processes/Processing.py
+++ b/coalib/processes/Processing.py
@@ -200,7 +200,6 @@ def print_result(results,
                  section,
                  log_printer,
                  file_diff_dict,
-                 ignore_ranges,
                  console_printer):
     """
     Takes the results produced by each bear and gives them to the print_results
@@ -223,6 +222,14 @@ def print_result(results,
     :return:               Returns False if any results were yielded. Else
                            True.
     """
+    if results and 'affected_code' in results[0].__dict__.keys() \
+            and len(results[0].__dict__['affected_code']) > 0:
+        file_to_check = results[0].__dict__['affected_code'][
+            0].__dict__['_start'].__dict__['_file']
+        ignore_ranges = list(yield_ignore_ranges(
+            {file_to_check: file_dict[file_to_check]}))
+    else:
+        ignore_ranges = ''
     min_severity_str = str(section.get('min_severity', 'INFO')).upper()
     min_severity = RESULT_SEVERITY.str_dict.get(min_severity_str, 'INFO')
     results = list(filter(lambda result:
@@ -545,7 +552,7 @@ def process_queues(processes,
     global_processes = len(processes)
     global_result_buffer = []
     result_files = set()
-    ignore_ranges = list(yield_ignore_ranges(file_dict))
+    list(yield_ignore_ranges(file_dict))
 
     # One process is the logger thread
     while local_processes > 1:
@@ -566,7 +573,6 @@ def process_queues(processes,
                                            section,
                                            log_printer,
                                            file_diff_dict,
-                                           ignore_ranges,
                                            console_printer=console_printer)
                 local_result_dict[index] = res
             else:
@@ -588,7 +594,6 @@ def process_queues(processes,
                                    section,
                                    log_printer,
                                    file_diff_dict,
-                                   ignore_ranges,
                                    console_printer=console_printer)
         global_result_dict[elem] = res
 
@@ -606,7 +611,6 @@ def process_queues(processes,
                                            section,
                                            log_printer,
                                            file_diff_dict,
-                                           ignore_ranges,
                                            console_printer)
                 global_result_dict[index] = res
             else:

--- a/tests/processes/ProcessingTest.py
+++ b/tests/processes/ProcessingTest.py
@@ -666,6 +666,6 @@ class ProcessingTest_PrintResult(unittest.TestCase):
         results = [5, HiddenResult('origin', []),
                    Result('somebear', 'message', debug_msg='debug')]
         retval, newres = print_result(results, {}, 0, lambda *args: None,
-                                      self.section, self.log_printer, {}, [],
+                                      self.section, self.log_printer, {},
                                       console_printer=self.console_printer)
         self.assertEqual(newres, [])


### PR DESCRIPTION
Delay the execution of yield_ignore_ranges()
method so that instead of checking all files
for ignore comments, check only the ones we've
already found an error in.

Closes https://github.com/coala/coala/issues/2330

<!--
Thanks for your contribution!

Reviewing pull requests takes a lot of time and we're all volunteers. Please make sure you go through the following checklist and all items before pinging someone for a review.
-->

### Checklist

- [ ] I have rebased properly. Please see [our tutorial on rebasing](http://coala.io/git#rebasing).
- [ ] I have gone through the [commit guidelines](http://coala.io/commit) and I've followed them.
- [ ] I have followed the [guidelines for the commit shortlog](http://coala.io/commit#shortlog).
- [ ] I have followed the [guidelines for the commit body](http://coala.io/commit#commit-body).
- [ ] I have included the issue URL with the 'Fixes' keyword if the commit fixes a *real bug* and the 'Closes' keyword if it adds a feature or enhancement. For details, check the [issue reference section in our commit guidelines](http://coala.io/commit#issue-reference).
- [ ] I have [run all the tests](http://api.coala.io/en/latest/Developers/Executing_Tests.html) and they all pass. If any CI (below) is not green, please fix them. If GitMate issues appear you will have to amend your commits, pushing new commits on top is not sufficient!

### Reviewers

<!--
Please list the Github handles of people you think susceptible to review this PR. Feel free to leave this section blank if you don't know who to tag.
-->

<!--
End note:

As you learn things over your Pull Request please help others on the chat and on PRs to get their stuff right as well!
-->
