### PR TITLE
tests: Get rid of all the time.sleeps

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,6 +1,7 @@
 argcomplete~=1.8
 coverage~=4.3.4
 codecov~=2.0.5
+freezegun~=0.3.9
 pytest~=3.0
 pytest-cov~=2.2
 pytest-env~=0.6.0

--- a/tests/bears/BearTest.py
+++ b/tests/bears/BearTest.py
@@ -1,10 +1,12 @@
 from collections import defaultdict
+import datetime
 from io import BytesIO
 import multiprocessing
 import unittest
 from os.path import abspath, exists, isfile, join, getmtime
 import shutil
-from time import sleep
+
+from freezegun import freeze_time
 
 import requests
 import requests_mock
@@ -396,7 +398,9 @@ class BearDownloadTest(BearTestBase):
         filename = self.filename
         file_location = self.file_location
 
-        with requests_mock.Mocker() as reqmock:
+        with freeze_time('2017-01-01') as frozen_datetime, \
+                requests_mock.Mocker() as reqmock:
+
             reqmock.get(mock_url, text=mock_text)
             self.assertFalse(isfile(file_location))
             expected_filename = file_location
@@ -404,8 +408,8 @@ class BearDownloadTest(BearTestBase):
             self.assertTrue(isfile(join(file_location)))
             self.assertEqual(result_filename, expected_filename)
             expected_time = getmtime(file_location)
-            sleep(0.5)
 
+            frozen_datetime.tick(delta=datetime.timedelta(seconds=0.5))
             result_filename = self.uut.download_cached_file(mock_url, filename)
             self.assertEqual(result_filename, expected_filename)
             result_time = getmtime(file_location)

--- a/tests/core/BearTest.py
+++ b/tests/core/BearTest.py
@@ -1,10 +1,12 @@
+import datetime
 from itertools import permutations
 from os.path import abspath, exists, isfile, join, getmtime
 import shutil
-from time import sleep
 import unittest
 
 from dependency_management.requirements.PipRequirement import PipRequirement
+
+from freezegun import freeze_time
 
 import requests
 
@@ -187,7 +189,9 @@ class BearTest(unittest.TestCase):
         filename = 'test.html'
         file_location = join(uut.data_dir, filename)
 
-        with requests_mock.Mocker() as reqmock:
+        with freeze_time('2017-01-01') as frozen_datetime, \
+                requests_mock.Mocker() as reqmock:
+
             reqmock.get(mock_url, text=mock_text)
             self.assertFalse(isfile(file_location))
             expected_filename = file_location
@@ -195,8 +199,8 @@ class BearTest(unittest.TestCase):
             self.assertTrue(isfile(join(file_location)))
             self.assertEqual(result_filename, expected_filename)
             expected_time = getmtime(file_location)
-            sleep(0.5)
 
+            frozen_datetime.tick(delta=datetime.timedelta(seconds=0.5))
             result_filename = uut.download_cached_file(mock_url, filename)
             self.assertEqual(result_filename, expected_filename)
             result_time = getmtime(file_location)


### PR DESCRIPTION
Replaced time.sleep with freezegun in tests.

Closes: https://github.com/coala/coala/issues/4262