### PR TITLE
LinterTest: Run test_process_directory on Windows

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -28,6 +28,7 @@ addopts =
     --doctest-ignore-import-error
     -r a
     --ignore=tests/collecting/collectors_test_dir/bears/incorrect_bear.py
+    --error-for-skips
     --cov
 reqsfilenamepatterns =
     requirements.txt

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -7,6 +7,7 @@ freezegun~=0.3.9
 pytest~=3.1.1
 pytest-cov~=2.2
 pytest-env~=0.6.0
+pytest-error-for-skips~=1.0
 pytest-instafail~=0.3.0
 pytest-mock~=1.1
 pytest-reorder~=0.1.0

--- a/tests/bearlib/abstractions/LinterTest.py
+++ b/tests/bearlib/abstractions/LinterTest.py
@@ -5,7 +5,6 @@ import re
 import sys
 import unittest
 from unittest.mock import ANY, Mock
-from unittest.case import skipIf
 
 from coalib.bearlib.abstractions.Linter import linter
 from coalib.results.Diff import Diff
@@ -13,6 +12,8 @@ from coalib.results.Result import Result
 from coalib.results.RESULT_SEVERITY import RESULT_SEVERITY
 from coalib.results.SourceRange import SourceRange
 from coalib.settings.Section import Section
+
+WINDOWS = platform.system() == 'Windows'
 
 
 def get_testfile_name(name):
@@ -38,15 +39,18 @@ class LinterComponentTest(unittest.TestCase):
 
     class RootDirTestLinter:
 
+        ROOT_DIR = 'C:\\' if WINDOWS else '/'
+        WRONG_DIR_MSG = ('The linter doesn\'t run the command in '
+                         'the right directory!')
+
         def create_arguments(self, *args, **kwargs):
-            return tuple()
+            return ('/c', 'cd') if WINDOWS else tuple()
 
         def get_config_dir(self):
             return '/'
 
         def process_output(self, output, *args, **kwargs):
-            assert output == '/\n', ("The linter doesn't run the command in "
-                                     'the right directory!')
+            assert output == '{}\n'.format(self.ROOT_DIR), self.WRONG_DIR_MSG
 
     class ManualProcessingTestLinter:
 
@@ -727,15 +731,12 @@ class LinterComponentTest(unittest.TestCase):
             '<ManualProcessingTestLinter linter object \\(wrapping ' +
             re.escape(repr(sys.executable)) + '\\) at 0x[a-fA-F0-9]+>')
 
-    @skipIf(platform.system() == 'Windows',
-            '`pwd` does not exist in Windows-cmd and `cd` is a built-in '
-            'command which fails the executable-existence check from @linter.')
     def test_process_directory(self):
         """
         The linter shall run the process in the right directory so tools can
         use the current working directory to resolve import like things.
         """
-        uut = (linter('pwd')
+        uut = (linter('cmd' if WINDOWS else 'pwd')
                (self.RootDirTestLinter)
                (self.section, None))
         uut.run('', [])  # Does an assert in the output processing


### PR DESCRIPTION
`LinterTest.test_process_directory` is the last test that is skipped
on Appveyor CI.  It was unnecessarily avoided on Windows as `pwd`
isnt commonly found on Windows, but it can be installed.

Activate pytest-error-for-skips to prevent new platform specific
test methods being introduced.

Related to https://github.com/coala/coala/issues/3715