### PR TITLE
Define bear aspects the magic metaclass way

### DIFF
--- a/coalib/bearlib/abstractions/Linter.py
+++ b/coalib/bearlib/abstractions/Linter.py
@@ -594,7 +594,12 @@ def _create_linter(klass, options):
             return '<{} linter object (wrapping {!r}) at {}>'.format(
                 type(self).__name__, self.get_executable(), hex(id(self)))
 
-    class LocalLinterBase(LinterBase, LocalBear):
+    class LocalLinterMeta(type(LinterBase), type(LocalBear)):
+        """
+        Solving base metaclasses conflict for ``LocalLinterBase``.
+        """
+
+    class LocalLinterBase(LinterBase, LocalBear, metaclass=LocalLinterMeta):
 
         @staticmethod
         def create_arguments(filename, file, config_file):
@@ -616,7 +621,12 @@ def _create_linter(klass, options):
             """
             raise NotImplementedError
 
-    class GlobalLinterBase(LinterBase, GlobalBear):
+    class GlobalLinterMeta(type(LinterBase), type(GlobalBear)):
+        """
+        Solving base metaclasses conflict for ``GlobalLinterBase``.
+        """
+
+    class GlobalLinterBase(LinterBase, GlobalBear, metaclass=GlobalLinterMeta):
 
         @staticmethod
         def create_arguments(config_file):

--- a/coalib/bears/Bear.py
+++ b/coalib/bears/Bear.py
@@ -21,8 +21,10 @@ from coalib.settings.FunctionMetadata import FunctionMetadata
 from coalib.settings.Section import Section
 from coalib.settings.ConfigurationGathering import get_config_directory
 
+from .meta import bearclass
 
-class Bear(Printer, LogPrinterMixin):
+
+class Bear(Printer, LogPrinterMixin, metaclass=bearclass):
     """
     A bear contains the actual subroutine that is responsible for checking
     source code for certain specifications. However it can actually do
@@ -139,6 +141,24 @@ class Bear(Printer, LogPrinterMixin):
     ...     SEE_MORE = 'https://www.pylint.org/'
     >>> PyLintBear.SEE_MORE
     'https://www.pylint.org/'
+
+    In the future, bears will not survive without aspects. aspects are defined
+    as part of the ``class`` statement's parameter list. According to the
+    classic ``CAN_DETECT`` and ``CAN_FIX`` attributes, aspects can either be
+    only ``'detect'``-able or also ``'fix'``-able:
+
+    >>> from coalib.bearlib.aspects.Metadata import CommitMessage
+
+    >>> class aspectsCommitBear(Bear, aspects={
+    ...         'detect': [CommitMessage.Shortlog.ColonExistence],
+    ...         'fix': [CommitMessage.Shortlog.TrailingPeriod],
+    ... }):
+    ...     pass
+
+    >>> aspectsCommitBear.aspects['detect']
+    [<aspectclass 'Root.Metadata.CommitMessage.Shortlog.ColonExistence'>]
+    >>> aspectsCommitBear.aspects['fix']
+    [<aspectclass 'Root.Metadata.CommitMessage.Shortlog.TrailingPeriod'>]
     """
 
     LANGUAGES = set()

--- a/coalib/bears/meta.py
+++ b/coalib/bears/meta.py
@@ -1,0 +1,25 @@
+from collections import defaultdict
+
+
+class bearclass(type):
+    """
+    Metaclass for :class:`coalib.bears.Bear.Bear` and therefore all bear
+    classes.
+
+    Pushing bears into the future... ;)
+    """
+
+    # by default a bear class has no aspects
+    aspects = defaultdict(lambda: [])
+
+    def __new__(mcs, clsname, bases, clsattrs, *varargs, aspects=None):
+        return type.__new__(mcs, clsname, bases, clsattrs, *varargs)
+
+    def __init__(cls, clsname, bases, clsattrs, *varargs, aspects=None):
+        """
+        Initializes the ``.aspects`` dict on new bear classes from the mapping
+        given to the keyword-only `aspects` argument.
+        """
+        type.__init__(cls, clsname, bases, clsattrs, *varargs)
+        if aspects is not None:
+            cls.aspects = defaultdict(lambda: [], aspects)


### PR DESCRIPTION
Implementation for https://github.com/coala/coala-bears/issues/1517

* Following my proposal in https://github.com/coala/coala-bears/pull/1391#discussion_r106233373 - slightly modified from list to dict ;)
* Allowing:

```python
from coalib.bearlib.aspects.Metadata import CommitMessage
```

```python
class SomeAspectsBear(Bear, aspects={
    'detect': [CommitMessage.Shortlog.ColonExistence],
    'fix': [CommitMessage.Shortlog.TrailingPeriod],
 }):
    ...
```

```python
>>> SomeAspectsBear.aspects
{'detect': [<aspectclass 'Root.Metadata.CommitMessage.Shortlog.ColonExistence'>],
 'fix': [<aspectclass 'Root.Metadata.CommitMessage.Shortlog.TrailingPeriod'>]}
```

@sils @Asnelchristian @Techievena @adhikasp @andreiraduta1101 