### PR TITLE
tests/bears/GlobalBearTest.py: Add more tests

### DIFF
--- a/coalib/bears/GlobalBear.py
+++ b/coalib/bears/GlobalBear.py
@@ -4,22 +4,28 @@ from coalib.bears.BEAR_KIND import BEAR_KIND
 
 class GlobalBear(Bear):
     """
-    A GlobalBear is able to analyze semantic facts across several file.
+    A GlobalBear analyzes semantic facts across several files.
 
     The results of a GlobalBear will be presented grouped by the origin Bear.
-    Therefore Results spanning above multiple files are allowed and will be
-    handled right.
+    Therefore Results spanning across multiple files are allowed and will be
+    handled correctly.
 
-    If you only look at one file at once anyway a LocalBear is better for your
-    needs. (And better for performance and usability for both user and
-    developer.)
+    If you are inspecting a single file at a time, you should consider
+    using a LocalBear.
     """
 
     def __init__(self,
-                 file_dict,  # filename : file contents
+                 file_dict,
                  section,
                  message_queue,
                  timeout=0):
+        """
+        Constructs a new GlobalBear.
+
+        :param file_dict: The dictionary of {filename: file contents}.
+
+        See :class:`coalib.bears.Bear` for other parameters.
+        """
         Bear.__init__(self, section, message_queue, timeout)
         self.file_dict = file_dict
 
@@ -34,7 +40,11 @@ class GlobalBear(Bear):
         """
         Handles all files in file_dict.
 
+        :param dependency_results: The dictionary of {bear name:
+                                   result list}.
         :return: A list of Result type.
+
+        See :class:`coalib.bears.Bear` for `run` method description.
         """
         raise NotImplementedError(
             'This function has to be implemented for a runnable bear.')

--- a/tests/bears/GlobalBearTest.py
+++ b/tests/bears/GlobalBearTest.py
@@ -6,9 +6,25 @@ from coalib.settings.Section import Section
 
 class GlobalBearTest(unittest.TestCase):
 
-    def test_api(self):
-        test_object = GlobalBear(0, Section('name'), None)
-        self.assertRaises(NotImplementedError, test_object.run)
+    def test_file_dict(self):
+        file_dict_0 = {
+            'filename1': 'contents1', 'filename2': 'contents2'
+        }
 
-    def test_kind(self):
+        # check that bear does not modify original dictionary
+        file_dict_1 = file_dict_0.copy()
+
+        bear = GlobalBear(file_dict_0, Section(''), None)
+
+        self.assertEqual(bear.file_dict, file_dict_0)
+        self.assertEqual(bear.file_dict, file_dict_1)
+
+    def test_run_raises(self):
+        bear = GlobalBear(None, Section(''), None)
+        self.assertRaises(NotImplementedError, bear.run)
+
+    def test_kind_is_staticmethod(self):
         self.assertEqual(GlobalBear.kind(), BEAR_KIND.GLOBAL)
+
+        bear = GlobalBear(None, Section(''), None)
+        self.assertEqual(bear.kind(), BEAR_KIND.GLOBAL)


### PR DESCRIPTION
In response to https://github.com/coala/coala/issues/3986 I have taken a look at the `GlobalBear` class. It is true that there were just a couple of unit-tests for this class. There is frankly not that much to test: it is an "abstract" class that other bears inherit from and reimpement its methods.

@jayvdb, here is a quick run down of tests that use `GlobalBear`:

1. `processes/BearRunningTest.py` that is all about dependencies between bears and the results of them running successfully/unsuccessfully.
2. `processes/section_executor_test_files/ProcessingGlobalTestBear.py` which is nearly empty and therefore hard for me to understand.
3. `settings/SectionFillingTest.py` which is all about appending/changing settings of bears (so, it is more about the `Settings` class, sections and so on)
4. `bears/BearTest.py` which contains both very broad tests (like [simple api][1]) and very specific tests (a bear [that downloads something with `requests_mock`][2])
5. `bears/GlobalBearTest.py` the file that I ended up modifying.
6. `collecting/collectors_test_dir/bears_local_global` that just has a couple of bears for, presumably, testing the bear-collecting logic.

So, this PR just adds a boring test to `GlobalBearTest.py`. Do you perhaps have some other/more specific test types in mind?

Weakly related question: many tests use the name `uut` for objects being tested. What does it stand for? "Unit Under Test"?

[1]: https://github.com/coala/coala/blob/b586c0a8e1d8417afc06621b20d0115f899e63ee/tests/bears/BearTest.py#L122

[2]: https://github.com/coala/coala/blob/b586c0a8e1d8417afc06621b20d0115f899e63ee/tests/bears/BearTest.py#L291