### PR TITLE
Collectors.icollect: Cache results of globs

### DIFF
--- a/coalib/collecting/Collectors.py
+++ b/coalib/collecting/Collectors.py
@@ -37,12 +37,13 @@ def _import_bears(file_path, kinds):
 
 
 @yield_once
-def icollect(file_paths, ignored_globs=None):
+def icollect(file_paths, ignored_globs=None, match_cache={}):
     """
     Evaluate globs in file paths and return all matching files.
 
     :param file_paths:    File path or list of such that can include globs
     :param ignored_globs: List of globs to ignore when matching files
+    :param match_cache:   Dictionary to use for caching results
     :return:              Iterator that yields tuple of path of a matching
                           file, the glob where it was found
     """
@@ -50,7 +51,10 @@ def icollect(file_paths, ignored_globs=None):
         file_paths = [file_paths]
 
     for file_path in file_paths:
-        for match in iglob(file_path):
+        if file_path not in match_cache:
+            match_cache[file_path] = list(iglob(file_path))
+
+        for match in match_cache[file_path]:
             if not ignored_globs or not fnmatch(match, ignored_globs):
                 yield match, file_path
 


### PR DESCRIPTION
<!--
Thanks for your contribution!

Reviewing pull requests takes a lot of time and we're all volunteers. Please make sure you go through the following checklist and all items before pinging someone for a review.
-->

By adding a very simple caching mechanism to stop `icollect` from doing the same exact work for multiple sections, coala's runtime on a real world project went from 55.73s to 14.06s.

### Checklist

- [x] I have rebased properly. Please see [our tutorial on rebasing](http://coala.io/git#rebasing).
- [x] I have gone through the [commit guidelines](http://coala.io/commit) and I've followed them.
- [x] I have followed the [guidelines for the commit shortlog](http://coala.io/commit#shortlog).
- [x] I have followed the [guidelines for the commit body](http://coala.io/commit#commit-body).
- [ ] I have included the issue URL with the 'Fixes' keyword if the commit fixes a *real bug* and the 'Closes' keyword if it adds a feature or enhancement. For details, check the [issue reference section in our commit guidelines](http://coala.io/commit#issue-reference).
- [x] I have [run all the tests](http://api.coala.io/en/latest/Developers/Executing_Tests.html) and they all pass. If any CI (below) is not green, please fix them. If GitMate issues appear you will have to amend your commits, pushing new commits on top is not sufficient!

**After you submit your pull request, DO NOT click the 'Update Branch' button**

### Reviewers

<!--
Please list the Github handles of people you think susceptible to review this PR. Feel free to leave this section blank if you don't know who to tag.
-->
- @sils 
- @fneu 
<!--
End note:

As you learn things over your Pull Request please help others on the chat and on PRs to get their stuff right as well!
-->
