### PR TITLE
ConfigurationGathering: Add strict mode

### DIFF
--- a/coalib/settings/ConfigurationGathering.py
+++ b/coalib/settings/ConfigurationGathering.py
@@ -53,25 +53,27 @@ def load_config_file(filename, log_printer, silent=False):
                         ``False``.
     """
     filename = os.path.abspath(filename)
-
+    strict = True  # TODO: Remove it (Just for testing purposes)
     try:
         return ConfParser().parse(filename)
     except FileNotFoundError:
         if not silent:
-            if os.path.basename(filename) == Constants.default_coafile:
+            if (not strict) and \
+                    os.path.basename(filename) == Constants.default_coafile:
                 log_printer.warn('The default coafile {0!r} was not found. '
                                  'You can generate a configuration file with '
-                                 'your current options by adding the `--save` '
-                                 'flag or suppress any use of config '
+                                 'your current options by adding the `--save`'
+                                 ' flag or suppress any use of config '
                                  'files with `-I`.'
                                  .format(Constants.default_coafile))
-            else:
+
+            else:  # The strict mode turned on
                 log_printer.err('The requested coafile {0!r} does not exist. '
                                 'You can generate it with your current '
                                 'options by adding the `--save` flag or '
                                 'suppress any use of config files with `-I`.'
                                 .format(filename))
-                sys.exit(2)
+            sys.exit(2)
 
         return {'default': Section('default')}
 


### PR DESCRIPTION
If coala runs with --strict mode, it should throw up an error if
it does not finds a .coafile.

Closes #3987

<!--
Thanks for your contribution!

Please take a quick look at those things down there. They're quite important.
Really! We wrote them for you. Yes you! With utmost care. Read them.
-->

**For short term contributors:** we understand that getting your commits well
defined like we require is a hard task and takes some learning. If you
look to help without wanting to contribute long term there's no need
for you to learn this. Just drop us a message and we'll take care of brushing
up your stuff for merge!

### Checklist

- [X] I read the [commit guidelines](http://coala.io/commit) and I've followed
      them.
- [X] I ran coala over my code locally. (*All commits have to pass
      individually.* It is not sufficient to have "fixup commits" on your PR,
      our bot will still report the issues for the previous commit.) You will
      likely receive a lot of bot comments and build failures if coala does not
      pass on every single commit!

After you submit your pull request, **DO NOT click the 'Update Branch' button.**
When asked for a rebase, consult [coala.io/rebase](https://coala.io/rebase)
instead.

Please consider helping us by reviewing other peoples pull requests as well:

- pick up any PR at <https://coala.io/review>
- review it (check <https://coala.io/reviewing> for more info)
- if you are sure that it needs work, use `cobot mark wip <URL>` to get it out
  of the review queue.

The more you review, the more your score will grow at coala.io and we will
review your PRs faster!
