### PR TITLE
Wrap aspects module for fancy aspect lookup

### DIFF
--- a/coalib/bearlib/aspects/root.py
+++ b/coalib/bearlib/aspects/root.py
@@ -1,0 +1,110 @@
+from .base import aspectbase
+from .meta import aspectclass
+
+
+class Root(aspectbase, metaclass=aspectclass):
+    """
+    The root aspectclass.
+
+    Define sub-aspectclasses with class-bound ``.subaspect`` decorator.
+    Definition string is taken from doc-string of decorated class.
+    Remaining docs are taken from a nested ``docs`` class.
+    Tastes are defined as class attributes that are instances of
+    :class:`coalib.bearlib.aspects.Taste`.
+
+    >>> from coalib.bearlib.aspects import Taste
+
+    >>> @Root.subaspect
+    ... class Formatting:
+    ...     \"""
+    ...     A parent aspect for code formatting aspects...
+    ...     \"""
+
+    We can now create subaspects like this:
+
+    >>> @Formatting.subaspect
+    ... class LineLength:
+    ...     \"""
+    ...     This aspect controls the length of a line...
+    ...     \"""
+    ...     class docs:
+    ...        example = "..."
+    ...        example_language = "..."
+    ...        importance_reason = "..."
+    ...        fix_suggestions = "..."
+    ...
+    ...     max_line_length = Taste[int](
+    ...         "Maximum length allowed for a line.",
+    ...         (80, 90, 120), default=80)
+
+    The representation will show the full "path" to the leaf of the tree:
+
+    >>> Root.Formatting.LineLength
+    <aspectclass 'Root.Formatting.LineLength'>
+
+    We can see, which settings are availables:
+
+    >>> Formatting.tastes
+    {}
+    >>> LineLength.tastes
+    {'max_line_length': <....Taste[int] object at ...>}
+
+    And instantiate the aspect with the values, they will be automatically
+    converted:
+
+    >>> Formatting('Python')
+    <....Root.Formatting object at 0x...>
+    >>> LineLength('Python', max_line_length="100").tastes
+    {'max_line_length': 100}
+
+    If no settings are given, the defaults will be taken:
+
+    >>> LineLength('Python').tastes
+    {'max_line_length': 80}
+
+    Tastes can also be made available for only specific languages:
+
+    >>> from coalib.bearlib.languages import Language
+    >>> @Language
+    ... class GreaterTrumpScript:
+    ...     pass
+
+    >>> @Formatting.subaspect
+    ... class Greatness:
+    ...     \"""
+    ...     This aspect controls the greatness of a file...
+    ...     \"""
+    ...
+    ...     min_greatness = Taste[int](
+    ...         "Minimum greatness factor needed for a TrumpScript file. "
+    ...         "This is fact.",
+    ...         (1000000, 1000000000, 1000000000000), default=1000000,
+    ...         languages=('GreaterTrumpScript' ,))
+
+    >>> Greatness.tastes
+    {'min_greatness': <....Taste[int] object at ...>}
+    >>> Greatness('GreaterTrumpScript').tastes
+    {'min_greatness': 1000000}
+    >>> Greatness('GreaterTrumpScript', min_greatness=1000000000000).tastes
+    {'min_greatness': 1000000000000}
+
+    >>> Greatness('Python').tastes
+    {}
+
+    >>> Greatness('Python', min_greatness=1000000000)
+    ... # doctest: +NORMALIZE_WHITESPACE
+    Traceback (most recent call last):
+      ...
+    coalib.bearlib.aspects.taste.TasteError:
+    Root.Formatting.Greatness.min_greatness is not available ...
+
+    >>> Greatness('Python').min_greatness
+    ... # doctest: +NORMALIZE_WHITESPACE
+    Traceback (most recent call last):
+      ...
+    coalib.bearlib.aspects.taste.TasteError:
+    Root.Formatting.Greatness.min_greatness is not available ...
+    """
+    parent = None
+
+    _tastes = {}

--- a/tests/bearlib/aspects/ModuleTest.py
+++ b/tests/bearlib/aspects/ModuleTest.py
@@ -1,0 +1,48 @@
+from types import ModuleType
+
+import coalib.bearlib.aspects
+
+import pytest
+
+
+class aspectsModuleTest:
+
+    def test_module(self):
+        # check that module is correctly wrapped
+        assert isinstance(coalib.bearlib.aspects, ModuleType)
+        assert type(coalib.bearlib.aspects) is not ModuleType
+        assert (type(coalib.bearlib.aspects) is
+                coalib.bearlib.aspects.aspectsModule)
+
+    def test__getitem__(self):
+        # check a leaf aspect
+        for aspectname in ['aspectsYEAH', 'spelling.aspectsYEAH',
+                           'root.SPELLING.aspectsYEAH']:
+            assert (coalib.bearlib.aspects[aspectname] is
+                    coalib.bearlib.aspects.Root.Spelling.aspectsYEAH)
+        # check a container aspect
+        for aspectname in ['Spelling', 'SPELLING', 'ROOT.spelling']:
+            assert (coalib.bearlib.aspects[aspectname] is
+                    coalib.bearlib.aspects.Root.Spelling)
+        # check root aspect
+        for aspectname in ['Root', 'root', 'ROOT']:
+            assert (coalib.bearlib.aspects[aspectname] is
+                    coalib.bearlib.aspects.Root)
+
+    def test__getitem__no_match(self):
+        for aspectname in ['noaspect', 'NOASPECT', 'Root.aspectsYEAH']:
+            with pytest.raises(LookupError) as exc:
+                coalib.bearlib.aspects[aspectname]
+            exc.match(r"^no aspect named '%s'$" % aspectname)
+
+    def test__getitem__multi_match(self):
+        for aspectname in ['Length', 'length', 'LENGTH']:
+            with pytest.raises(LookupError) as exc:
+                coalib.bearlib.aspects[aspectname]
+            exc.match(r"^multiple aspects named '%s'. " % aspectname +
+                      r'choose from '
+                      r'\[<aspectclass'
+                      r" 'Root.Metadata.CommitMessage.Body.Length'>,"
+                      r' <aspectclass'
+                      r" 'Root.Metadata.CommitMessage.Shortlog.Length'>"
+                      r'\]$')


### PR DESCRIPTION
Closes #4058 with some magic... Just like the Pythonic aspects playground deserves it ;) 

Allowing to directly index the `aspects` module for case-insensitively looking up an aspect by name:

```python
>>> import coalib.bearlib.aspects

>>> coalib.bearlib.aspects['Metadata']
<aspectclass 'Root.Metadata'>

>>> coalib.bearlib.aspects['commitmessage']
<aspectclass 'Root.Metadata.CommitMessage'>

>>> coalib.bearlib.aspects['shortlog.colonExistence']
<aspectclass 'Root.Metadata.CommitMessage.Shortlog.ColonExistence'>
```

When migrating to a separate **coala-aspects** project as proposed in #4038 , the above will further simplify to:

```python
>>> import coala_aspects

>>> coala_aspects['Metadata']
<aspectclass 'Root.Metadata'>

>>> coala_aspects['commitmessage']
<aspectclass 'Root.Metadata.CommitMessage'>

>>> coala_aspects['shortlog.colonExistence']
<aspectclass 'Root.Metadata.CommitMessage.Shortlog.ColonExistence'>
```

@coala/aspects-developers 