### PR TITLE
Use codecov-python

### DIFF
--- a/.misc/deploy.coverage.sh
+++ b/.misc/deploy.coverage.sh
@@ -1,6 +1,0 @@
-set -x
-set -e
-
-source .misc/env_variables.sh
-
-bash <(curl -s https://codecov.io/bash)

--- a/.travis.yml
+++ b/.travis.yml
@@ -78,7 +78,7 @@ script:
       make -C docs clean
       python setup.py docs
     fi
-  - bash .misc/deploy.coverage.sh
+  - codecov
 
 notifications:
   email: false

--- a/circle.yml
+++ b/circle.yml
@@ -23,7 +23,7 @@ test:
         timeout: 900  # Allow 15 mins
     - coala --non-interactive:
         parallel: true
-    - bash .misc/deploy.coverage.sh:
+    - codecov:
         parallel: true
     - make -C docs clean
     - python setup.py docs

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,4 +1,5 @@
 coverage~=4.0
+codecov~=2.0.5
 pytest~=3.0
 pytest-cov~=2.2
 pytest-env~=0.6.0


### PR DESCRIPTION
Currently codecov-bash is used, which involves an uncached fetch
of a unversioned bash script.
Using codecov-python allows the tool to be cached, and greater
reliability due to versioned releases of the tool.

In addition, codecov-bash does not work on Windows, and our
developer base is better tuned to investigate any python
related problems.

Fixes https://github.com/coala/coala/issues/3718
