### PR TITLE
AppVeyor CI: Allow builds on forks

### DIFF
--- a/.misc/appveyor.yml
+++ b/.misc/appveyor.yml
@@ -19,10 +19,9 @@ environment:
 cache:
   - "C:\\pip_cache"
 
-branches:  # Only build official branches, PRs are built anyway.
-  only:
-    - master
-    - /release.*/
+branches:
+  except:
+    - /^sils\/.*/
 
 install:
   # Prepend newly installed Python to the PATH of this build (this cannot be


### PR DESCRIPTION
Exclude only branch 'sils/*'.

Closes https://github.com/coala/coala/issues/3516
Related to https://github.com/coala/coala/issues/3664
