### PR TITLE
LineParser.py: Print warning for comments

### DIFF
--- a/coalib/parsing/LineParser.py
+++ b/coalib/parsing/LineParser.py
@@ -1,4 +1,5 @@
 import logging
+import re
 
 from coala_utils.string_processing.StringConverter import StringConverter
 from coala_utils.string_processing import (unescape, convert_to_raw,
@@ -78,6 +79,15 @@ class LineParser:
                      [(section_override, key), ...], value, to_append (True if
                      append delimiter is found else False), comment
         """
+        for separator in self.comment_separators:
+            if (re.match('[^ ]' + separator, line)
+                    or re.match(separator + '[^ ]', line)):
+                logging.warning('This comment does not have whitespace' +
+                                ' before or after ' + separator + ' in: ' +
+                                repr(line.replace('\n', '')) + '. If you ' +
+                                'didn\'t mean to make a comment, use a ' +
+                                'backslash for escaping.')
+
         line, comment = self.__separate_by_first_occurrence(
             line,
             self.comment_separators)

--- a/tests/parsing/LineParserTest.py
+++ b/tests/parsing/LineParserTest.py
@@ -14,6 +14,7 @@ class LineParserTest(unittest.TestCase):
         self.check_data_set('\n \n \n')
 
     def test_comment_parsing(self):
+        logger = logging.getLogger()
         self.check_data_set('# comment only$§\n',
                             output_comment='# comment only$§')
         self.check_data_set('   ; comment only  \n',
@@ -21,6 +22,23 @@ class LineParserTest(unittest.TestCase):
         self.check_data_set('   ; \\comment only  \n',
                             output_comment='; comment only')
         self.check_data_set('#', output_comment='#')
+        with self.assertLogs(logger, 'WARNING') as warn:
+            self.check_data_set('##\n', output_comment='##')
+        self.assertEqual(len(warn.output), 1)
+        self.assertEqual(warn.output[0], 'WARNING:root:This comment does ' +
+                                         'not have whitespace before or ' +
+                                         'after # in: ' + repr('##') +
+                                         '. If you didn\'t mean to make ' +
+                                         'a comment, use a backslash for ' +
+                                         'escaping.')
+        with self.assertLogs(logger, 'WARNING') as warn:
+            self.check_data_set('#A\n', output_comment='#A')
+        self.assertEqual(warn.output[0], 'WARNING:root:This comment does ' +
+                                         'not have whitespace before or ' +
+                                         'after # in: ' + repr('#A') +
+                                         '. If you didn\'t mean to make ' +
+                                         'a comment, use a backslash for ' +
+                                         'escaping.')
 
     def test_section_override(self):
         self.check_data_set(r'a.b, \a\.\b\ c=',


### PR DESCRIPTION
Adds warning if comment does not have
whitespace before or after #.

Closes https://github.com/coala/coala/issues/2926
