### PR TITLE
Bear.py: Rewrite download_cached_file in requests

### DIFF
--- a/coalib/bears/Bear.py
+++ b/coalib/bears/Bear.py
@@ -2,9 +2,7 @@ import traceback
 from functools import partial
 from os import makedirs
 from os.path import join, abspath, exists
-from shutil import copyfileobj
-from urllib.request import urlopen
-
+import requests
 from appdirs import user_data_dir
 
 from pyprint.Printer import Printer
@@ -388,8 +386,10 @@ class Bear(Printer, LogPrinterMixin):
         self.info('Downloading {filename!r} for bear {bearname} from {url}.'
                   .format(filename=filename, bearname=self.name, url=url))
 
-        with urlopen(url) as response, open(filename, 'wb') as out_file:
-            copyfileobj(response, out_file)
+        response = requests.get(url, stream=True, timeout=20)
+        with open(filename, 'wb') as file:
+            for chunk in response.iter_content(125):
+                file.write(chunk)
         return filename
 
     @classproperty

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ dependency_management~=0.3.1
 libclang-py3~=3.4.0
 Pygments~=2.1
 PyPrint~=0.2.6
+requests~=2.12.0

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -5,4 +5,5 @@ pytest-env~=0.6.0
 pytest-mock~=1.1
 pytest-timeout~=1.0
 pytest-xdist~=1.14
+requests-mock~=1.2.0
 wheel~=0.29


### PR DESCRIPTION
Rewrote `download_cached_file` in `requests` for better maintainability
and reliability. Also used `requests_mock` for the tests.

Related to https://github.com/coala/coala/issues/3332

<!--
Thanks for your contribution!

Reviewing pull requests takes a lot of time and we're all volunteers. Please make sure you go through the following checklist and all items before pinging someone for a review.
-->

### Checklist

- [x] I have rebased properly. Please see [our tutorial on rebasing](http://coala.io/git#rebasing).
- [x] I have gone through the [commit guidelines](http://coala.io/commit) and I've followed them.
- [x] I have followed the [guidelines for the commit shortlog](http://coala.io/commit#shortlog).
- [x] I have followed the [guidelines for the commit body](http://coala.io/commit#commit-body).
- [x] I have included the issue URL with the 'Fixes' keyword if the commit fixes a *real bug* and the 'Closes' keyword if it adds a feature or enhancement. For details, check the [issue reference section in our commit guidelines](http://coala.io/commit#issue-reference).
- [x] I have [run all the tests](http://api.coala.io/en/latest/Developers/Executing_Tests.html) and they all pass. If any CI (below) is not green, please fix them. If GitMate issues appear you will have to amend your commits, pushing new commits on top is not sufficient!

### Reviewers

<!--
Please list the Github handles of people you think susceptible to review this PR. Feel free to leave this section blank if you don't know who to tag.
-->

<!--
End note:

As you learn things over your Pull Request please help others on the chat and on PRs to get their stuff right as well!
-->
