### PR TITLE
aspects: Typo error for classnames in pydoc

### DIFF
--- a/coalib/bearlib/aspects/__init__.py
+++ b/coalib/bearlib/aspects/__init__.py
@@ -13,7 +13,7 @@ class Root(aspectbase, metaclass=aspectclass):
     Definition string is taken from doc-string of decorated class.
     Remaining docs are taken from a nested ``docs`` class.
     Tastes are defined as class attributes that are instances of
-    :class:`coalib.bearlib.aspectclasses.Taste`.
+    :class:`coalib.bearlib.aspects.Taste`.
 
     >>> @Root.subaspect
     ... class Formatting:

--- a/coalib/bearlib/aspects/base.py
+++ b/coalib/bearlib/aspects/base.py
@@ -8,9 +8,9 @@ class aspectbase:
     Base class for aspectclasses with common features for their instances.
 
     Derived classes must use
-    :class:`coalib.bearlib.aspectclasses.meta.aspectclass` as metaclass.
+    :class:`coalib.bearlib.aspects.meta.aspectclass` as metaclass.
     This is automatically handled by
-    :meth:`coalib.bearlib.aspectclasses.meta.aspectclass.subaspect` decorator.
+    :meth:`coalib.bearlib.aspects.meta.aspectclass.subaspect` decorator.
     """
 
     def __init__(self, language, **taste_values):

--- a/coalib/bearlib/aspects/meta.py
+++ b/coalib/bearlib/aspects/meta.py
@@ -11,7 +11,7 @@ class aspectclass(type):
     """
     Metaclass for aspectclasses.
 
-    Root aspectclass is :class:`coalib.bearlib.aspectclasses.Root`.
+    Root aspectclass is :class:`coalib.bearlib.aspects.Root`.
     """
     def __init__(cls, clsname, bases, clsattrs):
         """
@@ -23,7 +23,7 @@ class aspectclass(type):
     def tastes(cls):
         """
         Get a dictionary of all taste names mapped to their
-        :class:`coalib.bearlib.aspectclasses.Taste` instances.
+        :class:`coalib.bearlib.aspects.Taste` instances.
         """
         if cls.parent:
             return dict(cls.parent.tastes, **cls._tastes)
@@ -34,7 +34,7 @@ class aspectclass(type):
         """
         The sub-aspectclass decorator.
 
-        See :class:`coalib.bearlib.aspectclasses.Root` for description
+        See :class:`coalib.bearlib.aspects.Root` for description
         and usage.
         """
         aspectname = subcls.__name__

--- a/coalib/bearlib/aspects/taste.py
+++ b/coalib/bearlib/aspects/taste.py
@@ -11,7 +11,7 @@ class TasteError(AttributeError):
 
 class TasteMeta(type):
     """
-    Metaclass for :class:`coalib.bearlib.aspectclasses.Taste`
+    Metaclass for :class:`coalib.bearlib.aspects.Taste`
 
     Allows defining taste cast type via :meth:`.__getitem__`, like:
 
@@ -43,7 +43,7 @@ class Taste(metaclass=TasteMeta):
     (C#,)
 
     If no `languages` are given, they will be available for any language.
-    See :class:`coalib.bearlib.aspectclasses.Root` for further usage.
+    See :class:`coalib.bearlib.aspects.Root` for further usage.
     """
     cast_type = str
 


### PR DESCRIPTION
Fixes #3827