### PR TITLE
Compatibility.py: Require coverage on Python 3.4

### DIFF
--- a/coalib/misc/Compatibility.py
+++ b/coalib/misc/Compatibility.py
@@ -1,5 +1,5 @@
 import json
 try:
     JSONDecodeError = json.decoder.JSONDecodeError
-except AttributeError:  # pragma: no cover
+except AttributeError:  # pragma Python 3.5,3.6: no cover
     JSONDecodeError = ValueError

--- a/setup.cfg
+++ b/setup.cfg
@@ -59,3 +59,4 @@ exclude_lines =
     pragma: no ?cover
     pragma ${PLATFORM_SYSTEM}: no cover
     pragma ${OS_NAME}: no cover
+    pragma Python [0-9.,]*${PYTHON_VERSION}[0-9.,]*: no cover


### PR DESCRIPTION
The Python 3.4 CI jobs should require coverage of the code adding backwards compatibility for JSONDecodeError which is missing only in Python 3.4.
    
Closes https://github.com/coala/coala/issues/4157

(Includes https://github.com/coala/coala/pull/4337)