### PR TITLE
DocstyleDefinitionTest.py: Use assertRaisesRegex

### DIFF
--- a/tests/bearlib/languages/documentation/DocstyleDefinitionTest.py
+++ b/tests/bearlib/languages/documentation/DocstyleDefinitionTest.py
@@ -11,27 +11,27 @@ class DocstyleDefinitionTest(unittest.TestCase):
     dummy_metadata = Metadata(':param ', ':', ':return:')
 
     def test_fail_instantation(self):
-        with self.assertRaises(ValueError):
+        with self.assertRaisesRegex(ValueError, ''):
             DocstyleDefinition('PYTHON', 'doxyGEN',
                                (('##', '#'),), self.dummy_metadata)
 
-        with self.assertRaises(ValueError):
+        with self.assertRaisesRegex(ValueError, ''):
             DocstyleDefinition('WEIRD-PY',
                                'schloxygen',
                                (('##+', 'x', 'y', 'z'),),
                                self.dummy_metadata)
 
-        with self.assertRaises(ValueError):
+        with self.assertRaisesRegex(ValueError, ''):
             DocstyleDefinition('PYTHON',
                                'doxygen',
                                (('##', '', '#'), ('"""', '"""')),
                                self.dummy_metadata)
 
-        with self.assertRaises(TypeError):
+        with self.assertRaisesRegex(TypeError, ''):
             DocstyleDefinition(123, ['doxygen'], (('"""', '"""')),
                                self.dummy_metadata)
 
-        with self.assertRaises(TypeError):
+        with self.assertRaisesRegex(TypeError, ''):
             DocstyleDefinition('language', ['doxygen'], (('"""', '"""')),
                                'metdata')
 
@@ -72,15 +72,15 @@ class DocstyleDefinitionTest(unittest.TestCase):
 
     def test_load(self):
         # Test unregistered docstyle.
-        with self.assertRaises(FileNotFoundError):
+        with self.assertRaisesRegex(FileNotFoundError, ''):
             next(DocstyleDefinition.load('PYTHON', 'INVALID'))
 
         # Test unregistered language in existing docstyle.
-        with self.assertRaises(KeyError):
+        with self.assertRaisesRegex(KeyError, ''):
             next(DocstyleDefinition.load('bake-a-cake', 'default'))
 
         # Test wrong argument type.
-        with self.assertRaises(TypeError):
+        with self.assertRaisesRegex(TypeError, ''):
             next(DocstyleDefinition.load(123, ['list']))
 
         # Test python 3 default configuration and if everything is parsed


### PR DESCRIPTION
Usage of assertRaises was replaced by assertRaisesRegex which has
an extra parameter for exception message

Related to https://github.com/coala/coala/issues/3374

<!--
Thanks for your contribution!

Please take a quick look at those things down there. They're quite important.
Really! We wrote them for you. Yes you! With utmost care. Read them.
-->

**For short term contributors:** we understand that getting your commits well
defined like we require is a hard task and takes some learning. If you
look to help without wanting to contribute long term there's no need
for you to learn this. Just drop us a message and we'll take care of brushing
up your stuff for merge!

### Checklist

- [x] I read the [commit guidelines](http://coala.io/commit) and I've followed
      them.
- [x] I ran coala over my code locally. (*All commits have to pass
      individually.* It is not sufficient to have "fixup commits" on your PR,
      our bot will still report the issues for the previous commit.) You will
      likely receive a lot of bot comments and build failures if coala does not
      pass on every single commit!

After you submit your pull request, **DO NOT click the 'Update Branch' button.**
When asked for a rebase, consult [coala.io/rebase](https://coala.io/rebase)
instead.

Please consider helping us by reviewing other peoples pull requests as well:

- pick up any PR at <https://coala.io/review>
- review it (check <https://coala.io/reviewing> for more info)
- if you are sure that it needs work, use `cobot mark wip <URL>` to get it out
  of the review queue.

The more you review, the more your score will grow at coala.io and we will
review your PRs faster!
