### PR TITLE
coala_main: Non-zero exit code if errors logged

### DIFF
--- a/coalib/coala_main.py
+++ b/coalib/coala_main.py
@@ -8,6 +8,7 @@ from coalib.misc.Exceptions import get_exitcode
 from coalib.output.Interactions import fail_acquire_settings
 from coalib.output.printers.LogPrinter import LogPrinter
 from coalib.output.printers.LOG_LEVEL import LOG_LEVEL
+from coalib.output.Logging import CounterHandler
 from coalib.processes.Processing import execute_section, simplify_section_result
 from coalib.settings.ConfigurationGathering import gather_configuration
 from coalib.misc.Caching import FileCache
@@ -124,7 +125,9 @@ def run_coala(console_printer=None,
         if cache:
             cache.write()
 
-        if did_nothing:
+        if CounterHandler.get_num_calls_for_level('ERROR') > 0:
+            exitcode = 1
+        elif did_nothing:
             nothing_done(log_printer)
             exitcode = 2
         elif yielded_unfixed_results:

--- a/coalib/output/Logging.py
+++ b/coalib/output/Logging.py
@@ -1,8 +1,35 @@
 from datetime import datetime
+from collections import Counter
 import json
 import io
 import logging
 import logging.config
+
+
+class CounterHandler(logging.Handler):
+    """
+    A logging handler which counts the number of calls
+    for each logging level.
+    """
+    _call_counter = Counter()
+
+    @classmethod
+    def reset(cls):
+        """
+        Reset the counter to 0 for all levels
+        """
+        cls._call_counter.clear()
+
+    @classmethod
+    def emit(cls, record):
+        cls._call_counter[record.levelname] += 1
+
+    @classmethod
+    def get_num_calls_for_level(cls, level):
+        """
+        Returns the number of calls registered for a given log level.
+        """
+        return cls._call_counter[level]
 
 
 def configure_logging():
@@ -11,6 +38,9 @@ def configure_logging():
     """
     import sys
 
+    # reset counter handler
+    CounterHandler.reset()
+
     logging.config.dictConfig({
         'version': 1,
         'handlers': {
@@ -18,11 +48,14 @@ def configure_logging():
                 'class': 'logging.StreamHandler',
                 'formatter': 'colored',
                 'stream': sys.stderr
+            },
+            'counter': {
+                'class': 'coalib.output.Logging.CounterHandler'
             }
         },
         'root': {
             'level': 'DEBUG',
-            'handlers': ['colored']
+            'handlers': ['colored', 'counter']
         },
         'formatters': {
             'colored': {
@@ -48,6 +81,9 @@ def configure_json_logging():
     """
     stream = io.StringIO()
 
+    # reset counter handler
+    CounterHandler.reset()
+
     logging.config.dictConfig({
         'version': 1,
         'handlers': {
@@ -55,11 +91,14 @@ def configure_json_logging():
                 'class': 'logging.StreamHandler',
                 'formatter': 'json',
                 'stream': stream
+            },
+            'counter': {
+                'class': 'coalib.output.Logging.CounterHandler'
             }
         },
         'root': {
             'level': 'DEBUG',
-            'handlers': ['json']
+            'handlers': ['json', 'counter']
         },
         'formatters': {
             'json': {

--- a/tests/coalaCITest.py
+++ b/tests/coalaCITest.py
@@ -23,6 +23,8 @@ class coalaCITest(unittest.TestCase):
             coala_ci.main, 'coala-ci', '--help')
         self.assertIn('usage: coala', stdout)
         self.assertIn('Use of `coala-ci` binary is deprecated', stderr)
+        self.assertEqual(retval, 0,
+                         'coala must return zero when successful')
 
     def test_nonexistent(self):
         retval, stdout, stderr = execute_coala(
@@ -31,6 +33,8 @@ class coalaCITest(unittest.TestCase):
         self.assertRegex(
             stderr,
             ".*\\[ERROR\\].*The requested coafile '.*' does not exist. .+\n")
+        self.assertNotEqual(retval, 0,
+                            'coala must return nonzero when errors occured')
 
     def test_find_no_issues(self):
         with bear_test_module(), \
@@ -46,7 +50,7 @@ class coalaCITest(unittest.TestCase):
             self.assertIn('Executing section cli', stdout)
             self.assertFalse(stderr)
             self.assertEqual(retval, 0,
-                             'coala-ci must return zero when successful')
+                             'coala must return zero when successful')
 
     def test_find_issues(self):
         with bear_test_module(), \
@@ -61,7 +65,7 @@ class coalaCITest(unittest.TestCase):
                           'The output should report count as 1 lines')
             self.assertIn('This result has no patch attached.', stderr)
             self.assertNotEqual(retval, 0,
-                                'coala-ci was expected to return non-zero')
+                                'coala must return nonzero when errors occured')
 
     def test_show_patch(self):
         with bear_test_module(), \
@@ -75,7 +79,7 @@ class coalaCITest(unittest.TestCase):
             self.assertIn('Line contains ', stdout)  # Result message is shown
             self.assertIn("Applied 'ShowPatchAction'", stderr)
             self.assertEqual(retval, 5,
-                             'coala-ci must return exitcode 5 when it '
+                             'coala must return exitcode 5 when it '
                              'autofixes the code.')
 
     def test_fail_acquire_settings(self):
@@ -86,3 +90,5 @@ class coalaCITest(unittest.TestCase):
                                                    '-c', os.devnull)
             self.assertFalse(stdout)
             self.assertIn('During execution, we found that some', stderr)
+            self.assertNotEqual(retval, 0,
+                                'coala was expected to return non-zero')

--- a/tests/coalaJSONTest.py
+++ b/tests/coalaJSONTest.py
@@ -31,6 +31,8 @@ class coalaJSONTest(unittest.TestCase):
         test_text = '{\n  "results": {}\n}\n'
         self.assertEqual(stdout, test_text)
         self.assertRegex(stderr, ".*requested coafile '.*' does not exist. .+")
+        self.assertNotEqual(retval, 0,
+                            'coala must return nonzero when errors occured')
 
     def test_find_issues(self):
         with bear_test_module(), \
@@ -60,6 +62,8 @@ class coalaJSONTest(unittest.TestCase):
             self.assertEqual(stdout, test_text)
             self.assertIn('During execution, we found that some',
                           stderr, 'Missing settings not logged')
+            self.assertNotEqual(retval, 0,
+                                'coala must return nonzero when errors occured')
 
     def test_show_all_bears(self):
         with bear_test_module():
@@ -67,7 +71,7 @@ class coalaJSONTest(unittest.TestCase):
                 coala.main, 'coala', '--json', '-B', '-I')
             self.assertEqual(retval, 0)
             output = json.loads(stdout)
-            self.assertEqual(len(output['bears']), 6)
+            self.assertEqual(len(output['bears']), 7)
             self.assertFalse(stderr)
 
     def test_show_language_bears(self):
@@ -115,6 +119,8 @@ class coalaJSONTest(unittest.TestCase):
             stderr,
             ".*\\[ERROR\\].*The requested coafile '.*' does not exist. .+\n")
         self.assertEqual(stdout, test_text)
+        self.assertNotEqual(retval, 0,
+                            'coala must return nonzero when errors occured')
 
     def test_output_file(self):
         with prepare_file(['#todo this is todo'], None) as (lines, filename):
@@ -127,6 +133,7 @@ class coalaJSONTest(unittest.TestCase):
 
         with open('file.json') as fp:
             data = json.load(fp)
+
         output = json.loads(stdout1)
         self.assertFalse(stderr1)
         # Remove 'time' key from both as we cant compare them

--- a/tests/collecting/CollectorsTest.py
+++ b/tests/collecting/CollectorsTest.py
@@ -308,7 +308,8 @@ class CollectorsTests(unittest.TestCase):
                  'LineCountTestBear',
                  'JavaTestBear',
                  'SpaceConsistencyTestBear',
-                 'TestBear'})
+                 'TestBear',
+                 'ErrorTestBear'})
 
     def test_get_all_bears_names(self):
         with bear_test_module():
@@ -321,4 +322,5 @@ class CollectorsTests(unittest.TestCase):
                  'LineCountTestBear',
                  'JavaTestBear',
                  'SpaceConsistencyTestBear',
-                 'TestBear'})
+                 'TestBear',
+                 'ErrorTestBear'})

--- a/tests/test_bears/ErrorTestBear.py
+++ b/tests/test_bears/ErrorTestBear.py
@@ -1,0 +1,13 @@
+from coalib.bearlib.abstractions.Linter import linter
+
+
+@linter(executable='I_do_not_exist',
+        output_format='regex',
+        output_regex=r'.+:(?P<line>\d+):(?P<message>.*)')
+class ErrorTestBear:
+    """
+    Causes error when run due to missing executable.
+    """
+    @staticmethod
+    def create_arguments(filename, file, config_file):
+        return ()


### PR DESCRIPTION
Adds a new logging handler `CounterHandler`, which
counts the number of logged errors.
Adds logic in coala_main to exit with a non-zero
code if any errors were logged during the run.

Closes https://github.com/coala/coala/issues/3087

<!--
Thanks for your contribution!

Please take a quick look at those things down there. They're quite important.
Really! We wrote them for you. Yes you! With utmost care. Read them.
-->

**For short term contributors:** we understand that getting your commits well
defined like we require is a hard task and takes some learning. If you
look to help without wanting to contribute long term there's no need
for you to learn this. Just drop us a message and we'll take care of brushing
up your stuff for merge!

### Checklist

- [ ] I read the [commit guidelines](http://coala.io/commit) and I've followed
      them.
- [ ] I ran coala over my code locally. (*All commits have to pass
      individually.* It is not sufficient to have "fixup commits" on your PR,
      our bot will still report the issues for the previous commit.) You will
      likely receive a lot of bot comments and build failures if coala does not
      pass on every single commit!

After you submit your pull request, **DO NOT click the 'Update Branch' button.**
When asked for a rebase, consult [coala.io/rebase](https://coala.io/rebase)
instead.

Please consider helping us by reviewing other peoples pull requests as well:

- pick up any PR at <https://coala.io/review>
- review it (check <https://coala.io/reviewing> for more info)
- if you are sure that it needs work, use `cobot mark wip <URL>` to get it out
  of the review queue.

The more you review, the more your score will grow at coala.io and we will
review your PRs faster!
