### PR TITLE
.misc/check_setuptools.py: Add format to pip list

### DIFF
--- a/.misc/check_setuptools.py
+++ b/.misc/check_setuptools.py
@@ -24,7 +24,7 @@ def check_setuptools_version(version):
               file=sys.stderr)
         return 2
 
-    pip_list = subprocess.check_output(['pip', 'list'])
+    pip_list = subprocess.check_output(['pip', 'list', '--format=legacy'])
     pip_list = pip_list.decode('utf8')
     if 'setuptools (%s)' % version not in pip_list:
         print('Failed! pip list reports wrong setuptools:\n%s' % pip_list,


### PR DESCRIPTION
Add '--format=legacy' to pip list invocation as the
default format will switch to columns in the future.

Fixes https://github.com/coala/coala/issues/4141