### PR TITLE
appveyor.yml: Use builtin download command

### DIFF
--- a/.misc/appveyor.yml
+++ b/.misc/appveyor.yml
@@ -35,7 +35,7 @@ install:
 
   - "%CMD_IN_ENV% pip install --cache-dir=C:\\pip_cache -r requirements.txt -r test-requirements.txt"
 
-  - curl -fsSL http://llvm.org/releases/%LLVM_VERSION%/LLVM-%LLVM_VERSION%-win32.exe -o LLVM.exe
+  - appveyor DownloadFile http://llvm.org/releases/%LLVM_VERSION%/LLVM-%LLVM_VERSION%-win32.exe -FileName LLVM.exe
   - 7z x LLVM.exe -oC:\LLVM
 
 build: false  # Not a C# project, build stuff at the test step instead.


### PR DESCRIPTION
Use `DownloadFile` instead of curl. The latter seems to
be absent for some reason (even though their docs claim
otherwise).