### PR TITLE
Diff.py: Remove has_changes and fix __bool__

### DIFF
--- a/coalib/results/Diff.py
+++ b/coalib/results/Diff.py
@@ -26,7 +26,7 @@ class Diff:
         :param delete:    True if file is set to be deleted.
         """
         self._changes = {}
-        self._file = file_list
+        self._file = list(file_list)
         self.rename = rename
         self.delete = delete
 

--- a/coalib/results/Diff.py
+++ b/coalib/results/Diff.py
@@ -278,14 +278,6 @@ class Diff:
         return result
 
     @property
-    def has_changes(self):
-        """
-        True if the modified file is different than the original file,
-        else False.
-        """
-        return self.modified != self._file
-
-    @property
     def unified_diff(self):
         """
         Generates a unified diff corresponding to this patch.
@@ -440,7 +432,7 @@ class Diff:
         """
         return (self.rename is not False or
                 self.delete is True or
-                len(self._changes) > 0)
+                self.modified != self._file)
 
     def delete_line(self, line_nr):
         """

--- a/tests/results/DiffTest.py
+++ b/tests/results/DiffTest.py
@@ -148,12 +148,21 @@ class DiffTest(unittest.TestCase):
         del result_file[2]
         self.assertEqual(self.uut.modified, result_file)
 
-    def test_has_changes(self):
-        self.assertFalse(self.uut.has_changes)
+    def test_bool(self):
+        self.assertFalse(self.uut)
         self.uut.add_line(4, '4')
-        self.assertTrue(self.uut.has_changes)
+        self.assertTrue(self.uut)
         self.uut.delete_line(4)
-        self.assertFalse(self.uut.has_changes)
+        self.assertFalse(self.uut)
+
+        # test if it works with tuples.
+        uutuple = Diff(('1', '2', '3', '4'))
+
+        self.assertFalse(uutuple)
+        uutuple.add_line(4, '4')
+        self.assertTrue(uutuple)
+        uutuple.delete_line(4)
+        self.assertFalse(uutuple)
 
     def test_addition(self):
         self.assertRaises(TypeError, self.uut.__add__, 5)

--- a/tests/results/DiffTest.py
+++ b/tests/results/DiffTest.py
@@ -560,8 +560,16 @@ class DiffTest(unittest.TestCase):
         b = ['first', 'third']
         diff_1 = Diff.from_string_arrays(a, b)
 
+        c = ['first', 'second', 'third']
+        d = ['first', 'third']
+
+        diff_2 = Diff.from_string_arrays(c, d)
+
+        self.assertEqual(diff_1, diff_2)
+
+        # changing the original array should not influence
+        # the diff
         a[1] = 'else'
-        diff_2 = Diff.from_string_arrays(a, b)
         self.assertEqual(diff_1, diff_2)
 
         diff_1.rename = 'abcd'


### PR DESCRIPTION
Removes the `self.has_changes` property, since its functionality can be
accessed from the bool conversion.
Fixes inconstency of `__bool__` that results from looking at
`self._changes`:
removing one line, then adding the same content again resulted in
`bool(diff) == True`, instead of False.

`__bool__` now uses the mechanism that was employed by `has_changes`, to
fix this bug.

Closes #4178

<!--
Thanks for your contribution!

Please take a quick look at those things down there. They're quite important.
Really! We wrote them for you. Yes you! With utmost care. Read them.
-->

**For short term contributors:** we understand that getting your commits well
defined like we require is a hard task and takes some learning. If you
look to help without wanting to contribute long term there's no need
for you to learn this. Just drop us a message and we'll take care of brushing
up your stuff for merge!

### Checklist

- [x] I read the [commit guidelines](http://coala.io/commit) and I've followed
      them.
- [x] I ran coala over my code locally. (*All commits have to pass
      individually.* It is not sufficient to have "fixup commits" on your PR,
      our bot will still report the issues for the previous commit.) You will
      likely receive a lot of bot comments and build failures if coala does not
      pass on every single commit!

After you submit your pull request, **DO NOT click the 'Update Branch' button.**
When asked for a rebase, consult [coala.io/rebase](https://coala.io/rebase)
instead.

Please consider helping us by reviewing other peoples pull requests as well:

- pick up any PR at <https://coala.io/review>
- review it (check <https://coala.io/reviewing> for more info)
- if you are sure that it needs work, use `cobot mark wip <URL>` to get it out
  of the review queue.

The more you review, the more your score will grow at coala.io and we will
review your PRs faster!
