### PR TITLE
DocumentationCommentTest.py: Use assertRaisesRegex

### DIFF
--- a/tests/bearlib/languages/documentation/DocumentationCommentTest.py
+++ b/tests/bearlib/languages/documentation/DocumentationCommentTest.py
@@ -61,7 +61,7 @@ class GeneralDocumentationCommentTest(DocumentationCommentTest):
                                           self.Metadata('', '', ''))
         not_implemented = DocumentationComment(
             'some docs', raw_docstyle, None, None, None)
-        with self.assertRaises(NotImplementedError):
+        with self.assertRaisesRegex(NotImplementedError, ''):
             not_implemented.parse()
 
     def test_from_metadata(self):


### PR DESCRIPTION
Usage of assertRaises was replaced by assertRaisesRegex which has
an extra parameter for exception message

Related to https://github.com/coala/coala/issues/3374