### PR TITLE
ShellCommandResult: Fix doctest

### DIFF
--- a/coalib/misc/Shell.py
+++ b/coalib/misc/Shell.py
@@ -15,11 +15,15 @@ class ShellCommandResult(tuple):
 
     It additionally stores the return ``.code``:
 
-    >>> process = Popen(['python', '-c', 'print(input() + " processed")'],
+    >>> process = Popen(['python', '-c',
+    ...                  'import sys; print(sys.stdin.readline().strip() +'
+    ...                  '                  " processed")'],
     ...                 stdin=PIPE, stdout=PIPE, stderr=PIPE,
     ...                 universal_newlines=True)
 
     >>> stdout, stderr = process.communicate(input='data')
+    >>> stderr
+    ''
     >>> result = ShellCommandResult(process.returncode, stdout, stderr)
     >>> result[0]
     'data processed\\n'


### PR DESCRIPTION
The doctest uses python3 syntax while invoking `python`,
which fails if the executable `python` is the Python 2 runtime.

Fixes https://github.com/coala/coala/issues/3780
