### PR TITLE
Writing_Linter_Bears.rst: Replace double quotes with single quotes #3832

### DIFF
--- a/docs/Developers/Writing_Linter_Bears.rst
+++ b/docs/Developers/Writing_Linter_Bears.rst
@@ -392,7 +392,7 @@ gather information by using these values. Our bear now looks like:
       https://pylint.org/
       """
 
-      LANGUAGES = {"Python", "Python 2", "Python 3"}
+      LANGUAGES = {'Python', 'Python 2', 'Python 3'}
       REQUIREMENTS = {PipRequirement('pylint', '1.*')}
       AUTHORS = {'The coala developers'}
       AUTHORS_EMAILS = {'coala-devel@googlegroups.com'}


### PR DESCRIPTION
Writing_Linter_Bears.rst: Replace " with ' in line --
LANGUAGES = {"Python", "Python 2", "Python 3"}


Closes https://github.com/coala/coala/issues/3832