### PR TITLE
coala.py: Format the output of CI mode when both --format and --ci are used

### DIFF
--- a/coalib/coala.py
+++ b/coalib/coala.py
@@ -71,6 +71,9 @@ def main():
     except BaseException as exception:  # pylint: disable=broad-except
         return get_exitcode(exception, log_printer)
 
+    if args.non_interactive and args.format:
+        return mode_format()
+
     if args.non_interactive:
         return mode_non_interactive(console_printer, args)
 

--- a/tests/coalaFormatTest.py
+++ b/tests/coalaFormatTest.py
@@ -37,3 +37,19 @@ class coalaFormatTest(unittest.TestCase):
                              'coala-format must return exitcode 1 when it '
                              'yields results')
             self.assertFalse(stderr)
+            
+    def test_format_ci_combination(self):
+        with bear_test_module(), \
+                prepare_file(['#fixme'], None) as (lines, filename):
+            retval, stdout, stderr = execute_coala(coala.main, 'coala',
+                                                   '--format', '--ci', '-c',
+                                                   os.devnull, '-f',
+                                                   re.escape(filename),
+                                                   '-b', 'LineCountTestBear')
+            self.assertRegex(stdout, r'message:This file has [0-9]+ lines.',
+                             'coala --format --ci output for line count should '
+                             'not be empty')
+            self.assertEqual(retval, 1,
+                             'coala --format --ci must return exitcode 1 when it '
+                             'yields results')
+            self.assertFalse(stderr)


### PR DESCRIPTION
Checks if both --format and --ci args are given
and combines them by formatting CI's output.

Closes https://github.com/coala/coala/issues/3999

<!--
Thanks for your contribution!

Please take a quick look at those things down there. They're quite important.
Really! We wrote them for you. Yes you! With utmost care. Read them.
-->

**For short term contributors:** we understand that getting your commits well
defined like we require is a hard task and takes some learning. If you
look to help without wanting to contribute long term there's no need
for you to learn this. Just drop us a message and we'll take care of brushing
up your stuff for merge!

### Checklist

- [ ] I read the [commit guidelines](http://coala.io/commit) and I've followed
      them.
- [ ] I ran coala over my code locally. (*All commits have to pass
      individually.* It is not sufficient to have "fixup commits" on your PR,
      our bot will still report the issues for the previous commit.) You will
      likely receive a lot of bot comments and build failures if coala does not
      pass on every single commit!

After you submit your pull request, **DO NOT click the 'Update Branch' button.**
When asked for a rebase, consult [coala.io/rebase](https://coala.io/rebase)
instead.

Please consider helping us by reviewing other peoples pull requests as well:

- pick up any PR at <https://coala.io/review>
- review it (check <https://coala.io/reviewing> for more info)
- if you are sure that it needs work, use `cobot mark wip <URL>` to get it out
  of the review queue.

The more you review, the more your score will grow at coala.io and we will
review your PRs faster!
