### PR TITLE
tests: Avoid exception in test logic

### DIFF
--- a/tests/coalaTest.py
+++ b/tests/coalaTest.py
@@ -29,12 +29,16 @@ class coalaTest(unittest.TestCase):
             retval, stdout, stderr = execute_coala(
                              coala.main,
                              'coala', '-c', os.devnull,
+                             '--non-interactive', '--no-color',
                              '-f', re.escape(filename),
                              '-b', 'LineCountTestBear')
             self.assertIn('This file has 1 lines.',
                           stdout,
                           'The output should report count as 1 lines')
-            self.assertIn('During execution of coala', stderr)
+            self.assertEqual(1, len(stderr.splitlines()))
+            self.assertIn(
+                'LineCountTestBear: This result has no patch attached.',
+                stderr)
             self.assertNotEqual(retval, 0,
                                 'coala must return nonzero when errors occured')
 

--- a/tests/misc/CachingTest.py
+++ b/tests/misc/CachingTest.py
@@ -122,20 +122,28 @@ class CachingTest(unittest.TestCase):
             retval, stdout, stderr = execute_coala(
                 coala.main,
                 'coala',
+                '--non-interactive', '--no-color',
                 '-c', os.devnull,
                 '-f', re.escape(filename),
                 '-b', 'LineCountTestBear')
             self.assertIn('This file has', stdout)
-            self.assertIn(' During execution of coala', stderr)
+            self.assertEqual(1, len(stderr.splitlines()))
+            self.assertIn(
+                'LineCountTestBear: This result has no patch attached.',
+                stderr)
 
             retval, stdout, stderr = execute_coala(
                 coala.main,
                 'coala',
+                '--non-interactive', '--no-color',
                 '-c', os.devnull,
                 '-f', re.escape(filename),
                 '-b', 'LineCountTestBear')
             self.assertIn('This file has', stdout)
-            self.assertIn('During execution of coala', stderr)
+            self.assertEqual(1, len(stderr.splitlines()))
+            self.assertIn(
+                'LineCountTestBear: This result has no patch attached.',
+                stderr)
 
     def test_caching_multi_results(self):
         """
@@ -159,10 +167,14 @@ class CachingTest(unittest.TestCase):
             retval, stdout, stderr = execute_coala(
                coala.main,
                'coala',
+               '--non-interactive', '--no-color',
                '-c', filename + '.coafile',
                '-f', filename + 'test.py')
             self.assertIn('This file has', stdout)
-            self.assertIn('During execution of coala', stderr)
+            self.assertEqual(2, len(stderr.splitlines()))
+            self.assertIn(
+                'LineCountTestBear: This result has no patch attached.',
+                stderr)
             self.assertIn(
                 'Implicit \'Default\' section inheritance is deprecated',
                 stderr)


### PR DESCRIPTION
Three tests allowed coala to have an internal exception occur,
which was then captured and reported as a success in the test
assertions.

These invocations of coala where seeking user input, which
failed under pytest as tests should not depend on user input.

Fixes https://github.com/coala/coala/issues/4249