### PR TITLE
ConfigurationGathering.py: Irrelevant warning

### DIFF
--- a/coalib/settings/ConfigurationGathering.py
+++ b/coalib/settings/ConfigurationGathering.py
@@ -160,7 +160,8 @@ def warn_config_absent(sections, argument, log_printer):
     return False
 
 
-def load_configuration(arg_list, log_printer, arg_parser=None, args=None):
+def load_configuration(arg_list, log_printer, arg_parser=None, args=None,
+                       silent=False):
     """
     Parses the CLI args and loads the config file accordingly, taking
     default_coafile and the users .coarc into account.
@@ -170,6 +171,9 @@ def load_configuration(arg_list, log_printer, arg_parser=None, args=None):
     :param arg_parser:  An ``argparse.ArgumentParser`` instance used for
                         parsing the CLI arguments.
     :param args:        Alternative pre-parsed CLI arguments.
+    :param arg_list:    Alternative pre-parsed CLI arguments.
+    :param silent:      Whether or not to warn the user/exit if the file
+                        doesn't exist. It is ignored when `save` is enabled.
     :return:            A tuple holding (log_printer: LogPrinter, sections:
                         dict(str, Section), targets: list(str)). (Types
                         indicated after colon.)
@@ -211,7 +215,8 @@ def load_configuration(arg_list, log_printer, arg_parser=None, args=None):
             # but to a specific file.
             save = True
 
-        coafile_sections = load_config_file(config, log_printer, silent=save)
+        coafile_sections = load_config_file(
+            config, log_printer, silent=silent or save)
 
         sections = merge_section_dicts(base_sections, user_sections)
 
@@ -351,7 +356,8 @@ def get_all_bears(log_printer, arg_parser=None):
     """
     sections, _ = load_configuration(arg_list=None,
                                      log_printer=log_printer,
-                                     arg_parser=arg_parser)
+                                     arg_parser=arg_parser,
+                                     silent=True)
     local_bears, global_bears = collect_all_bears_from_sections(
         sections, log_printer)
     return local_bears, global_bears

--- a/tests/settings/ConfigurationGatheringTest.py
+++ b/tests/settings/ConfigurationGatheringTest.py
@@ -387,3 +387,23 @@ class ConfigurationGatheringCollectionTest(unittest.TestCase):
         self.assertEqual(str(local_bears['cli'][1]),
                          "<class 'LineCountTestBear.LineCountTestBear'>")
         self.assertEqual(len(global_bears['cli']), 0)
+
+    def test_show_bears(self):
+        current_dir = os.path.abspath(os.path.dirname(__file__))
+        child_dir = os.path.join(current_dir,
+                                 'section_manager_test_files',
+                                 'child_dir')
+        logger = logging.getLogger()
+
+        with change_directory(child_dir):
+            with self.assertLogs(logger, 'WARNING') as cm:
+                local_bears, global_bears = get_filtered_bears(
+                    [],
+                    self.log_printer)
+            self.assertNotIn('WARNING', cm.output[0])
+
+            with self.assertLogs(logger, 'WARNING') as cm:
+                local_bears, global_bears = get_filtered_bears(
+                    ['c'],
+                    self.log_printer)
+            self.assertNotIn('WARNING', cm.output[0])


### PR DESCRIPTION
While running `coala -B` or `coala -B -l <language>` ,
if the .coafile is not found then coala prints
irrelevent warnings.

Fixes coala#2775

<!--
Thanks for your contribution!

Please take a quick look at those things down there. They're quite important.
Really! We wrote them for you. Yes you! With utmost care. Read them.
-->

**For short term contributors:** we understand that getting your commits well
defined like we require is a hard task and takes some learning. If you
look to help without wanting to contribute long term there's no need
for you to learn this. Just drop us a message and we'll take care of brushing
up your stuff for merge!

### Checklist

- [ ] I read the [commit guidelines](http://coala.io/commit) and I've followed
      them.
- [ ] I ran coala over my code locally. (*All commits have to pass
      individually.* It is not sufficient to have "fixup commits" on your PR,
      our bot will still report the issues for the previous commit.) You will
      likely receive a lot of bot comments and build failures if coala does not
      pass on every single commit!

After you submit your pull request, **DO NOT click the 'Update Branch' button.**
When asked for a rebase, consult [coala.io/rebase](https://coala.io/rebase)
instead.

Please consider helping us by reviewing other peoples pull requests as well:

- pick up any PR at <https://coala.io/review>
- review it (check <https://coala.io/reviewing> for more info)
- if you are sure that it needs work, use `cobot mark wip <URL>` to get it out
  of the review queue.

The more you review, the more your score will grow at coala.io and we will
review your PRs faster!
