### PR TITLE
.travis.yml: Escape script after unsupported check

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,8 +28,6 @@ addons:
 
 before_install:
   - if [[ $TRAVIS_OS_NAME == osx ]]; then TRAVIS_PYTHON_VERSION=3.5; fi
-  - export TRAVIS_PYTHON_VERSION_MAJOR=${TRAVIS_PYTHON_VERSION%.[0-9]}
-  - export TRAVIS_PYTHON_VERSION_MINOR=${TRAVIS_PYTHON_VERSION#[0-9].}
 
   - >
     if [[ $TRAVIS_OS_NAME == osx ]]; then
@@ -62,22 +60,22 @@ before_script:
 
 script:
   - >
-    if [[ $TRAVIS_PYTHON_VERSION_MINOR < 4 || $TRAVIS_PYTHON_VERSION_MAJOR == 2 ]]; then
+    if [[ "$UNSUPPORTED" == true ]]; then
       coverage run setup.py install | grep -q 'coala supports only python 3.4 or later'
-    else
-      set -e
-      bash .misc/tests.sh
-      python setup.py bdist_wheel
-      pip install ./dist/coala-*.whl
-      pip install coala-bears[alldeps] --pre -U
-      # https://github.com/coala/coala-bears/issues/1037
-      if [[ "$TRAVIS_PULL_REQUEST" != "false" ]]; then
-        sed -i.bak '/bears = GitCommitBear/d' .coafile
-      fi
-      coala --non-interactive
-      make -C docs clean
-      python setup.py docs
     fi
+  - if [[ "$UNSUPPORTED" == true ]]; then codecov || true; exit; fi
+  - bash .misc/tests.sh
+  - python setup.py bdist_wheel
+  - pip install ./dist/coala-*.whl
+  - pip install coala-bears[alldeps] --pre -U
+  # https://github.com/coala/coala-bears/issues/1037
+  - >
+    if [[ "$TRAVIS_PULL_REQUEST" != "false" ]]; then
+      sed -i.bak '/bears = GitCommitBear/d' .coafile
+    fi
+  - coala --non-interactive
+  - make -C docs clean
+  - python setup.py docs
   - codecov
 
 notifications:


### PR DESCRIPTION
Add an ``exit`` if UNSUPPORTED==true, and move the other
commands up to the top level of script block.

Follows style of https://github.com/coala/coala-bears/commit/a0f258e