### PR TITLE
Blacklist `urlopen`

### DIFF
--- a/.coafile
+++ b/.coafile
@@ -17,7 +17,7 @@ language = Python
 preferred_quotation = '
 
 default_actions = *: ApplyPatchAction
- 
+
 [autopep8]
 bears = PEP8Bear, PycodestyleBear
 

--- a/.coafile
+++ b/.coafile
@@ -120,3 +120,9 @@ language = python 3
 
 ci_keywords, keywords = \#TODO, \# TODO, \#FIXME, \# FIXME
 cs_keywords =
+
+[urllib]
+# Encourage usage of requests library by blacklisting usage of urlopen()
+bears = KeywordBear
+language = python 3
+keywords = urlopen


### PR DESCRIPTION
No `urlopen()` can be found in the code base right now. This pull request will prevent urlopen from being used in the future, as was suggested in #3620.