### PR TITLE
Ignore Action: Remove action after comment added

### DIFF
--- a/coalib/output/ConsoleInteraction.py
+++ b/coalib/output/ConsoleInteraction.py
@@ -165,45 +165,37 @@ def acquire_actions_and_apply(console_printer,
     cli_actions = CLI_ACTIONS if cli_actions is None else cli_actions
     failed_actions = set()
     applied_actions = {}
+
     while True:
-        actions = []
-        for action in cli_actions:
-            if action.is_applicable(result, file_dict, file_diff_dict) is True:
-                actions.append(action)
-
-        if actions == []:
-            return
-
         action_dict = {}
         metadata_list = []
-        for action in actions:
-            metadata = action.get_metadata()
-            action_dict[metadata.name] = action
-            metadata_list.append(metadata)
+
+        for action in cli_actions:
+            if action.is_applicable(result,
+                                    file_dict,
+                                    file_diff_dict,
+                                    tuple(applied_actions.keys())) is True:
+                metadata = action.get_metadata()
+                action_dict[metadata.name] = action
+                metadata_list.append(metadata)
+
+        if not metadata_list:
+            return
 
         # User can always choose no action which is guaranteed to succeed
-        if apply_single:
-            ask_for_action_and_apply(console_printer,
-                                     section,
-                                     metadata_list,
-                                     action_dict,
-                                     failed_actions,
-                                     result,
-                                     file_diff_dict,
-                                     file_dict,
-                                     applied_actions,
-                                     apply_single=apply_single)
-            break
-        elif not ask_for_action_and_apply(console_printer,
-                                          section,
-                                          metadata_list,
-                                          action_dict,
-                                          failed_actions,
-                                          result,
-                                          file_diff_dict,
-                                          file_dict,
-                                          applied_actions,
-                                          apply_single=apply_single):
+        continue_interaction = ask_for_action_and_apply(
+            console_printer,
+            section,
+            metadata_list,
+            action_dict,
+            failed_actions,
+            result,
+            file_diff_dict,
+            file_dict,
+            applied_actions,
+            apply_single=apply_single
+        )
+        if not continue_interaction:
             break
 
 
@@ -778,6 +770,7 @@ def ask_for_action_and_apply(console_printer,
     :return:                Returns a boolean value. True will be returned, if
                             it makes sense that the user may choose to execute
                             another action, False otherwise.
+                            If apply_single ist set, always return False.
     """
     actions_desc, actions_name = choose_action(console_printer, metadata_list,
                                                apply_single)
@@ -801,6 +794,7 @@ def ask_for_action_and_apply(console_printer,
                                     file_diff_dict,
                                     file_dict,
                                     applied_actions)
+        return False
     else:
         for action_choice, action_choice_name in zip(actions_desc,
                                                      actions_name):

--- a/coalib/results/result_actions/IgnoreResultAction.py
+++ b/coalib/results/result_actions/IgnoreResultAction.py
@@ -18,11 +18,18 @@ class IgnoreResultAction(ResultAction):
 
     @staticmethod
     @enforce_signature
-    def is_applicable(result: Result, original_file_dict, file_diff_dict):
+    def is_applicable(result: Result,
+                      original_file_dict,
+                      file_diff_dict,
+                      applied_actions=()):
         """
         For being applicable, the result has to point to a number of files
         that have to exist i.e. have not been previously deleted.
+        Additionally, the action should not have been applied to the current
+        result before.
         """
+        if IgnoreResultAction.__name__ in applied_actions:
+            return 'An ignore comment was already added for this result.'
 
         if len(result.affected_code) == 0:
             return 'The result is not associated with any source code.'

--- a/coalib/results/result_actions/OpenEditorAction.py
+++ b/coalib/results/result_actions/OpenEditorAction.py
@@ -101,7 +101,10 @@ class OpenEditorAction(ResultAction):
 
     @staticmethod
     @enforce_signature
-    def is_applicable(result: Result, original_file_dict, file_diff_dict):
+    def is_applicable(result: Result,
+                      original_file_dict,
+                      file_diff_dict,
+                      applied_actions=()):
         """
         For being applicable, the result has to point to a number of files
         that have to exist i.e. have not been previously deleted.

--- a/coalib/results/result_actions/PrintAspectAction.py
+++ b/coalib/results/result_actions/PrintAspectAction.py
@@ -8,7 +8,10 @@ class PrintAspectAction(ResultAction):
 
     @staticmethod
     @enforce_signature
-    def is_applicable(result: Result, original_file_dict, file_diff_dict):
+    def is_applicable(result: Result,
+                      original_file_dict,
+                      file_diff_dict,
+                      applied_actions=()):
         if result.aspect is None:
             return 'There is no aspect associated with the result.'
         return True

--- a/coalib/results/result_actions/PrintDebugMessageAction.py
+++ b/coalib/results/result_actions/PrintDebugMessageAction.py
@@ -8,7 +8,10 @@ class PrintDebugMessageAction(ResultAction):
 
     @staticmethod
     @enforce_signature
-    def is_applicable(result: Result, original_file_dict, file_diff_dict):
+    def is_applicable(result: Result,
+                      original_file_dict,
+                      file_diff_dict,
+                      applied_actions=()):
         if result.debug_msg != '':
             return True
         return 'There is no debug message.'

--- a/coalib/results/result_actions/PrintMoreInfoAction.py
+++ b/coalib/results/result_actions/PrintMoreInfoAction.py
@@ -8,7 +8,10 @@ class PrintMoreInfoAction(ResultAction):
 
     @staticmethod
     @enforce_signature
-    def is_applicable(result: Result, original_file_dict, file_diff_dict):
+    def is_applicable(result: Result,
+                      original_file_dict,
+                      file_diff_dict,
+                      applied_actions=()):
         if result.additional_info != '':
             return True
         return 'There is no additional info.'

--- a/coalib/results/result_actions/ResultAction.py
+++ b/coalib/results/result_actions/ResultAction.py
@@ -13,7 +13,10 @@ class ResultAction:
     SUCCESS_MESSAGE = 'The action was executed successfully.'
 
     @staticmethod
-    def is_applicable(result, original_file_dict, file_diff_dict):
+    def is_applicable(result,
+                      original_file_dict,
+                      file_diff_dict,
+                      applied_actions=()):
         """
         Checks whether the Action is valid for the result type.
 
@@ -28,6 +31,9 @@ class ResultAction:
                                    original_file_dict to the current state.
                                    This dict will be altered so you do not
                                    need to use the return value.
+        :applied_actions:          List of actions names that have already been
+                                   applied for the current result. Action names
+                                   are stored in order of application.
         """
         return True
 

--- a/coalib/results/result_actions/ShowPatchAction.py
+++ b/coalib/results/result_actions/ShowPatchAction.py
@@ -58,7 +58,10 @@ class ShowPatchAction(ResultAction):
 
     @staticmethod
     @enforce_signature
-    def is_applicable(result: Result, original_file_dict, file_diff_dict):
+    def is_applicable(result: Result,
+                      original_file_dict,
+                      file_diff_dict,
+                      applied_actions=()):
 
         if not result.diffs:
             return 'This result has no patch attached.'

--- a/tests/output/ConsoleInteractionTest.py
+++ b/tests/output/ConsoleInteractionTest.py
@@ -575,7 +575,7 @@ class ConsoleInteractionTest(unittest.TestCase):
                 set(), Result('origin', 'message'), {}, {}, {}, apply_single]
 
         with simulate_console_inputs('a') as generator:
-            self.assertTrue(ask_for_action_and_apply(*args))
+            self.assertFalse(ask_for_action_and_apply(*args))
 
     def test_default_input_apply_single_fail(self):
         action = TestAction()
@@ -592,7 +592,7 @@ class ConsoleInteractionTest(unittest.TestCase):
                     apply_single]
 
         with simulate_console_inputs('a') as generator:
-            self.assertTrue(ask_for_action_and_apply(*args))
+            self.assertFalse(ask_for_action_and_apply(*args))
 
     def test_print_result_no_input(self):
         with make_temp() as testfile_path:

--- a/tests/results/result_actions/IgnoreResultActionTest.py
+++ b/tests/results/result_actions/IgnoreResultActionTest.py
@@ -9,19 +9,35 @@ from coalib.results.result_actions.IgnoreResultAction import IgnoreResultAction
 class IgnoreResultActionTest(unittest.TestCase):
 
     def test_is_applicable(self):
+        prior_ignore = ('IgnoreResultAction')
+        associated_result = Result.from_values('origin', 'msg',
+                                               "file doesn't exist", 2)
 
         with self.assertRaises(TypeError) as context:
             IgnoreResultAction.is_applicable('str', {}, {})
+        with self.assertRaises(TypeError) as context:
+            IgnoreResultAction.is_applicable('str', {}, {}, prior_ignore)
+
+        self.assertEqual(
+            IgnoreResultAction.is_applicable(associated_result, {}, {}),
+            "The result is associated with source code that doesn't "
+            'seem to exist.')
 
         self.assertEqual(
             IgnoreResultAction.is_applicable(
-                Result.from_values('origin', 'msg', "file doesn't exist", 2),
+                associated_result,
                 {},
-                {}
-            ),
-            "The result is associated with source code that doesn't "
-            'seem to exist.'
-        )
+                {},
+                prior_ignore),
+            'An ignore comment was already added for this result.')
+
+        self.assertEqual(
+            IgnoreResultAction.is_applicable(
+                Result('', ''),
+                {},
+                {},
+                prior_ignore),
+            'An ignore comment was already added for this result.')
 
         self.assertEqual(
             IgnoreResultAction.is_applicable(
@@ -33,8 +49,15 @@ class IgnoreResultActionTest(unittest.TestCase):
         )
 
         with make_temp() as f_a:
-            self.assertTrue(IgnoreResultAction.is_applicable(
-                Result.from_values('origin', 'msg', f_a, 2), {}, {}))
+            result = Result.from_values('origin', 'msg', f_a, 2)
+            self.assertTrue(IgnoreResultAction.is_applicable(result, {}, {}))
+            self.assertEqual(
+                IgnoreResultAction.is_applicable(
+                    result,
+                    {},
+                    {},
+                    prior_ignore),
+                'An ignore comment was already added for this result.')
 
     def test_no_orig(self):
         uut = IgnoreResultAction()


### PR DESCRIPTION
This avoids asking the users if they want to add an ignore comment,
AFTER they already applied one.
Includes a new parameter for Action.is_applicable, which can be
checked for earlier actions.
Change in behaviour for IgnoreResultAction:
If this action was already used before, Action.is_applicable will
always return false, even on other failure cases.

Closes https://github.com/coala/coala/issues/3375

<!--
Thanks for your contribution!

Please take a quick look at those things down there. They're quite important.
Really! We wrote them for you. Yes you! With utmost care. Read them.
-->

**For short term contributors:** we understand that getting your commits well
defined like we require is a hard task and takes some learning. If you
look to help without wanting to contribute long term there's no need
for you to learn this. Just drop us a message and we'll take care of brushing
up your stuff for merge!

### Checklist

- [x] I read the [commit guidelines](http://coala.io/commit) and I've followed
      them.
- [x] I ran coala over my code locally. (*All commits have to pass
      individually.* It is not sufficient to have "fixup commits" on your PR,
      our bot will still report the issues for the previous commit.) You will
      likely receive a lot of bot comments and build failures if coala does not
      pass on every single commit!

After you submit your pull request, **DO NOT click the 'Update Branch' button.**
When asked for a rebase, consult [coala.io/rebase](https://coala.io/rebase)
instead.

Please consider helping us by reviewing other peoples pull requests as well:

- pick up any PR at <https://coala.io/review>
- review it (check <https://coala.io/reviewing> for more info)
- if you are sure that it needs work, use `cobot mark wip <URL>` to get it out
  of the review queue.

The more you review, the more your score will grow at coala.io and we will
review your PRs faster!
