### PR TITLE
setup.py, tests/__init__.py: Catch (None, None) locale

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,10 @@ from coalib import VERSION, assert_supported_version, get_version
 from coalib.misc.BuildManPage import BuildManPage
 
 try:
-    locale.getlocale()
+    lc = locale.getlocale()
+    pf = platform.system()
+    if pf != 'Windows' and lc == (None, None):
+        locale.setlocale(locale.LC_ALL, 'C.UTF-8')
 except (ValueError, UnicodeError):
     locale.setlocale(locale.LC_ALL, 'en_US.UTF-8')
 

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,11 @@
+import locale
+import platform
+
+
+try:
+    lc = locale.getlocale()
+    ps = platform.system()
+    if ps != 'Windows' and lc == (None, None):
+        locale.setlocale(locale.LC_ALL, 'C.UTF-8')
+except (ValueError, UnicodeError):
+    locale.setlocale(locale.LC_ALL, 'en_US.UTF-8')


### PR DESCRIPTION
Sometimes docker images have locale problem.
I found that `locale.getlocale()` can
return (None, None).
So I fixed that when it return (None, None) then setlocale for it.
* setup.py: Catch (None, None) locale
* tests/__init__.py: Catch (None, None) locale

Fixes https://github.com/coala/coala/issues/3906

<!--
Thanks for your contribution!

Please take a quick look at those things down there. They're quite important.
Really! We wrote them for you. Yes you! With utmost care. Read them.
-->

**For short term contributors:** we understand that getting your commits well
defined like we require is a hard task and takes some learning. If you
look to help without wanting to contribute long term there's no need
for you to learn this. Just drop us a message and we'll take care of brushing
up your stuff for merge!

### Checklist

- [x] I read the [commit guidelines](http://coala.io/commit) and I've followed
      them.
- [x] I ran coala over my code locally. (*All commits have to pass
      individually.* It is not sufficient to have "fixup commits" on your PR,
      our bot will still report the issues for the previous commit.) You will
      likely receive a lot of bot comments and build failures if coala does not
      pass on every single commit!

After you submit your pull request, **DO NOT click the 'Update Branch' button.**
When asked for a rebase, consult [coala.io/rebase](https://coala.io/rebase)
instead.

Please consider helping us by reviewing other peoples pull requests as well:

- pick up any PR at <https://coala.io/review>
- review it (check <https://coala.io/reviewing> for more info)
- if you are sure that it needs work, use `cobot mark wip <URL>` to get it out
  of the review queue.

The more you review, the more your score will grow at coala.io and we will
review your PRs faster!
