### PR TITLE
Removed warning for SkipTest (issue 2884)

### DIFF
--- a/tests/results/DiffTest.py
+++ b/tests/results/DiffTest.py
@@ -1,7 +1,7 @@
 import json
 import logging
 import unittest
-from unittest.case import SkipTest
+import unittest.case
 
 from coalib.output.JSONEncoder import create_json_encoder
 from coalib.results.Diff import ConflictError, Diff, SourceRange
@@ -210,7 +210,7 @@ class DiffTest(unittest.TestCase):
         try:
             from clang.cindex import Index, LibclangError
         except ImportError as err:
-            raise SkipTest(str(err))
+            raise unittest.case.SkipTest(str(err))
 
         joined_file = 'struct { int f0; }\nx = { f0 :1 };\n'
         file = joined_file.splitlines(True)
@@ -219,7 +219,7 @@ class DiffTest(unittest.TestCase):
             tu = Index.create().parse('t.c', unsaved_files=[
                 ('t.c', joined_file)])
         except LibclangError as err:
-            raise SkipTest(str(err))
+            raise unittest.case.SkipTest(str(err))
 
         fixit = tu.diagnostics[0].fixits[0]
         clang_fixed_file = Diff.from_clang_fixit(fixit, file).modified


### PR DESCRIPTION
`/tests/results/DiffTest.py` : changed the inclusion of SkipTest to implicit inclusion

Closes : https://github.com/coala/coala/issues/2884
<!--
Thanks for your contribution!

Please take a quick look at those things down there. They're quite important.
Really! We wrote them for you. Yes you! With utmost care. Read them.
-->

**For short term contributors:** we understand that getting your commits well
defined like we require is a hard task and takes some learning. If you
look to help without wanting to contribute long term there's no need
for you to learn this. Just drop us a message and we'll take care of brushing
up your stuff for merge!

### Checklist

- [x] I read the [commit guidelines](http://coala.io/commit) and I've followed
      them.
- [x] I ran coala over my code locally. (*All commits have to pass
      individually.* It is not sufficient to have "fixup commits" on your PR,
      our bot will still report the issues for the previous commit.) You will
      likely receive a lot of bot comments and build failures if coala does not
      pass on every single commit!

After you submit your pull request, **DO NOT click the 'Update Branch' button.**
When asked for a rebase, consult [coala.io/rebase](https://coala.io/rebase)
instead.

Please consider helping us by reviewing other peoples pull requests as well:

- pick up any PR at <https://coala.io/review>
- review it (check <https://coala.io/reviewing> for more info)
- if you are sure that it needs work, use `cobot mark wip <URL>` to get it out
  of the review queue.

The more you review, the more your score will grow at coala.io and we will
review your PRs faster!
