### PR TITLE
BearTest: Directly import urllib3

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -11,3 +11,4 @@ pytest-xdist~=1.14
 requests-mock~=1.2.0
 pip>=9.0.0
 wheel~=0.29
+urllib3~=1.21

--- a/tests/bears/BearTest.py
+++ b/tests/bears/BearTest.py
@@ -10,6 +10,7 @@ from freezegun import freeze_time
 
 import requests
 import requests_mock
+import urllib3
 
 from coalib.bearlib.aspects.collections import aspectlist
 from coalib.bearlib.aspects.Metadata import CommitMessage
@@ -370,7 +371,7 @@ class BearDownloadTest(BearTestBase):
     def test_read_broken(self):
         exc = (
             requests.exceptions.RequestException,
-            requests.packages.urllib3.exceptions.ProtocolError,
+            urllib3.exceptions.ProtocolError,
         )
         fake_content = [b'Fake read data', b'Another line']
         fake_content_provider = BrokenReadHTTPResponse(fake_content)


### PR DESCRIPTION
And don't use `requests.packages.urllib3`, which doesn't exist anymore in latest `requests` release

**Closes** https://github.com/coala/coala/issues/4293
