### PR TITLE
Remove triple backticks from RST

### DIFF
--- a/coalib/bearlib/languages/documentation/DocumentationExtraction.py
+++ b/coalib/bearlib/languages/documentation/DocumentationExtraction.py
@@ -54,13 +54,11 @@ def _extract_doc_comment_continuous(content, line, column, markers):
 
     The property of the continuous layout is that the each-line-marker and the
     end-marker do equal. Documentation is extracted until no further marker is
-    found. Applies e.g. for doxygen style python documentation:
+    found. Applies e.g. for doxygen style python documentation::
 
-    ```
-    ## main
-    #
-    #  detailed
-    ```
+        ## main
+        #
+        #  detailed
 
     :param content: Presplitted lines of the source-code-string.
     :param line:    Line where the documentation comment starts (behind the
@@ -100,13 +98,11 @@ def _extract_doc_comment_standard(content, line, column, markers):
     Extract a documentation that starts at given beginning with standard
     layout.
 
-    The standard layout applies e.g. for C doxygen-style documentation:
+    The standard layout applies e.g. for C doxygen-style documentation::
 
-    ```
-    /**
-     * documentation
-     */
-    ```
+        /**
+         * documentation
+         */
 
     :param content: Presplitted lines of the source-code-string.
     :param line:    Line where the documentation comment starts (behind the

--- a/coalib/misc/BuildManPage.py
+++ b/coalib/misc/BuildManPage.py
@@ -30,7 +30,7 @@ class BuildManPage(Command):
             --parser=coalib.parsing.DefaultArgParser:default_arg_parser
 
     If automatically want to build the man page every time you invoke
-    your build, add to your ```setup.cfg``` the following::
+    your build, add to your ``setup.cfg`` the following::
 
         [build_manpage]
         output = <appname>.1


### PR DESCRIPTION
Triple backticks are not RST syntax, resulting in literal backticks
in the output generated by Sphinx.

Fixes https://github.com/coala/coala/issues/4012

<!--
Thanks for your contribution!

Please take a quick look at those things down there. They're quite important.
Really! We wrote them for you. Yes you! With utmost care. Read them.
-->

**For short term contributors:** we understand that getting your commits well
defined like we require is a hard task and takes some learning. If you
look to help without wanting to contribute long term there's no need
for you to learn this. Just drop us a message and we'll take care of brushing
up your stuff for merge!

### Checklist

- [ ] I read the [commit guidelines](http://coala.io/commit) and I've followed
      them.
- [ ] I ran coala over my code locally. (*All commits have to pass
      individually.* It is not sufficient to have "fixup commits" on your PR,
      our bot will still report the issues for the previous commit.) You will
      likely receive a lot of bot comments and build failures if coala does not
      pass on every single commit!

After you submit your pull request, **DO NOT click the 'Update Branch' button.**
When asked for a rebase, consult [coala.io/rebase](https://coala.io/rebase)
instead.

Please consider helping us by reviewing other peoples pull requests as well:

- pick up any PR at <https://coala.io/review>
- review it (check <https://coala.io/reviewing> for more info)
- if you are sure that it needs work, use `cobot mark wip <URL>` to get it out
  of the review queue.

The more you review, the more your score will grow at coala.io and we will
review your PRs faster!
