### PR TITLE
Readme: Fix Link to Travis CI for macOS Status

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -25,7 +25,7 @@ coala supports popular programming languages including **Python**, **C/C++**, **
 .. |Windows Build status| image:: https://img.shields.io/appveyor/ci/coala/coala/master.svg?label=windows%20build
    :target: https://ci.appveyor.com/project/coala/coala/branch/master
 .. |macOS Build Status| image:: https://img.shields.io/travis/coala/coala/master.svg?label=macOS%20build
-   :target: https://travis-ci/coala/coala
+   :target: https://travis-ci.org/coala/coala
 .. |codecov.io| image:: https://img.shields.io/codecov/c/github/coala/coala/master.svg?label=branch%20coverage
    :target: https://codecov.io/github/coala/coala?branch=master
 .. |Documentation Status| image:: https://readthedocs.org/projects/coala/badge/?version=latest


### PR DESCRIPTION
The shield for the macOS Build (Travis CI) currently points to 
https://travis-ci/coala/coala instead of travis-ci.org/coala/coala.

Fixes `https://github.com/coala/coala/issues/4273`.