### PR TITLE
typed_...: Create converter class instead of func

### DIFF
--- a/coalib/settings/Setting.py
+++ b/coalib/settings/Setting.py
@@ -46,47 +46,75 @@ def glob_list(obj, *args, **kwargs):
 
 def typed_list(conversion_func):
     """
-    Creates a function that converts a setting into a list of elements each
+    Creates a class that converts a setting into a list of elements each
     converted with the given conversion function.
 
     :param conversion_func: The conversion function that converts a string into
                             your desired list item object.
-    :return:                A conversion function.
+    :return:                An instance of the created conversion class.
     """
-    return lambda setting: [
-        conversion_func(StringConverter(elem)) for elem in setting]
+
+    class Converter:
+
+        def __call__(self, setting):
+            return [conversion_func(StringConverter(elem))
+                    for elem in setting]
+
+        def __repr__(self):
+            return 'typed_list(%s)' % conversion_func.__name__
+
+    return Converter()
 
 
 def typed_dict(key_type, value_type, default):
     """
-    Creates a function that converts a setting into a dict with the given
-    types.
+    Creates a class that converts a setting into a dict with the given types.
 
     :param key_type:   The type conversion function for the keys.
     :param value_type: The type conversion function for the values.
     :param default:    The default value to use if no one is given by the user.
-    :return:           A conversion function.
+    :return:           An instance of the created conversion class.
     """
-    return lambda setting: {
-        key_type(StringConverter(key)):
-        value_type(StringConverter(value)) if value != '' else default
-        for key, value in dict(setting).items()}
+
+    class Converter:
+
+        def __call__(self, setting):
+            return {key_type(StringConverter(key)):
+                    value_type(StringConverter(value))
+                    if value != '' else default
+                    for key, value in dict(setting).items()}
+
+        def __repr__(self):
+            return 'typed_dict(%s, %s, default=%s)' % (
+                key_type.__name__, value_type.__name__, default)
+
+    return Converter()
 
 
 def typed_ordered_dict(key_type, value_type, default):
     """
-    Creates a function that converts a setting into an ordered dict with the
+    Creates a class that converts a setting into an ordered dict with the
     given types.
 
     :param key_type:   The type conversion function for the keys.
     :param value_type: The type conversion function for the values.
     :param default:    The default value to use if no one is given by the user.
-    :return:           A conversion function.
+    :return:           An instance of the created conversion class.
     """
-    return lambda setting: OrderedDict(
-        (key_type(StringConverter(key)),
-         value_type(StringConverter(value)) if value != '' else default)
-        for key, value in OrderedDict(setting).items())
+
+    class Converter:
+
+        def __call__(self, setting):
+            return OrderedDict((key_type(StringConverter(key)),
+                                value_type(StringConverter(value))
+                                if value != '' else default)
+                               for key, value in OrderedDict(setting).items())
+
+        def __repr__(self):
+            return 'typed_ordered_dict(%s, %s, default=%s)' % (
+                key_type.__name__, value_type.__name__, default)
+
+    return Converter()
 
 
 @generate_repr('key', 'value', 'origin', 'from_cli', 'to_append')

--- a/tests/settings/SettingTest.py
+++ b/tests/settings/SettingTest.py
@@ -81,6 +81,8 @@ class SettingTest(unittest.TestCase):
             self.uut = Setting('key', '1, a, 3')
             typed_list(int)(self.uut)
 
+        self.assertEqual(repr(typed_list(int)), 'typed_list(int)')
+
     def test_typed_dict(self):
         self.uut = Setting('key', '1, 2: t, 3')
         self.assertEqual(typed_dict(int, str, None)(self.uut),
@@ -90,6 +92,9 @@ class SettingTest(unittest.TestCase):
             self.uut = Setting('key', '1, a, 3')
             typed_dict(int, str, '')(self.uut)
 
+        self.assertEqual(repr(typed_dict(int, str, None)),
+                         'typed_dict(int, str, default=None)')
+
     def test_typed_ordered_dict(self):
         self.uut = Setting('key', '1, 2: t, 3')
         self.assertEqual(typed_ordered_dict(int, str, None)(self.uut),
@@ -98,6 +103,9 @@ class SettingTest(unittest.TestCase):
         with self.assertRaises(ValueError):
             self.uut = Setting('key', '1, a, 3')
             typed_ordered_dict(int, str, '')(self.uut)
+
+        self.assertEqual(repr(typed_ordered_dict(int, str, None)),
+                         'typed_ordered_dict(int, str, default=None)')
 
     def test_inherited_conversions(self):
         self.uut = Setting('key', ' 22\n', '.', strip_whitespaces=True)


### PR DESCRIPTION
For better function signatures in `sphinx`-autodoc-generated API docs when `typed_list/dict/ordered_dict(...)` are used as argument annotation

In case of `PEP8Bear.run()`, instead of current

> `run(filename, file, max_line_length: int = 79, indent_size: int = 4, pep_ignore: <function typed_list.<locals>.<lambda> at 0x000001CC99B73378> = (), pep_select: <function typed_list.<locals>.<lambda> at 0x000001CC99B73400> = (), local_pep8_config: bool = False)`

you get now

> `run(filename, file, max_line_length: int = 79, indent_size: int = 4, pep_ignore: typed_list(str) = (), pep_select: typed_list(str) = (), local_pep8_config: bool = False)`

Closes https://github.com/coala/coala/issues/4341