### PR TITLE
LocalBearTestHelper: Add ``assertObjectsEqual``

### DIFF
--- a/coalib/testing/LocalBearTestHelper.py
+++ b/coalib/testing/LocalBearTestHelper.py
@@ -8,6 +8,7 @@ import pytest
 from coalib.bearlib.abstractions.LinterClass import LinterClass
 from coalib.testing.BearTestHelper import generate_skip_decorator
 from coalib.bears.LocalBear import LocalBear
+from coala_utils.Comparable import Comparable
 from coala_utils.ContextManagers import prepare_file
 from coalib.settings.Section import Section
 from coalib.settings.Setting import Setting
@@ -109,6 +110,28 @@ class LocalBearTestHelper(unittest.TestCase):
 
     If you miss some methods, get in contact with us, we'll be happy to help!
     """
+
+    def assertComparableObjectsEqual(self, observed_result, expected_result):
+        if len(observed_result) == len(expected_result):
+            messages = ''
+            for observed, expected in zip(observed_result, expected_result):
+                if (isinstance(observed, Comparable)
+                    and isinstance(expected, Comparable)) and (
+                            type(observed) is type(expected)):
+                    for attribute in type(observed).__compare_fields__:
+                        try:
+                            self.assertEqual(
+                                getattr(observed, attribute),
+                                getattr(expected, attribute),
+                                msg='{} mismatch.'.format(attribute))
+                        except AssertionError as ex:
+                            messages += (str(ex) + '\n\n')
+                else:
+                    self.assertEqual(observed_result, expected_result)
+            if messages:
+                raise AssertionError(messages)
+        else:
+            self.assertEqual(observed_result, expected_result)
 
     def check_validity(self,
                        local_bear,
@@ -227,16 +250,6 @@ class LocalBearTestHelper(unittest.TestCase):
                               list,
                               msg='The given results are not a list.')
 
-        if results in [[], ()]:
-            msg = ("The local bear '{}' yields a result although it "
-                   "shouldn't.".format(local_bear.__class__.__name__))
-            check_order = True
-        else:
-            msg = ("The local bear '{}' doesn't yield the right results."
-                   .format(local_bear.__class__.__name__))
-            if check_order:
-                msg += ' Or the order may be wrong.'
-
         bear_output = get_results(local_bear, lines,
                                   filename=filename,
                                   force_linebreaks=force_linebreaks,
@@ -244,9 +257,10 @@ class LocalBearTestHelper(unittest.TestCase):
                                   tempfile_kwargs=tempfile_kwargs,
                                   settings=settings)
         if not check_order:
-            self.assertEqual(sorted(bear_output), sorted(results), msg=msg)
+            self.assertComparableObjectsEqual(
+                sorted(bear_output), sorted(results))
         else:
-            self.assertEqual(bear_output, results, msg=msg)
+            self.assertComparableObjectsEqual(bear_output, results)
 
         return bear_output
 

--- a/tests/testing/LocalBearTestHelperTest.py
+++ b/tests/testing/LocalBearTestHelperTest.py
@@ -7,6 +7,10 @@ from tests.test_bears.TestBearDep import (TestDepBearBDependsA,
                                           TestDepBearCDependsB,
                                           TestDepBearDependsAAndAA)
 from coalib.bearlib.abstractions.Linter import linter
+from tests.test_bears.LineCountTestBear import LineCountTestBear
+from coala_utils.ContextManagers import prepare_file
+from coalib.results.Result import Result
+from coalib.results.RESULT_SEVERITY import RESULT_SEVERITY
 from coalib.settings.Section import Section
 from coalib.settings.Setting import Setting
 from coalib.testing.LocalBearTestHelper import verify_local_bear, execute_bear
@@ -38,6 +42,55 @@ class LocalBearCheckResultsTest(Helper):
         with self.assertRaises(AssertionError):
             self.check_results(self.uut, ['a', 'b'], ['b', 'a'],
                                check_order=True)
+
+    def test_result_inequality(self):
+        with self.assertRaises(AssertionError):
+            self.check_results(self.uut, ['a', 'b'], ['a', 'b', None],
+                               check_order=True)
+
+    def test_good_assertComparableObjectsEqual(self):
+        self.uut = LineCountTestBear(Section('name'), Queue())
+        file_content = 'a\nb\nc'
+        with prepare_file(file_content.splitlines(), filename=None,
+                          create_tempfile=True) as (file, fname):
+            self.check_results(self.uut,
+                               file_content.splitlines(),
+                               [Result.from_values(
+                                origin='LineCountTestBear',
+                                message='This file has 3 lines.',
+                                severity=RESULT_SEVERITY.INFO,
+                                file=fname)],
+                               filename=fname,
+                               create_tempfile=False)
+
+    def test_bad_assertComparableObjectsEqual(self):
+        with self.assertRaises(AssertionError) as cm:
+            self.uut = LineCountTestBear(Section('name'), Queue())
+            file_content = 'a\nb\nc'
+            with prepare_file(file_content.splitlines(), filename=None,
+                              create_tempfile=True) as (file, fname):
+                self.check_results(self.uut,
+                                   file_content.splitlines(),
+                                   [Result.from_values(
+                                    origin='LineCountTestBea',
+                                    message='This file has 2 lines.',
+                                    severity=RESULT_SEVERITY.INFO,
+                                    file=fname)],
+                                   filename=fname,
+                                   create_tempfile=False)
+        self.assertEqual('\'LineCountTestBear\' != \'LineCountTestBea\'\n'
+                         '- LineCountTestBear\n'
+                         '?                 -\n'
+                         '+ LineCountTestBea\n'
+                         ' : origin mismatch.\n\n'
+                         '\'This file has 3 lines.\' != \'This file has 2 '
+                         'lines.\'\n'
+                         '- This file has 3 lines.\n'
+                         '?               ^\n'
+                         '+ This file has 2 lines.\n'
+                         '?               ^\n'
+                         ' : message_base mismatch.\n\n',
+                         str(cm.exception))
 
 
 class LocalBearTestCheckLineResultCountTest(Helper):


### PR DESCRIPTION
Add ``assertObjectsEqual(..)`` method that compares individual
fields of the Result object and yields better, easy to understand
messages in case of an attribute mismatch.

Closes https://github.com/coala/coala/issues/4302

<!--
Thanks for your contribution!

Please take a quick look at those things down there. They're quite important.
Really! We wrote them for you. Yes you! With utmost care. Read them.
-->

**For short term contributors:** we understand that getting your commits well
defined like we require is a hard task and takes some learning. If you
look to help without wanting to contribute long term there's no need
for you to learn this. Just drop us a message and we'll take care of brushing
up your stuff for merge!

### Checklist

- [x] I read the [commit guidelines](http://coala.io/commit) and I've followed
      them.
- [x] I ran coala over my code locally. (*All commits have to pass
      individually.* It is not sufficient to have "fixup commits" on your PR,
      our bot will still report the issues for the previous commit.) You will
      likely receive a lot of bot comments and build failures if coala does not
      pass on every single commit!

After you submit your pull request, **DO NOT click the 'Update Branch' button.**
When asked for a rebase, consult [coala.io/rebase](https://coala.io/rebase)
instead.

Please consider helping us by reviewing other peoples pull requests as well:

- pick up any PR at <https://coala.io/review>
- review it (check <https://coala.io/reviewing> for more info)
- if you are sure that it needs work, use `cobot mark wip <URL>` to get it out
  of the review queue.

The more you review, the more your score will grow at coala.io and we will
review your PRs faster!
