### PR TITLE
FunctionMetadata.py: Modify param's metadata

### DIFF
--- a/coalib/bearlib/abstractions/ExternalBearWrap.py
+++ b/coalib/bearlib/abstractions/ExternalBearWrap.py
@@ -83,8 +83,7 @@ def _create_wrapper(klass, options):
             if default_value is NoDefaultValue:
                 return (description, setting_type)
             else:
-                return (description + ' ' +
-                        FunctionMetadata.str_optional.format(default_value),
+                return (description,
                         setting_type, default_value)
 
         @classmethod

--- a/coalib/settings/FunctionMetadata.py
+++ b/coalib/settings/FunctionMetadata.py
@@ -8,7 +8,6 @@ from coalib.settings.DocstringMetadata import DocstringMetadata
 
 class FunctionMetadata:
     str_nodesc = 'No description given.'
-    str_optional = "Optional, defaults to '{}'."
 
     @enforce_signature
     def __init__(self,
@@ -126,7 +125,7 @@ class FunctionMetadata:
 
         for param in self.optional_params:
             if param in section:
-                _, annotation, _ = self.optional_params[param]
+                _, annotation, _, _ = self.optional_params[param]
                 params[param] = self._get_param(param, section, annotation)
 
         return params
@@ -186,11 +185,10 @@ class FunctionMetadata:
                     argspec.annotations.get(arg, None))
             else:
                 optional_params[arg] = (
-                    doc_comment.param_dict.get(arg, cls.str_nodesc) + ' (' +
-                    cls.str_optional.format(
-                        defaults[i-num_non_defaults]) + ')',
+                    doc_comment.param_dict.get(arg, cls.str_nodesc),
                     argspec.annotations.get(arg, None),
-                    defaults[i-num_non_defaults])
+                    defaults[i-num_non_defaults],
+                    'Optional')
 
         return cls(name=func.__name__,
                    desc=doc_comment.desc,

--- a/tests/bearlib/abstractions/external_bear_wrap_testfiles/ExternalBearWrapTest.py
+++ b/tests/bearlib/abstractions/external_bear_wrap_testfiles/ExternalBearWrapTest.py
@@ -99,15 +99,12 @@ class ExternalBearWrapComponentTest(unittest.TestCase):
         self.assertEqual(metadata.non_optional_params['asetting'][0],
                          FunctionMetadata.str_nodesc)
         self.assertEqual(metadata.optional_params['bsetting'][0],
-                         FunctionMetadata.str_nodesc + ' ' +
-                         FunctionMetadata.str_optional.format(True))
-        self.assertEqual(metadata.optional_params['csetting'][0], 'My desc.' +
-                         ' ' + FunctionMetadata.str_optional.format(False))
+                         FunctionMetadata.str_nodesc)
+        self.assertEqual(metadata.optional_params['csetting'][0], 'My desc.')
         self.assertEqual(metadata.non_optional_params['dsetting'][0],
                          'Another desc')
         self.assertEqual(metadata.optional_params['esetting'][0],
-                         FunctionMetadata.str_nodesc + ' ' +
-                         FunctionMetadata.str_optional.format(None))
+                         FunctionMetadata.str_nodesc)
 
     def test_optional_settings(self):
         uut = (external_bear_wrap(sys.executable, settings={

--- a/tests/output/ConsoleInteractionTest.py
+++ b/tests/output/ConsoleInteractionTest.py
@@ -712,9 +712,7 @@ class ShowBearsTest(unittest.TestCase):
                              '  Needed Settings:\n'
                              '   * setting1: Required Setting.\n\n'
                              '  Optional Settings:\n'
-                             '   * setting2: Optional Setting. ('
-                             "Optional, defaults to 'None'."
-                             ')\n\n'
+                             '   * setting2: Optional Setting.\n\n'
                              '  Can detect:\n   * Formatting\n\n'
                              '  Can fix:\n   * Formatting\n\n  Path:\n   ' +
                              repr(TestBear.source_location) + '\n\n')

--- a/tests/settings/FunctionMetadataTest.py
+++ b/tests/settings/FunctionMetadataTest.py
@@ -49,11 +49,8 @@ class FunctionMetadataTest(unittest.TestCase):
                 'param2': ('d', None)
             },
             optional_params={
-                'param3': (uut.str_nodesc + ' ('
-                           + uut.str_optional.format('5') + ')',
-                           None, 5),
-                'param4': ('p4 desc ('
-                           + uut.str_optional.format('6') + ')', int, 6)})
+                'param3': (uut.str_nodesc, None, 5, 'Optional'),
+                'param4': ('p4 desc', int, 6, 'Optional')})
 
         uut = FunctionMetadata.from_function(TestClass(5, 5).__init__,
                                              omit={'param3', 'param2'})
@@ -67,9 +64,7 @@ class FunctionMetadataTest(unittest.TestCase):
                            None)
             },
             optional_params={
-                'param4': ('p4 desc (' + uut.str_optional.format('6') + ')',
-                           int,
-                           6)})
+                'param4': ('p4 desc', int, 6, 'Optional')})
 
     def test_create_params_from_section_invalid(self):
         section = Section('name')


### PR DESCRIPTION
Split "optional_params" description into two parts to ensure that hard coded
default values are not present. The first part corresponds to the description
of a parameter and the second part corresponds to the string "Optional".

Fixes https://github.com/coala/coala/issues/3020

<!--
Thanks for your contribution!

Please take a quick look at those things down there. They're quite important.
Really! We wrote them for you. Yes you! With utmost care. Read them.
-->

**For short term contributors:** we understand that getting your commits well
defined like we require is a hard task and takes some learning. If you
look to help without wanting to contribute long term there's no need
for you to learn this. Just drop us a message and we'll take care of brushing
up your stuff for merge!

### Checklist

- [x] I read the [commit guidelines](http://coala.io/commit) and I've followed
      them.
- [x] I ran coala over my code locally. (*All commits have to pass
      individually.* It is not sufficient to have "fixup commits" on your PR,
      our bot will still report the issues for the previous commit.) You will
      likely receive a lot of bot comments and build failures if coala does not
      pass on every single commit!

After you submit your pull request, **DO NOT click the 'Update Branch' button.**
When asked for a rebase, consult [coala.io/rebase](https://coala.io/rebase)
instead.

Please consider helping us by reviewing other peoples pull requests as well:

- pick up any PR at <https://coala.io/review>
- review it (check <https://coala.io/reviewing> for more info)
- if you are sure that it needs work, use `cobot mark wip <URL>` to get it out
  of the review queue.

The more you review, the more your score will grow at coala.io and we will
review your PRs faster!
