### PR TITLE
Store Language.versions as Version instances

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ colorlog~=2.7
 dependency_management~=0.4.0
 # libclang-py3 version numbering maps to the clang releases
 libclang-py3~=3.4.0
+packaging~=16.8
 Pygments~=2.1
 PyPrint~=0.2.6
 requests~=2.12


### PR DESCRIPTION
Use `packaging.version.Version` instead of `float` for storing versions to support micro version numbers while keeping comparability

Closes https://github.com/coala/coala/issues/4325

Prerequisite for #4109 
