### PR TITLE
TasteTest.py: Add missing field

### DIFF
--- a/tests/bearlib/aspects/TasteTest.py
+++ b/tests/bearlib/aspects/TasteTest.py
@@ -1,5 +1,6 @@
 from coalib.bearlib.aspects import Taste
 from coalib.bearlib.aspects.taste import TasteMeta
+from coalib.bearlib.languages import Languages
 
 
 class TasteTest:
@@ -17,6 +18,10 @@ class TasteTest:
         assert taste.description is ''
         assert taste.suggested_values is ()
         assert taste.default is None
+        assert type(taste.languages) is Languages
+        assert not taste.languages
+        assert not len(taste.languages)
+        assert taste.languages == ()
 
     def test__get__(
             self, SubAspect, SubAspect_tastes, SubAspect_taste_values):


### PR DESCRIPTION
taste.languages field was added to test_init_defaults function

Fixes https://github.com/coala/coala/issues/3929