### PR TITLE
LocalBearTestHelper:Add settings to check_validity

### DIFF
--- a/coalib/testing/LocalBearTestHelper.py
+++ b/coalib/testing/LocalBearTestHelper.py
@@ -59,7 +59,8 @@ class LocalBearTestHelper(unittest.TestCase):
                        valid=True,
                        force_linebreaks=True,
                        create_tempfile=True,
-                       tempfile_kwargs={}):
+                       tempfile_kwargs={},
+                       settings={}):
         """
         Asserts that a check of the given lines with the given local bear
         either yields or does not yield any results.
@@ -79,7 +80,8 @@ class LocalBearTestHelper(unittest.TestCase):
                                check_order=True,
                                force_linebreaks=force_linebreaks,
                                create_tempfile=create_tempfile,
-                               tempfile_kwargs=tempfile_kwargs
+                               tempfile_kwargs=tempfile_kwargs,
+                               settings=settings,
                                )
         else:
             return self.check_invalidity(local_bear, lines,
@@ -87,6 +89,7 @@ class LocalBearTestHelper(unittest.TestCase):
                                          force_linebreaks=force_linebreaks,
                                          create_tempfile=create_tempfile,
                                          tempfile_kwargs=tempfile_kwargs,
+                                         settings=settings,
                                          )
 
     def check_invalidity(self,
@@ -95,7 +98,8 @@ class LocalBearTestHelper(unittest.TestCase):
                          filename=None,
                          force_linebreaks=True,
                          create_tempfile=True,
-                         tempfile_kwargs={}):
+                         tempfile_kwargs={},
+                         settings={}):
         """
         Asserts that a check of the given lines with the given local bear
         yields results.
@@ -120,7 +124,9 @@ class LocalBearTestHelper(unittest.TestCase):
                                   filename=filename,
                                   force_linebreaks=force_linebreaks,
                                   create_tempfile=create_tempfile,
-                                  tempfile_kwargs=tempfile_kwargs)
+                                  tempfile_kwargs=tempfile_kwargs,
+                                  settings=settings,
+                                  )
         msg = ("The local bear '{}' yields no result although it "
                'should.'.format(local_bear.__class__.__name__))
         self.assertNotEqual(len(bear_output), 0, msg=msg)


### PR DESCRIPTION
Add `settings` argument to `LocalBearTestHelper.check_validity`
and `LocalBearTestHelper.check_invalidity`.

Closes https://github.com/coala/coala/issues/4247

<!--
Thanks for your contribution!

Please take a quick look at those things down there. They're quite important.
Really! We wrote them for you. Yes you! With utmost care. Read them.
-->

**For short term contributors:** we understand that getting your commits well
defined like we require is a hard task and takes some learning. If you
look to help without wanting to contribute long term there's no need
for you to learn this. Just drop us a message and we'll take care of brushing
up your stuff for merge!

### Checklist

- [x] I read the [commit guidelines](http://coala.io/commit) and I've followed
      them.
- [x] I ran coala over my code locally. (*All commits have to pass
      individually.* It is not sufficient to have "fixup commits" on your PR,
      our bot will still report the issues for the previous commit.) You will
      likely receive a lot of bot comments and build failures if coala does not
      pass on every single commit!

After you submit your pull request, **DO NOT click the 'Update Branch' button.**
When asked for a rebase, consult [coala.io/rebase](https://coala.io/rebase)
instead.

Please consider helping us by reviewing other peoples pull requests as well:

- pick up any PR at <https://coala.io/review>
- review it (check <https://coala.io/reviewing> for more info)
- if you are sure that it needs work, use `cobot mark wip <URL>` to get it out
  of the review queue.

The more you review, the more your score will grow at coala.io and we will
review your PRs faster!
