### PR TITLE
WIP: CI: Remove workaround pip install docutils==0.13.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -68,7 +68,6 @@ script:
   - python setup.py bdist_wheel
   - pip install ./dist/coala-*.whl
   - pip install coala-bears[alldeps] --pre -U
-  - pip install docutils==0.13.1
   # https://github.com/coala/coala-bears/issues/1037
   - >
     if [[ "$TRAVIS_PULL_REQUEST" != "false" ]]; then

--- a/circle.yml
+++ b/circle.yml
@@ -23,8 +23,6 @@ test:
         timeout: 900  # Allow 15 mins
     - pip install -r docs-requirements.txt:
         parallel: true
-    - pip install docutils==0.13.1:
-        parallel: true
     - coala --non-interactive:
         parallel: true
     - codecov:

--- a/docs-requirements.txt
+++ b/docs-requirements.txt
@@ -2,4 +2,4 @@
 -r requirements.txt
 -r test-requirements.txt
 sphinx~=1.6.2
-sphinx-argparse~=0.2.0
+sphinx-argparse~=0.2.1

--- a/docs-requirements.txt
+++ b/docs-requirements.txt
@@ -1,5 +1,5 @@
 # all requirements are needed so that autodoc can find them
 -r requirements.txt
 -r test-requirements.txt
-sphinx~=1.5.5
-sphinx-argparse~=0.1.15
+sphinx~=1.6.2
+sphinx-argparse~=0.2.0


### PR DESCRIPTION
That workaround won't be needed anymore after merged https://github.com/coala/coala/pull/4330

Contains the commit from above PR for now to show that it works... hopefully ;)

Closes https://github.com/coala/coala/issues/4331

According to https://github.com/sphinx-doc/sphinx/issues/3846 that failing `docutils` version check should not happen anymore with `sphinx-1.6.2`