### PR TITLE
Shell.py: Add missing function

### DIFF
--- a/coalib/misc/Shell.py
+++ b/coalib/misc/Shell.py
@@ -46,6 +46,10 @@ class ShellCommandResult(tuple):
         self.code = code
 
 
+def call_without_output(command):
+    run(' '.join(command), stdout=Capture(), stderr=Capture())
+
+
 @contextmanager
 def run_interactive_shell_command(command, **kwargs):
     """


### PR DESCRIPTION
Function call_without_output was added to Shell.py
which was found missing during cib installation

Fixes https://github.com/coala/coala/issues/3940