### PR TITLE
ConsoleInteraction.py: Typo in docstring 

### DIFF
--- a/coalib/output/ConsoleInteraction.py
+++ b/coalib/output/ConsoleInteraction.py
@@ -231,7 +231,7 @@ def print_result(console_printer,
     :param result:          A derivative of Result.
     :param file_dict:       A dictionary containing all files with filename as
                             key.
-    :param interactive:     Variable to check wether or not to
+    :param interactive:     Variable to check whether or not to
                             offer the user actions interactively.
     """
     no_color = not console_printer.print_colored


### PR DESCRIPTION
ConsoleInteraction.print_result: Fix docstring

Fixes https://github.com/coala/coala/issues/4018