### PR TITLE
Result.py: Format message only if arguments provided

### DIFF
--- a/coalib/results/Result.py
+++ b/coalib/results/Result.py
@@ -105,7 +105,8 @@ class Result:
         self.origin = origin
         self.message_base = message
         self.message_arguments = message_arguments
-        self.message_base.format(**self.message_arguments)
+        if message_arguments:
+            self.message_base.format(**self.message_arguments)
         self.debug_msg = debug_msg
         self.additional_info = additional_info
         # Sorting is important for tuple comparison
@@ -120,6 +121,8 @@ class Result:
 
     @property
     def message(self):
+        if not self.message_arguments:
+            return self.message_base
         return self.message_base.format(**self.message_arguments)
 
     @message.setter

--- a/tests/results/ResultTest.py
+++ b/tests/results/ResultTest.py
@@ -35,7 +35,7 @@ class ResultTest(unittest.TestCase):
         self.assertEqual(uut.message, 'msg')
 
         with self.assertRaises(KeyError):
-            Result('origin', '{msg}')
+            Result('origin', '{msg}', message_arguments={'message': 'msg'})
 
     def test_string_dict(self):
         uut = Result(None, '')


### PR DESCRIPTION
`message` should be formatted only if `message_arguments` are
provided. This allows bears to have `{` or `}` in their message without
the need to escape formatting.

Closes https://github.com/coala/coala/issues/3606
