### PR TITLE
Create check_unsupported.sh

### DIFF
--- a/.misc/check_unsupported.sh
+++ b/.misc/check_unsupported.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+
+set +e
+
+# Enable capturing the non-zero exit status of coverage instead of tee
+set -o pipefail
+
+coverage run setup.py install | tee setup.log
+
+retval=$?
+
+# coalib.__init__.py should exit with 4 on unsupported versions of Python
+if [[ $retval != 4 ]]; then
+  echo "Unexpected error code $?"
+
+  # When the exit code is 0, use a non-zero exit code instead
+  if [[ $retval == 0 ]]; then
+    exit 127
+  fi
+  exit $retval
+fi
+
+# error when no lines selected by grep
+set -e
+
+grep -q 'coala supports only python 3.4 or later' setup.log
+
+echo "Unsupported check completed successfully"

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,10 @@ matrix:
     # Restore matrix job entry from d2d67fab to test OSX
     - python: 2.7
       env: UNSUPPORTED=true
+      script: .misc/check_unsupported.sh
     - python: 3.3
       env: UNSUPPORTED=true
+      script: .misc/check_unsupported.sh
 
 cache:
   pip: true
@@ -60,11 +62,6 @@ before_script:
   - python .misc/check_setuptools.py
 
 script:
-  - >
-    if [[ "$UNSUPPORTED" == true ]]; then
-      coverage run setup.py install | grep -q 'coala supports only python 3.4 or later'
-    fi
-  - if [[ "$UNSUPPORTED" == true ]]; then codecov || true; exit; fi
   - py.test
   - python setup.py bdist_wheel
   - pip install ./dist/coala-*.whl
@@ -77,6 +74,11 @@ script:
     fi
   - coala --non-interactive
   - python setup.py docs
+
+after_success:
+  - codecov
+
+after_failure:
   - codecov
 
 notifications:

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,7 +1,7 @@
 argcomplete~=1.8
 coverage~=4.3.4
 coverage-env-plugin~=0.1
-coverage-config-reload-plugin~=0.1
+coverage-config-reload-plugin~=0.2
 codecov~=2.0.5
 freezegun~=0.3.9
 pytest~=3.1.1


### PR DESCRIPTION
Fixes https://github.com/coala/coala/issues/4375 , and a related bug in pipe handling exposed during https://github.com/coala/coala/issues/4372 .

It also prepares the ground for https://github.com/coala/coala/issues/4323 , making it easier to move the check around.