### PR TITLE
ConsoleInteraction.py: Add default value for use_spaces

### DIFF
--- a/coalib/output/ConsoleInteraction.py
+++ b/coalib/output/ConsoleInteraction.py
@@ -65,7 +65,7 @@ def highlight_text(no_color, text, lexer=TextLexer(), style=None):
 
 
 STR_GET_VAL_FOR_SETTING = ('Please enter a value for the setting \"{}\" ({}) '
-                           'needed by {} for section \"{}\": ')
+                           'needed by {} for section \"{}\":')
 STR_LINE_DOESNT_EXIST = ('The line belonging to the following result '
                          'cannot be printed because it refers to a line '
                          "that doesn't seem to exist in the given file.")
@@ -529,7 +529,10 @@ def acquire_settings(log_printer, settings_names_dict, section):
     for setting_name, arr in sorted(settings_names_dict.items(),
                                     key=lambda x: (join_names(x[1][1:]), x[0])):
         value = require_setting(setting_name, arr, section)
-        result.update({setting_name: value} if value is not None else {})
+        while value is None:
+            print('You have not entered any value.')
+            value = require_setting(setting_name, arr, section)
+        result.update({setting_name: value})
 
     return result
 


### PR DESCRIPTION
There was a problem when an user used SpaceConsistencyBear
because if he didn`t enter anything as a value for
use_spaces no default value would`ve been assigned. Adds
a default value and updates the message.

Fixes https://github.com/coala/coala/issues/3558

<!--
Thanks for your contribution!

Reviewing pull requests takes a lot of time and we're all volunteers. Please make sure you go through the following checklist and all items before pinging someone for a review.
-->

### Checklist

- [x] I have rebased properly. Please see [our tutorial on rebasing](http://coala.io/git#rebasing).
- [x] I have gone through the [commit guidelines](http://coala.io/commit) and I've followed them.
- [x] I have followed the [guidelines for the commit shortlog](http://coala.io/commit#shortlog).
- [x] I have followed the [guidelines for the commit body](http://coala.io/commit#commit-body).
- [x] I have included the issue URL with the 'Fixes' keyword if the commit fixes a *real bug* and the 'Closes' keyword if it adds a feature or enhancement. For details, check the [issue reference section in our commit guidelines](http://coala.io/commit#issue-reference).
- [x] I have [run all the tests](http://api.coala.io/en/latest/Developers/Executing_Tests.html) and they all pass. If any CI (below) is not green, please fix them. If GitMate issues appear you will have to amend your commits, pushing new commits on top is not sufficient!

### Reviewers

<!--
Please list the Github handles of people you think susceptible to review this PR. Feel free to leave this section blank if you don't know who to tag.
-->

<!--
End note:

As you learn things over your Pull Request please help others on the chat and on PRs to get their stuff right as well!
-->
