### PR TITLE
aspects: Create aspectlist

### DIFF
--- a/coalib/bearlib/aspects/collections.py
+++ b/coalib/bearlib/aspects/collections.py
@@ -1,0 +1,22 @@
+from coalib.bearlib.aspects import aspectclass, aspectbase
+from coalib.bearlib.aspects.meta import issubaspect
+
+
+class aspectlist(list):
+    """
+    List-derived container to hold aspects.
+    """
+
+    def __init__(self, seq=()):
+        for item in seq:
+            if not isinstance(item, (aspectclass, aspectbase)):
+                raise TypeError(
+                    '{} is not an aspectclass or an instance of an '
+                    'aspectclass'.format(repr(item)))
+        list.__init__(self, seq)
+
+    def __contains__(self, aspect):
+        for item in self:
+            if issubaspect(aspect, item):
+                return True
+        return False

--- a/coalib/bears/meta.py
+++ b/coalib/bears/meta.py
@@ -1,5 +1,7 @@
 from collections import defaultdict
 
+from coalib.bearlib.aspects.collections import aspectlist
+
 
 class bearclass(type):
     """
@@ -10,7 +12,7 @@ class bearclass(type):
     """
 
     # by default a bear class has no aspects
-    aspects = defaultdict(lambda: [])
+    aspects = defaultdict(lambda: aspectlist([]))
 
     def __new__(mcs, clsname, bases, clsattrs, *varargs, aspects=None):
         return type.__new__(mcs, clsname, bases, clsattrs, *varargs)
@@ -22,4 +24,6 @@ class bearclass(type):
         """
         type.__init__(cls, clsname, bases, clsattrs, *varargs)
         if aspects is not None:
-            cls.aspects = defaultdict(lambda: [], aspects)
+            cls.aspects = defaultdict(
+                lambda: aspectlist([]),
+                ((k, aspectlist(v)) for (k, v) in dict(aspects).items()))

--- a/tests/bearlib/aspects/CollectionsTest.py
+++ b/tests/bearlib/aspects/CollectionsTest.py
@@ -1,0 +1,31 @@
+import pytest
+
+from coalib.bearlib.aspects.collections import aspectlist
+from coalib.bearlib.aspects.Metadata import Metadata
+
+
+class aspectlistTest:
+
+    def test__init__(self):
+        with pytest.raises(TypeError) as exc:
+            aspectlist(['String'])
+        exc.match("'String' is not an aspectclass or "
+                  'an instance of an aspectclass')
+
+    def test__contains__(self):
+        list_of_aspect = aspectlist(
+            [Metadata.CommitMessage.Shortlog, Metadata.CommitMessage.Body])
+        assert Metadata.CommitMessage.Shortlog in list_of_aspect
+        assert Metadata.CommitMessage.Shortlog.ColonExistence in list_of_aspect
+        assert Metadata.CommitMessage.Body in list_of_aspect
+        assert Metadata not in list_of_aspect
+        assert Metadata.CommitMessage.Emptiness not in list_of_aspect
+
+        with pytest.raises(TypeError) as exc:
+            'Metadata.CommitMessage.Shortlog' in list_of_aspect
+        exc.match("'Metadata.CommitMessage.Shortlog' is not an "
+                  'aspectclass or an instance of an aspectclass')
+        with pytest.raises(TypeError) as exc:
+            str in list_of_aspect
+        exc.match("<class 'str'> is not an "
+                  'aspectclass or an instance of an aspectclass')

--- a/tests/bears/BearTest.py
+++ b/tests/bears/BearTest.py
@@ -9,6 +9,7 @@ from time import sleep
 import requests
 import requests_mock
 
+from coalib.bearlib.aspects.collections import aspectlist
 from coalib.bearlib.aspects.Metadata import CommitMessage
 from coalib.bears.Bear import Bear
 from coalib.bears.BEAR_KIND import BEAR_KIND
@@ -142,26 +143,42 @@ class BearTest(BearTestBase):
 
     def test_default_aspects(self):
         assert type(Bear.aspects) is defaultdict
+        assert type(Bear.aspects['detect']) is aspectlist
+        assert type(Bear.aspects['fix']) is aspectlist
         assert Bear.aspects['detect'] == Bear.aspects['fix'] == []
 
     def test_no_fix_aspects(self):
         assert type(aspectsDetectOnlyTestBear.aspects) is defaultdict
+        assert type(aspectsDetectOnlyTestBear.aspects['detect']) is aspectlist
+        assert type(aspectsDetectOnlyTestBear.aspects['fix']) is aspectlist
         assert aspectsDetectOnlyTestBear.aspects['fix'] == []
         assert (aspectsDetectOnlyTestBear.aspects['detect'] ==
                 [CommitMessage.Shortlog.ColonExistence])
+        assert (CommitMessage.Shortlog.ColonExistence in
+                aspectsDetectOnlyTestBear.aspects['detect'])
 
     def test_no_detect_aspects(self):
         assert type(aspectsFixOnlyTestBear.aspects) is defaultdict
+        assert type(aspectsFixOnlyTestBear.aspects['detect']) is aspectlist
+        assert type(aspectsFixOnlyTestBear.aspects['fix']) is aspectlist
         assert aspectsFixOnlyTestBear.aspects['detect'] == []
         assert (aspectsFixOnlyTestBear.aspects['fix'] ==
                 [CommitMessage.Shortlog.TrailingPeriod])
+        assert (CommitMessage.Shortlog.TrailingPeriod in
+                aspectsFixOnlyTestBear.aspects['fix'])
 
     def test_detect_and_fix_aspects(self):
         assert type(aspectsTestBear.aspects) is defaultdict
+        assert type(aspectsTestBear.aspects['detect']) is aspectlist
+        assert type(aspectsTestBear.aspects['fix']) is aspectlist
         assert aspectsTestBear.aspects == {
             'detect': [CommitMessage.Shortlog.ColonExistence],
             'fix': [CommitMessage.Shortlog.TrailingPeriod],
         }
+        assert (CommitMessage.Shortlog.ColonExistence in
+                aspectsTestBear.aspects['detect'])
+        assert (CommitMessage.Shortlog.TrailingPeriod in
+                aspectsTestBear.aspects['fix'])
 
     def test_simple_api(self):
         self.assertRaises(TypeError, TestBear, self.settings, 2)


### PR DESCRIPTION
Create ``list``-derived ``aspectslist`` class to be used as value type 
for the ``Bear.aspects`` dictionary.

Closes https://github.com/coala/coala/issues/4054

@coala/aspects-developers 