### PR TITLE
Brackets were added to Result.from_values()

### DIFF
--- a/docs/Developers/Testing_Bears.rst
+++ b/docs/Developers/Testing_Bears.rst
@@ -125,7 +125,7 @@ passed.
                 self.uut,
                 file,
                 Result.from_values(["TooManyLinesBear",
-                                   "Too many lines"
+                                   "Too many lines",
                                    settings={'max_number_of_lines': int=20}]))
 
 ``check_results`` asserts if your bear results match the actual

--- a/docs/Developers/Testing_Bears.rst
+++ b/docs/Developers/Testing_Bears.rst
@@ -124,9 +124,9 @@ passed.
             self.check_results(
                 self.uut,
                 file,
-                Result.from_values("TooManyLinesBear",
+                Result.from_values(["TooManyLinesBear",
                                    "Too many lines"
-                                   settings={'max_number_of_lines': int=20}))
+                                   settings={'max_number_of_lines': int=20}]))
 
 ``check_results`` asserts if your bear results match the actual
 results on execution on CLI. Just like the above example, we need to ``setUp``


### PR DESCRIPTION
Testing_Bears.rst : enclosed in []s

The argument passed to Result.from_values() is a list,so added []s

Fixes #3770 Testing_Bears.rst: Enlose result in []