### PR TITLE
test-requirements.txt: Add argcomplete

### DIFF
--- a/coalib/parsing/DefaultArgParser.py
+++ b/coalib/parsing/DefaultArgParser.py
@@ -230,11 +230,12 @@ To run coala without user interaction, run the `coala --non-interactive`,
         '-n', '--no-orig', const=True, action='store_const',
         help="don't create .orig backup files before patching")
 
-    try:  # pragma: no cover
+    try:
         # Auto completion should be optional, because of somewhat complicated
         # setup.
         import argcomplete
         argcomplete.autocomplete(arg_parser)
-    except ImportError:
+    except ImportError:  # pragma: no cover
         pass
+
     return arg_parser

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,3 +1,4 @@
+argcomplete~=1.8
 coverage~=4.3.4
 codecov~=2.0.5
 pytest~=3.0


### PR DESCRIPTION
Adding argcomplete to test-requirements.txt allows simple
compatibility testing with argcomplete.

Closes https://github.com/coala/coala/issues/4163
