### PR TITLE
Processing: Reset cached files if a bear isn't run

### DIFF
--- a/coalib/processes/Processing.py
+++ b/coalib/processes/Processing.py
@@ -374,6 +374,7 @@ def instantiate_processes(section,
     message_queue = multiprocessing.Queue()
     control_queue = multiprocessing.Queue()
 
+    loaded_local_bears_count = len(local_bear_list)
     local_bear_list[:], global_bear_list[:] = instantiate_bears(
         section,
         local_bear_list,
@@ -381,9 +382,13 @@ def instantiate_processes(section,
         complete_file_dict,
         message_queue,
         console_printer=console_printer)
+    loaded_valid_local_bears_count = len(local_bear_list)
+    # Note: the complete file dict is given as the file dict to bears and
+    # the whole project is accessible to every bear. However, local bears are
+    # run only for the changed files if caching is enabled.
 
     # Start tracking all the files
-    if cache:
+    if cache and loaded_valid_local_bears_count == loaded_local_bears_count:
         cache.track_files(set(complete_filename_list))
         changed_files = cache.get_uncached_files(
             set(filename_list)) if cache else filename_list

--- a/tests/processes/ProcessingTest.py
+++ b/tests/processes/ProcessingTest.py
@@ -1,3 +1,4 @@
+import copy
 import multiprocessing
 import os
 import platform
@@ -9,6 +10,7 @@ import unittest
 
 from pyprint.ConsolePrinter import ConsolePrinter
 
+from coalib.bears.Bear import Bear
 from coalib.output.printers.LogPrinter import LogPrinter
 from coalib.processes.CONTROL_ELEMENT import CONTROL_ELEMENT
 from coalib.processes.Processing import (
@@ -491,6 +493,46 @@ class ProcessingTest(unittest.TestCase):
         self.assertEqual(source_range.start.column, 1)
         self.assertEqual(source_range.end.line, 1)
         self.assertEqual(source_range.end.column, 14)
+
+    def test_loaded_bears_with_error_result(self):
+        class BearWithMissingPrerequisites(Bear):
+
+            def __init__(self, section, queue, timeout=0.1):
+                Bear.__init__(self, section, queue, timeout)
+
+            def run(self):
+                return []
+
+            @classmethod
+            def check_prerequisites(cls):
+                return False
+
+        multiprocessing.Queue()
+        tmp_local_bears = copy.copy(self.local_bears['cli'])
+        tmp_local_bears.append(BearWithMissingPrerequisites)
+        cache = FileCache(self.log_printer,
+                          'coala_test_on_error',
+                          flush_cache=True)
+        results = execute_section(self.sections['cli'],
+                                  [],
+                                  tmp_local_bears,
+                                  lambda *args: self.result_queue.put(args[2]),
+                                  cache,
+                                  self.log_printer,
+                                  console_printer=self.console_printer)
+        self.assertEqual(len(cache.data), 0)
+
+        cache = FileCache(self.log_printer,
+                          'coala_test_on_error',
+                          flush_cache=False)
+        results = execute_section(self.sections['cli'],
+                                  [],
+                                  self.local_bears['cli'],
+                                  lambda *args: self.result_queue.put(args[2]),
+                                  cache,
+                                  self.log_printer,
+                                  console_printer=self.console_printer)
+        self.assertGreater(len(cache.data), 0)
 
 
 class ProcessingTest_GetDefaultActions(unittest.TestCase):


### PR DESCRIPTION
When a bear could not be run because of a missing requirement,
the files were cached anyway so if we install the requirement
and run again, the files are ignored.

This change removes from cache all files only from a section
where a bear could not be run.

Fixes: https://github.com/coala/coala/issues/3693

<!--
Thanks for your contribution!

Please take a quick look at those things down there. They're quite important.
Really! We wrote them for you. Yes you! With utmost care. Read them.
-->

**For short term contributors:** we understand that getting your commits well
defined like we require is a hard task and takes some learning. If you
look to help without wanting to contribute long term there's no need
for you to learn this. Just drop us a message and we'll take care of brushing
up your stuff for merge!

### Checklist

- [x] I read the [commit guidelines](http://coala.io/commit) and I've followed
      them.
- [x] I ran coala over my code locally. (*All commits have to pass
      individually.* It is not sufficient to have "fixup commits" on your PR,
      our bot will still report the issues for the previous commit.) You will
      likely receive a lot of bot comments and build failures if coala does not
      pass on every single commit!

After you submit your pull request, **DO NOT click the 'Update Branch' button.**
When asked for a rebase, consult [coala.io/rebase](https://coala.io/rebase)
instead.

Please consider helping us by reviewing other peoples pull requests as well:

- pick up any PR at <https://coala.io/review>
- review it (check <https://coala.io/reviewing> for more info)
- if you are sure that it needs work, use `cobot mark wip <URL>` to get it out
  of the review queue.

The more you review, the more your score will grow at coala.io and we will
review your PRs faster!
