### PR TITLE
Git_Basics.rst: Specify rebasing example's origin

### DIFF
--- a/docs/Developers/Git_Basics.rst
+++ b/docs/Developers/Git_Basics.rst
@@ -253,6 +253,20 @@ local fork going out of sync with the remote repository.
 To sync your changes with the remote repository run the following commands in
 the desired branch:
 
+.. note::
+
+    This assumes that the remote ``origin`` is the original
+    coala repository at https://github.com/coala/coala (or other,
+    like coala/coala-bears, etc.), **not your fork**.
+
+    If you have followed the steps outlined in this guide and cloned
+    the original coala repository, ``origin`` should refer to it.
+    You can proceed to the following section without worry.
+
+    If you're unsure about this, run ``git remote -v`` to check which
+    remote points to the original repository and use that instead
+    of ``origin`` in the following section.
+
 ::
 
     $ git fetch origin


### PR DESCRIPTION
The origin in the rebasing example is not explicitly mentioned to be the
remote of either https://github.com/coala/coala or
https://github.com/coala/coala-bears. This makes it clear what origin
refers to in this context.

Closes: https://github.com/coala/coala/issues/3947

<!--
Thanks for your contribution!

Please take a quick look at those things down there. They're quite important.
Really! We wrote them for you. Yes you! With utmost care. Read them.
-->

**For short term contributors:** we understand that getting your commits well
defined like we require is a hard task and takes some learning. If you
look to help without wanting to contribute long term there's no need
for you to learn this. Just drop us a message and we'll take care of brushing
up your stuff for merge!

### Checklist

- [X] I read the [commit guidelines](http://coala.io/commit) and I've followed
      them.
- [X] I ran coala over my code locally. (*All commits have to pass
      individually.* It is not sufficient to have "fixup commits" on your PR,
      our bot will still report the issues for the previous commit.) You will
      likely receive a lot of bot comments and build failures if coala does not
      pass on every single commit!

After you submit your pull request, **DO NOT click the 'Update Branch' button.**
When asked for a rebase, consult [coala.io/rebase](https://coala.io/rebase)
instead.

Please consider helping us by reviewing other peoples pull requests as well:

- pick up any PR at <https://coala.io/review>
- review it (check <https://coala.io/reviewing> for more info)
- if you are sure that it needs work, use `cobot mark wip <URL>` to get it out
  of the review queue.

The more you review, the more your score will grow at coala.io and we will
review your PRs faster!
