### PR TITLE
bearlib: Add @wraps to wrapping_function

### DIFF
--- a/coalib/bearlib/__init__.py
+++ b/coalib/bearlib/__init__.py
@@ -5,6 +5,7 @@ while offering the best possible flexibility.
 """
 
 import logging
+from functools import wraps
 
 from coalib.settings.FunctionMetadata import FunctionMetadata
 
@@ -98,6 +99,7 @@ def deprecate_settings(**depr_args):
 
         logged_deprecated_args = set()
 
+        @wraps(func)
         def wrapping_function(*args, **kwargs):
             for arg, depr_value in wrapping_function.__metadata__.depr_values:
                 deprecated_arg = depr_value[0]

--- a/tests/bearlib/DeprecateSettingsTest.py
+++ b/tests/bearlib/DeprecateSettingsTest.py
@@ -1,0 +1,17 @@
+import unittest
+
+from coalib.bearlib import deprecate_settings
+
+
+@deprecate_settings(new='old')
+def func(new):
+    """
+    This docstring will not be lost.
+    """
+
+
+class DeprecateSettingsTest(unittest.TestCase):
+
+    def test_docstring(self):
+        self.assertEqual(func.__doc__.strip(),
+                         'This docstring will not be lost.')


### PR DESCRIPTION
@wraps(func) prevents the loss of doc string
of func, which occurs due to the use of
decorator on func.

Fixes https://github.com/coala/coala/issues/3946

<!--
Thanks for your contribution!

Please take a quick look at those things down there. They're quite important.
Really! We wrote them for you. Yes you! With utmost care. Read them.
-->

**For short term contributors:** we understand that getting your commits well
defined like we require is a hard task and takes some learning. If you
look to help without wanting to contribute long term there's no need
for you to learn this. Just drop us a message and we'll take care of brushing
up your stuff for merge!

### Checklist

- [ ] I read the [commit guidelines](http://coala.io/commit) and I've followed
      them.
- [ ] I ran coala over my code locally. (*All commits have to pass
      individually.* It is not sufficient to have "fixup commits" on your PR,
      our bot will still report the issues for the previous commit.) You will
      likely receive a lot of bot comments and build failures if coala does not
      pass on every single commit!

After you submit your pull request, **DO NOT click the 'Update Branch' button.**
When asked for a rebase, consult [coala.io/rebase](https://coala.io/rebase)
instead.

Please consider helping us by reviewing other peoples pull requests as well:

- pick up any PR at <https://coala.io/review>
- review it (check <https://coala.io/reviewing> for more info)
- if you are sure that it needs work, use `cobot mark wip <URL>` to get it out
  of the review queue.

The more you review, the more your score will grow at coala.io and we will
review your PRs faster!
