### PR TITLE
DocumentationComment.py: Accept `position`

### DIFF
--- a/coalib/bearlib/languages/documentation/DocumentationComment.py
+++ b/coalib/bearlib/languages/documentation/DocumentationComment.py
@@ -201,7 +201,7 @@ class DocumentationComment:
         ...               Parameter(name='age', desc=' Age\n')]
         >>> str(DocumentationComment.from_metadata(
         ...         parsed_doc, python_default,
-        ...         python_default.markers[0], 4,
+        ...         python_default.markers[0], '    ',
         ...         TextRange.from_values(0, 0, 0, 0)))
         '\nDescription\n:param age: Age\n'
 

--- a/coalib/bearlib/languages/documentation/DocumentationComment.py
+++ b/coalib/bearlib/languages/documentation/DocumentationComment.py
@@ -37,8 +37,8 @@ class DocumentationComment:
         """
         self.documentation = documentation
         self.docstyle_definition = docstyle_definition
-        self.indent = indent
-        self.marker = marker
+        self.indent = '' if indent is None else indent
+        self.marker = ('', '', '') if marker is None else marker
         self.range = range
 
     def __str__(self):

--- a/coalib/bearlib/languages/documentation/DocumentationExtraction.py
+++ b/coalib/bearlib/languages/documentation/DocumentationExtraction.py
@@ -4,7 +4,7 @@ from coalib.bearlib.languages.documentation.DocstyleDefinition import (
     DocstyleDefinition)
 from coalib.bearlib.languages.documentation.DocumentationComment import (
     DocumentationComment)
-from coalib.results.TextRange import TextRange
+from coalib.results.TextPosition import TextPosition
 
 
 def _extract_doc_comment_simple(content, line, column, markers):
@@ -198,12 +198,9 @@ def _extract_doc_comment_from_line(content, line, column, regex,
             if doc_comment is not None:
                 end_line, end_column, documentation = doc_comment
 
-                rng = TextRange.from_values(line + 1,
-                                            len(indent) + 1,
-                                            end_line + 1,
-                                            end_column + 1)
+                position = TextPosition(line + 1, len(indent) + 1)
                 doc = DocumentationComment(documentation, docstyle_definition,
-                                           indent, marker, rng)
+                                           indent, marker, position)
 
                 return end_line, end_column, doc
 

--- a/tests/bearlib/languages/documentation/DocumentationCommentTest.py
+++ b/tests/bearlib/languages/documentation/DocumentationCommentTest.py
@@ -8,6 +8,7 @@ from coalib.bearlib.languages.documentation.DocumentationExtraction import (
     extract_documentation)
 from tests.bearlib.languages.documentation.TestUtils import (
     load_testdata)
+from coalib.results.TextPosition import TextPosition
 
 
 class DocumentationCommentTest(unittest.TestCase):
@@ -28,7 +29,7 @@ class GeneralDocumentationCommentTest(DocumentationCommentTest):
                                    c_doxygen,
                                    ' ',
                                    ('/**', '*', '*/'),
-                                   (25, 45))
+                                   TextPosition(3, 1))
 
         self.assertEqual(uut.documentation, 'my doc')
         self.assertEqual(uut.language, 'c')
@@ -36,7 +37,7 @@ class GeneralDocumentationCommentTest(DocumentationCommentTest):
         self.assertEqual(uut.indent, ' ')
         self.assertEqual(str(uut), 'my doc')
         self.assertEqual(uut.marker, ('/**', '*', '*/'))
-        self.assertEqual(uut.range, (25, 45))
+        self.assertEqual(uut.position, TextPosition(3, 1))
 
         python_doxygen = DocstyleDefinition.load('python', 'doxygen')
 
@@ -57,6 +58,7 @@ class GeneralDocumentationCommentTest(DocumentationCommentTest):
         self.assertEqual(str(uut), 'qwertzuiop')
         self.assertEqual(uut.marker, ('##', '#', '#'))
         self.assertEqual(uut.range, None)
+        self.assertEqual(uut.position, None)
         self.assertEqual(uut.metadata, python_doxygen_metadata)
 
     def test_not_implemented(self):
@@ -72,7 +74,7 @@ class GeneralDocumentationCommentTest(DocumentationCommentTest):
 
         original = list(extract_documentation(data, 'python', 'default'))
 
-        parsed_docs = [(doc.parse(), doc.marker, doc.indent, doc.range)
+        parsed_docs = [(doc.parse(), doc.marker, doc.indent, doc.position)
                        for doc in original]
 
         docstyle_definition = DocstyleDefinition.load('python', 'default')

--- a/tests/bearlib/languages/documentation/DocumentationExtractionTest.py
+++ b/tests/bearlib/languages/documentation/DocumentationExtractionTest.py
@@ -8,7 +8,7 @@ from coalib.bearlib.languages.documentation.DocumentationExtraction import (
     extract_documentation)
 from tests.bearlib.languages.documentation.TestUtils import (
     load_testdata)
-from coalib.results.TextRange import TextRange
+from coalib.results.TextPosition import TextPosition
 
 
 class DocumentationExtractionTest(unittest.TestCase):
@@ -33,7 +33,7 @@ class DocumentationExtractionTest(unittest.TestCase):
                                  ' @returns Your favorite number.\n'),
                                 docstyle_C_doxygen, '',
                                 docstyle_C_doxygen.markers[0],
-                                TextRange.from_values(3, 1, 7, 4)),
+                                TextPosition(3, 1)),
                             DocumentationComment(
                                 ('\n'
                                  ' Preserves alignment\n'
@@ -42,7 +42,7 @@ class DocumentationExtractionTest(unittest.TestCase):
                                  '     - sub sub item\n'),
                                 docstyle_C_doxygen, '',
                                 docstyle_C_doxygen.markers[2],
-                                TextRange.from_values(15, 1, 20, 4)),
+                                TextPosition(15, 1)),
                             DocumentationComment(
                                 (' ABC\n'
                                  '    Another type of comment\n'
@@ -50,13 +50,13 @@ class DocumentationExtractionTest(unittest.TestCase):
                                  '    ...'),
                                 docstyle_C_doxygen, '',
                                 docstyle_C_doxygen.markers[1],
-                                TextRange.from_values(23, 1, 26, 11)),
+                                TextPosition(23, 1)),
                             DocumentationComment(
                                 (' foobar = barfoo.\n'
                                  ' @param x whatever...\n'),
                                 docstyle_C_doxygen, '',
                                 docstyle_C_doxygen.markers[0],
-                                TextRange.from_values(28, 1, 30, 4)))
+                                TextPosition(28, 1)))
 
         self.assertEqual(tuple(
             extract_documentation(data, 'C', 'doxygen')),
@@ -72,7 +72,7 @@ class DocumentationExtractionTest(unittest.TestCase):
             [DocumentationComment(' my main description\n continues here',
                                   docstyle_C_doxygen, '',
                                   docstyle_C_doxygen.markers[0],
-                                  TextRange.from_values(1, 1, 2, 21))])
+                                  TextPosition(1, 1))])
 
     def test_extract_documentation_CPP(self):
         data = load_testdata('data.cpp')
@@ -91,23 +91,23 @@ class DocumentationExtractionTest(unittest.TestCase):
                                '          Or any other number.\n'),
                               docstyle_CPP_doxygen, '',
                               docstyle_CPP_doxygen.markers[0],
-                              TextRange.from_values(4, 1, 8, 4)),
+                              TextPosition(4, 1)),
                           DocumentationComment(
                               (' foobar\n'
                                ' @param xyz\n'),
                               docstyle_CPP_doxygen, '',
                               docstyle_CPP_doxygen.markers[0],
-                              TextRange.from_values(15, 1, 17, 4)),
+                              TextPosition(15, 1)),
                           DocumentationComment(
                               ' Some alternate style of documentation\n',
                               docstyle_CPP_doxygen, '',
                               docstyle_CPP_doxygen.markers[4],
-                              TextRange.from_values(22, 1, 23, 1)),
+                              TextPosition(22, 1)),
                           DocumentationComment(
                               ' ends instantly',
                               docstyle_CPP_doxygen, '\t',
                               docstyle_CPP_doxygen.markers[0],
-                              TextRange.from_values(26, 2, 26, 23)),
+                              TextPosition(26, 2)),
                           DocumentationComment(
                               (' Should work\n'
                                '\n'
@@ -116,7 +116,7 @@ class DocumentationExtractionTest(unittest.TestCase):
                                ' @param foo WHAT PARAM PLEASE!?\n'),
                               docstyle_CPP_doxygen, '',
                               docstyle_CPP_doxygen.markers[4],
-                              TextRange.from_values(32, 1, 37, 1))))
+                              TextPosition(32, 1))))
 
     def test_extract_documentation_CPP_2(self):
         data = load_testdata('data2.cpp')
@@ -129,7 +129,7 @@ class DocumentationExtractionTest(unittest.TestCase):
                            ' hello world\n'),
                           docstyle_CPP_doxygen, '',
                           docstyle_CPP_doxygen.markers[0],
-                          TextRange.from_values(1, 1, 3, 4)),))
+                          TextPosition(1, 1)),))
 
     def test_extract_documentation_PYTHON3(self):
         data = load_testdata('data.py')
@@ -145,19 +145,19 @@ class DocumentationExtractionTest(unittest.TestCase):
                          'Some more foobar-like text.\n'),
                         docstyle_PYTHON3_default, '',
                         docstyle_PYTHON3_default.markers[0],
-                        TextRange.from_values(1, 1, 5, 4)),
+                        TextPosition(1, 1)),
                     DocumentationComment(
                         ('\n'
                          'A nice and neat way of documenting code.\n'
                          ':param radius: The explosion radius.\n'),
                         docstyle_PYTHON3_default, ' ' * 4,
                         docstyle_PYTHON3_default.markers[0],
-                        TextRange.from_values(8, 5, 11, 8)),
+                        TextPosition(8, 5)),
                     DocumentationComment(
                         '\nA function that returns 55.\n',
                         docstyle_PYTHON3_default, ' ' * 8,
                         docstyle_PYTHON3_default.markers[0],
-                        TextRange.from_values(13, 9, 15, 12)),
+                        TextPosition(13, 9)),
                     DocumentationComment(
                         ('\n'
                          'Docstring with layouted text.\n'
@@ -167,20 +167,20 @@ class DocumentationExtractionTest(unittest.TestCase):
                          'this is intended.\n'),
                         docstyle_PYTHON3_default, '',
                         docstyle_PYTHON3_default.markers[0],
-                        TextRange.from_values(19, 1, 24, 4)),
+                        TextPosition(19, 1)),
                     DocumentationComment(
                         (' Docstring directly besides triple quotes.\n'
                          '    Continues here. '),
                         docstyle_PYTHON3_default, '',
                         docstyle_PYTHON3_default.markers[0],
-                        TextRange.from_values(26, 1, 27, 24)),
+                        TextPosition(26, 1)),
                     DocumentationComment(
                         ('super\n'
                          ' nicely\n'
                          'short'),
                         docstyle_PYTHON3_default, '',
                         docstyle_PYTHON3_default.markers[0],
-                        TextRange.from_values(40, 1, 42, 9)),
+                        TextPosition(40, 1)),
                     DocumentationComment(
                         ('\n'
                          'A bad indented docstring\n'
@@ -188,7 +188,7 @@ class DocumentationExtractionTest(unittest.TestCase):
                          ':param impact: The force of Impact.\n'),
                         docstyle_PYTHON3_default, ' ' * 4,
                         docstyle_PYTHON3_default.markers[0],
-                        TextRange.from_values(45, 5, 49, 8)),
+                        TextPosition(45, 5)),
                     )
 
         self.assertEqual(
@@ -200,7 +200,7 @@ class DocumentationExtractionTest(unittest.TestCase):
                                              docstyle_PYTHON3_doxygen,
                                              r.indent,
                                              r.marker,
-                                             r.range)
+                                             r.position)
                         for r in expected)
 
         expected.insert(5, DocumentationComment(
@@ -211,7 +211,7 @@ class DocumentationExtractionTest(unittest.TestCase):
              '\n'),
             docstyle_PYTHON3_doxygen, '',
             docstyle_PYTHON3_doxygen.markers[1],
-            TextRange.from_values(30, 1, 35, 1)))
+            TextPosition(30, 1)))
 
         self.assertEqual(
             list(extract_documentation(data, 'PYTHON3', 'doxygen')),
@@ -228,7 +228,7 @@ class DocumentationExtractionTest(unittest.TestCase):
             [DocumentationComment(' documentation in single line  ',
                                   docstyle_PYTHON3_default, '',
                                   docstyle_PYTHON3_default.markers[0],
-                                  TextRange.from_values(2, 1, 2, 38))])
+                                  TextPosition(2, 1))])
 
     def test_extract_documentation_PYTHON3_3(self):
         data = ['## documentation in single line without return at end.']
@@ -242,7 +242,7 @@ class DocumentationExtractionTest(unittest.TestCase):
                                   'return at end.',
                                   docstyle_PYTHON3_doxygen, '',
                                   docstyle_PYTHON3_doxygen.markers[1],
-                                  TextRange.from_values(1, 1, 1, 55))])
+                                  TextPosition(1, 1))])
 
     def test_extract_documentation_PYTHON3_4(self):
         data = ['\n', 'triple_quote_string_test = """\n',


### PR DESCRIPTION
DocumentationComment accept `position` instead
of `range` in `__init__`.
Amend tests to comply with changes.
Closes https://github.com/coala/coala/issues/2646

<!--
Thanks for your contribution!

Please take a quick look at those things down there. They're quite important.
Really! We wrote them for you. Yes you! With utmost care. Read them.
-->

**For short term contributors:** we understand that getting your commits well
defined like we require is a hard task and takes some learning. If you
look to help without wanting to contribute long term there's no need
for you to learn this. Just drop us a message and we'll take care of brushing
up your stuff for merge!

### Checklist

- [x] I read the [commit guidelines](http://coala.io/commit) and I've followed
      them.
- [x] I ran coala over my code locally. (*All commits have to pass
      individually.* It is not sufficient to have "fixup commits" on your PR,
      our bot will still report the issues for the previous commit.) You will
      likely receive a lot of bot comments and build failures if coala does not
      pass on every single commit!

After you submit your pull request, **DO NOT click the 'Update Branch' button.**
When asked for a rebase, consult [coala.io/rebase](https://coala.io/rebase)
instead.

Please consider helping us by reviewing other peoples pull requests as well:

- pick up any PR at <https://coala.io/review>
- review it (check <https://coala.io/reviewing> for more info)
- if you are sure that it needs work, use `cobot mark wip <URL>` to get it out
  of the review queue.

The more you review, the more your score will grow at coala.io and we will
review your PRs faster!
