### PR TITLE
LocalBearTestHelper: Remove pragma: no cover

### DIFF
--- a/coalib/testing/LocalBearTestHelper.py
+++ b/coalib/testing/LocalBearTestHelper.py
@@ -26,7 +26,7 @@ def execute_bear(bear, *args, **kwargs):
     return list(bear_output_generator)
 
 
-class LocalBearTestHelper(unittest.TestCase):  # pragma: no cover
+class LocalBearTestHelper(unittest.TestCase):
     """
     This is a helper class for simplification of testing of local bears.
 

--- a/coalib/testing/LocalBearTestHelper.py
+++ b/coalib/testing/LocalBearTestHelper.py
@@ -57,6 +57,16 @@ class LocalBearTestHelper(unittest.TestCase):  # pragma: no cover
         :param create_tempfile:  Whether to save lines in tempfile if needed.
         :param tempfile_kwargs:  Kwargs passed to tempfile.mkstemp().
         """
+        if valid:
+            self.check_results(local_bear, lines,
+                               results=[], filename=filename,
+                               check_order=True,
+                               force_linebreaks=force_linebreaks,
+                               create_tempfile=create_tempfile,
+                               tempfile_kwargs=tempfile_kwargs
+                               )
+            return
+
         assert isinstance(self, unittest.TestCase)
         self.assertIsInstance(local_bear,
                               LocalBear,
@@ -70,14 +80,9 @@ class LocalBearTestHelper(unittest.TestCase):  # pragma: no cover
                           create_tempfile=create_tempfile,
                           tempfile_kwargs=tempfile_kwargs) as (file, fname), \
                 execute_bear(local_bear, fname, file) as bear_output:
-            if valid:
-                msg = ("The local bear '{}' yields a result although it "
-                       "shouldn't.".format(local_bear.__class__.__name__))
-                self.assertEqual(bear_output, [], msg=msg)
-            else:
-                msg = ("The local bear '{}' yields no result although it "
-                       'should.'.format(local_bear.__class__.__name__))
-                self.assertNotEqual(len(bear_output), 0, msg=msg)
+            msg = ("The local bear '{}' yields no result although it "
+                   'should.'.format(local_bear.__class__.__name__))
+            self.assertNotEqual(len(bear_output), 0, msg=msg)
             return bear_output
 
     def check_results(self,
@@ -117,15 +122,22 @@ class LocalBearTestHelper(unittest.TestCase):  # pragma: no cover
                               list,
                               msg='The given results are not a list.')
 
+        if results in [[], ()]:
+            msg = ("The local bear '{}' yields a result although it "
+                   "shouldn't.".format(local_bear.__class__.__name__))
+            check_order = True
+        else:
+            msg = ("The local bear '{}' doesn't yield the right results."
+                   .format(local_bear.__class__.__name__))
+            if check_order:
+                msg += ' Or the order may be wrong.'
+
         with prepare_file(lines, filename,
                           force_linebreaks=force_linebreaks,
                           create_tempfile=create_tempfile,
                           tempfile_kwargs=tempfile_kwargs) as (file, fname), \
                 execute_bear(local_bear, fname, file,
                              **settings) as bear_output:
-            msg = ("The local bear '{}' doesn't yield the right results. Or "
-                   'the order may be wrong.'
-                   .format(local_bear.__class__.__name__))
             if not check_order:
                 self.assertEqual(sorted(bear_output), sorted(results), msg=msg)
             else:

--- a/coalib/testing/LocalBearTestHelper.py
+++ b/coalib/testing/LocalBearTestHelper.py
@@ -65,8 +65,33 @@ class LocalBearTestHelper(unittest.TestCase):  # pragma: no cover
                                create_tempfile=create_tempfile,
                                tempfile_kwargs=tempfile_kwargs
                                )
-            return
+        else:
+            return self.check_invalidity(local_bear, lines,
+                                         filename=filename,
+                                         force_linebreaks=force_linebreaks,
+                                         create_tempfile=create_tempfile,
+                                         tempfile_kwargs=tempfile_kwargs,
+                                         )
 
+    def check_invalidity(self,
+                         local_bear,
+                         lines,
+                         filename=None,
+                         force_linebreaks=True,
+                         create_tempfile=True,
+                         tempfile_kwargs={}):
+        """
+        Asserts that a check of the given lines with the given local bear
+        yields results.
+
+        :param local_bear:       The local bear to check with.
+        :param lines:            The lines to check. (List of strings)
+        :param filename:         The filename, if it matters.
+        :param force_linebreaks: Whether to append newlines at each line
+                                 if needed. (Bears expect a \\n for every line)
+        :param create_tempfile:  Whether to save lines in tempfile if needed.
+        :param tempfile_kwargs:  Kwargs passed to tempfile.mkstemp().
+        """
         assert isinstance(self, unittest.TestCase)
         self.assertIsInstance(local_bear,
                               LocalBear,
@@ -142,6 +167,8 @@ class LocalBearTestHelper(unittest.TestCase):  # pragma: no cover
                 self.assertEqual(sorted(bear_output), sorted(results), msg=msg)
             else:
                 self.assertEqual(bear_output, results, msg=msg)
+
+            return bear_output
 
 
 def verify_local_bear(bear,

--- a/tests/test_bears/TestBear.py
+++ b/tests/test_bears/TestBear.py
@@ -3,9 +3,12 @@ from coalib.bears.LocalBear import LocalBear
 
 class TestBear(LocalBear):
 
-    def run(self, file, filename, result: bool=False, exception: bool = False):
-        if result:
-            yield result
+    def run(self, file, filename, result=False, exception: bool = False):
+        if result is True:
+            yield True
+        elif result is not False:
+            for item in result:
+                yield item
 
         if exception:
             raise ValueError

--- a/tests/testing/LocalBearTestHelperTest.py
+++ b/tests/testing/LocalBearTestHelperTest.py
@@ -5,6 +5,7 @@ from tests.test_bears.TestBear import TestBear
 from coalib.settings.Section import Section
 from coalib.settings.Setting import Setting
 from coalib.testing.LocalBearTestHelper import verify_local_bear, execute_bear
+from coalib.testing.LocalBearTestHelper import LocalBearTestHelper as Helper
 
 
 files = ('Everything is invalid/valid/raises error',)
@@ -15,6 +16,23 @@ invalidTest = verify_local_bear(TestBear,
 validTest = verify_local_bear(TestBear,
                               valid_files=files,
                               invalid_files=())
+
+
+class LocalBearCheckResultsTest(Helper):
+
+    def setUp(self):
+        section = Section('')
+        section.append(Setting('result', 'a, b'))
+        self.uut = TestBear(section, Queue())
+
+    def test_order_ignored(self):
+        self.check_results(self.uut, ['a', 'b'], ['b', 'a'],
+                           check_order=False)
+
+    def test_require_order(self):
+        with self.assertRaises(AssertionError):
+            self.check_results(self.uut, ['a', 'b'], ['b', 'a'],
+                               check_order=True)
 
 
 class LocalBearTestHelper(unittest.TestCase):


### PR DESCRIPTION
Fixes https://github.com/coala/coala/issues/4158 , and implements `check_invalidity` as requested at https://github.com/coala/coala/issues/2197 .
