### PR TITLE
.travis.yml: Move unsupported Python versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,5 @@
 language: python
 python:
-  - 2.7
-  - 3.3
   - 3.4
   - 3.5
   - 3.6-dev
@@ -17,6 +15,10 @@ matrix:
       cache:
         directories:
           - ~/Library/Caches/pip
+    - python: 2.7
+      env: UNSUPPORTED=true
+    - python: 3.3
+      env: UNSUPPORTED=true
 
 cache: pip
 


### PR DESCRIPTION
Places jobs for unsupported Python versions after the
supported versions, so newcomers dont read those first.

---

Note: `UNSUPPORTED=true` is only for visual effect ; e.g. https://travis-ci.org/jayvdb/coala/builds/194116155