### PR TITLE
Setting.__path__: Use Setting.value instead of str(Setting)

### DIFF
--- a/coalib/settings/Setting.py
+++ b/coalib/settings/Setting.py
@@ -163,7 +163,11 @@ class Setting(StringConverter):
         :raises ValueError:        If no origin is specified in the setting
                                    nor the given origin parameter.
         """
-        strrep = str(self).strip()
+        if hasattr(self, 'value'):
+            strrep = self.value.strip()
+        else:
+            strrep = str(self).strip()
+
         if os.path.isabs(strrep):
             return strrep
 

--- a/tests/coalaDeleteOrigTest.py
+++ b/tests/coalaDeleteOrigTest.py
@@ -1,7 +1,6 @@
 import tempfile
 import unittest
 import os
-import re
 
 from coalib import coala_delete_orig
 from coala_utils.ContextManagers import retrieve_stderr
@@ -45,7 +44,7 @@ class coalaDeleteOrigTest(unittest.TestCase):
             temporary = tempfile.mkstemp(suffix='.orig', dir=directory)
             os.close(temporary[0])
             section = Section('')
-            section.append(Setting('project_dir', re.escape(directory)))
+            section.append(Setting('project_dir', directory))
             retval = coala_delete_orig.main(section=section)
             self.assertEqual(retval, 0)
             self.assertFalse(os.path.isfile(temporary[1]))

--- a/tests/settings/SettingTest.py
+++ b/tests/settings/SettingTest.py
@@ -1,5 +1,4 @@
 import os
-import re
 import unittest
 from collections import OrderedDict
 
@@ -24,7 +23,7 @@ class SettingTest(unittest.TestCase):
                          os.path.abspath(os.path.join('.', '22')))
 
         abspath = os.path.abspath('.')
-        self.uut = Setting('key', re.escape(abspath))
+        self.uut = Setting('key', abspath)
         self.assertEqual(path(self.uut), abspath)
 
         self.uut = Setting('key', ' 22', '')


### PR DESCRIPTION
str(Setting) will call unescape, which apparently causes problems on Windows. e.g. https://github.com/coala/coala-bears/pull/1425
c.f. https://gitlab.com/coala/coala-utils/issues/27

This has been tested on all bears using the docker: https://travis-ci.org/jayvdb/coala/builds/228653730