### PR TITLE
docstyle: Add docstlye definition for Golang

### DIFF
--- a/coalib/bearlib/languages/definitions/Golang.py
+++ b/coalib/bearlib/languages/definitions/Golang.py
@@ -1,0 +1,12 @@
+from coalib.bearlib.languages.Language import Language
+
+
+@Language
+class Golang:
+    extensions = '.go',
+    comment_delimiter = '//'
+    multiline_comment_delimiters = {'/*': '*/'}
+    string_delimiters = {'"': '"'}
+    multiline_string_delimiters = {'`': '`'}
+    indent_types = {'{': '}'}
+    encapsulators = {'(': ')', '[': ']'}

--- a/coalib/bearlib/languages/documentation/DocumentationComment.py
+++ b/coalib/bearlib/languages/documentation/DocumentationComment.py
@@ -76,6 +76,9 @@ class DocumentationComment:
         elif self.language == 'java' and self.docstyle == 'default':
             return self._parse_documentation_with_symbols(
                 ('@param  ', ' '), '@return ')
+        elif self.language == 'golang' and self.docstyle == 'golang':
+            # golang does not have param, return markers
+            return self.documentation.splitlines(keepends=True)
         else:
             raise NotImplementedError(
                 'Documentation parsing for {0.language!r} in {0.docstyle!r}'

--- a/coalib/bearlib/languages/documentation/golang.coalang
+++ b/coalib/bearlib/languages/documentation/golang.coalang
@@ -1,0 +1,3 @@
+[golang]
+doc-marker1 = //\ , //\ , //\ # a space
+doc-marker2 = /*, , */

--- a/tests/bearlib/languages/documentation/DocumentationCommentTest.py
+++ b/tests/bearlib/languages/documentation/DocumentationCommentTest.py
@@ -194,6 +194,25 @@ class JavaDocumentationCommentTest(DocumentationCommentTest):
         self.assertEqual(expected, parsed_docs)
 
 
+class GoDocumentationCommentTest(DocumentationCommentTest):
+
+    def test_go_default(self):
+        data = load_testdata('default.go')
+
+        parsed_docs = [doc.parse() for doc in
+                       extract_documentation(data, 'golang', 'golang')]
+
+        expected = [['\n',
+                     'Comments may span\n',
+                     'multiple lines\n'],
+                    ['A class comment\n',
+                     'that also spans\n',
+                     'multiple lines\n'],
+                    ['More documentation for everyone, but in one line\n']]
+
+        self.assertEqual(expected, parsed_docs)
+
+
 class DocumentationAssemblyTest(unittest.TestCase):
 
     def test_python_assembly(self):

--- a/tests/bearlib/languages/documentation/documentation_extraction_testdata/default.go
+++ b/tests/bearlib/languages/documentation/documentation_extraction_testdata/default.go
@@ -1,0 +1,21 @@
+/*
+Comments may span
+multiple lines
+*/
+package main
+
+import (
+    "fmt"
+)
+
+// A class comment
+// that also spans
+// multiple lines
+type Result struct {
+    code int
+}
+
+// More documentation for everyone, but in one line
+func main() {
+    fmt.Println(Result{code: 200})
+}


### PR DESCRIPTION
This is not entirely conformant to the code style convetions laid out by golang. Comments that have an empty line after the comment should *not* qualify as doc comments. However, we don't have the methods to check for stuff like that.

Closes https://github.com/coala/coala/issues/4068