### PR TITLE
DocumentationComment.py: Add `marker[1]==marker[2]`

### DIFF
--- a/coalib/bearlib/languages/documentation/DocumentationComment.py
+++ b/coalib/bearlib/languages/documentation/DocumentationComment.py
@@ -221,6 +221,7 @@ class DocumentationComment:
         assembled += ''.join('\n' if line == '\n' and not self.marker[1]
                              else self.indent + self.marker[1] + line
                              for line in lines[1:])
-        return (assembled +
-                (self.indent if lines[-1][-1] == '\n' else '') +
-                self.marker[2])
+        return (assembled if self.marker[1] == self.marker[2] else
+                (assembled +
+                 (self.indent if lines[-1][-1] == '\n' else '') +
+                 self.marker[2]))

--- a/tests/bearlib/languages/documentation/DocumentationCommentTest.py
+++ b/tests/bearlib/languages/documentation/DocumentationCommentTest.py
@@ -222,6 +222,13 @@ class DocumentationAssemblyTest(unittest.TestCase):
         for doc in extract_documentation(data, 'python', 'default'):
             self.assertIn(doc.assemble(), docs)
 
+    def test_doxygen_assembly(self):
+        data = load_testdata('doxygen.py')
+        docs = ''.join(data)
+
+        for doc in extract_documentation(data, 'python', 'doxygen'):
+            self.assertIn(doc.assemble(), docs)
+
     def test_c_assembly(self):
         data = load_testdata('default.c')
         docs = ''.join(data)


### PR DESCRIPTION
assemble() accounts for `marker[1]==marker[2]`

Fixes https://github.com/coala/coala/issues/2645

<!--
Thanks for your contribution!

Please take a quick look at those things down there. They're quite important.
Really! We wrote them for you. Yes you! With utmost care. Read them.
-->

**For short term contributors:** we understand that getting your commits well
defined like we require is a hard task and takes some learning. If you
look to help without wanting to contribute long term there's no need
for you to learn this. Just drop us a message and we'll take care of brushing
up your stuff for merge!

### Checklist

- [x] I read the [commit guidelines](http://coala.io/commit) and I've followed
      them.
- [x] I ran coala over my code locally. (*All commits have to pass
      individually.* It is not sufficient to have "fixup commits" on your PR,
      our bot will still report the issues for the previous commit.) You will
      likely receive a lot of bot comments and build failures if coala does not
      pass on every single commit!

After you submit your pull request, **DO NOT click the 'Update Branch' button.**
When asked for a rebase, consult [coala.io/rebase](https://coala.io/rebase)
instead.

Please consider helping us by reviewing other peoples pull requests as well:

- pick up any PR at <https://coala.io/review>
- review it (check <https://coala.io/reviewing> for more info)
- if you are sure that it needs work, use `cobot mark wip <URL>` to get it out
  of the review queue.

The more you review, the more your score will grow at coala.io and we will
review your PRs faster!
