### PR TITLE
circle.yml: Install docs-requirements

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -21,6 +21,8 @@ test:
     - pip install coala-bears[alldeps] --pre -U:
         parallel: true
         timeout: 900  # Allow 15 mins
+    - pip install -r docs-requirements.txt:
+        parallel: true
     - pip install docutils==0.13.1:
         parallel: true
     - coala --non-interactive:


### PR DESCRIPTION
So that proper `sphinx` and `sphinx-argparse` releases are used for building docs in CircleCI process

Closes https://github.com/coala/coala/issues/4332

The missing installation of `docs-requirements` is also not consistent with https://github.com/coala/documentation/blob/master/README.rst#how-to-build and https://github.com/coala/documentation/blob/master/Users/Install.rst#generating-documentation
