### PR TITLE
coafile: Fix shortlog regex

### DIFF
--- a/.coafile
+++ b/.coafile
@@ -62,7 +62,7 @@ languagetool_disable_rules =
 [commit]
 bears = GitCommitBear
 shortlog_trailing_period = False
-shortlog_regex = ([^:]*|[^:]+[^ ]: [A-Z0-9*].*)
+shortlog_regex = ([^:]*[^: ]: [A-Z0-9*].*)
 
 [Pylint]
 enabled = False


### PR DESCRIPTION
Fixes regex which allowed commit messages with two colons to pass and also removed redundancy in regex.

Fixes https://github.com/coala/coala/issues/3587

<!--
Thanks for your contribution!

Reviewing pull requests takes a lot of time and we're all volunteers. Please make sure you go through the following checklist and all items before pinging someone for a review.
-->

### Checklist

- [x] I have rebased properly. Please see [our tutorial on rebasing](http://coala.io/git#rebasing).
- [x] I have gone through the [commit guidelines](http://coala.io/commit) and I've followed them.
- [x] I have followed the [guidelines for the commit shortlog](http://coala.io/commit#shortlog).
- [x] I have followed the [guidelines for the commit body](http://coala.io/commit#commit-body).
- [x] I have included the issue URL with the 'Fixes' keyword if the commit fixes a *real bug* and the 'Closes' keyword if it adds a feature or enhancement. For details, check the [issue reference section in our commit guidelines](http://coala.io/commit#issue-reference).
- [x] I have [run all the tests](http://api.coala.io/en/latest/Developers/Executing_Tests.html) and they all pass. If any CI (below) is not green, please fix them. If GitMate issues appear you will have to amend your commits, pushing new commits on top is not sufficient!

### Reviewers

<!--
Please list the Github handles of people you think susceptible to review this PR. Feel free to leave this section blank if you don't know who to tag.
-->

<!--
End note:

As you learn things over your Pull Request please help others on the chat and on PRs to get their stuff right as well!
-->
