### PR TITLE
Add ShellCommandResult for accessing return codes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,6 +35,9 @@ before_install:
       sudo ln -sf $(which pip3) $(which pip 2>/dev/null || echo /usr/bin/pip)
     fi
 
+  # always use latest versions of pip and setuptools
+  - pip install pip setuptools -U
+
   # https://github.com/coala/coala/issues/3183
   # Travis automatically installs the `requirements.txt` in "install" stage
   - cp requirements.txt requirements.orig

--- a/circle.yml
+++ b/circle.yml
@@ -13,6 +13,8 @@ test:
   override:
     - bash .misc/tests.sh:
         parallel: true
+    - pip install pip setuptools -U:
+        parallel: true
     - python setup.py install:
         parallel: true
     - pip install coala-bears[alldeps] --pre -U:


### PR DESCRIPTION
`@linter` bears can produce wrong results when the external linting tools fail, which can't be checked with the current `coalib.misc.Shell` API. No chance to check the `returncode` of the process created by `run_shell_command`.

This is most probably also the reason for https://github.com/coala/coala-bears/issues/1235

Currently `run_shell_command` only returns the `(stdout, stderr)` tuple from `Popen.communicate`. I wrapped that in a backwards-compatible `tuple`-derived `ShellCommandResult` class which additionally stores the `Popen` instance and has a `.code` property to easily check the return code of the process.