### PR TITLE
Setting.py: Create aspectlist converter for Setting object

### DIFF
--- a/coalib/settings/Setting.py
+++ b/coalib/settings/Setting.py
@@ -1,11 +1,13 @@
 import os
 from collections import Iterable, OrderedDict
 
+import coalib.bearlib.aspects
 from coala_utils.decorators import (
     enforce_signature,
     generate_repr,
 )
 from coala_utils.string_processing.StringConverter import StringConverter
+from coalib.bearlib.aspects.collections import aspectlist
 from coalib.parsing.Globbing import glob_escape
 
 
@@ -87,6 +89,17 @@ def typed_ordered_dict(key_type, value_type, default):
         (key_type(StringConverter(key)),
          value_type(StringConverter(value)) if value != '' else default)
         for key, value in OrderedDict(setting).items())
+
+
+def aspect_list(obj, *args, **kwargs):
+    """
+    Create an aspectlist instance from a list of string that hold aspect name.
+
+    :param obj: The ``Setting`` object from which the key is obtained.
+    :return:    An aspectlist instance.
+    """
+    return aspectlist([coalib.bearlib.aspects[aspect] for aspect in
+                       obj.__iter__(*args, **kwargs)])
 
 
 @generate_repr('key', 'value', 'origin', 'from_cli', 'to_append')

--- a/tests/settings/SettingTest.py
+++ b/tests/settings/SettingTest.py
@@ -3,9 +3,10 @@ import re
 import unittest
 from collections import OrderedDict
 
+import coalib.bearlib.aspects.Spelling
 from coalib.settings.Setting import (
     Setting, path, path_list, url, typed_dict, typed_list, typed_ordered_dict,
-    glob, glob_list)
+    glob, glob_list, aspect_list)
 from coalib.parsing.Globbing import glob_escape
 
 
@@ -98,6 +99,15 @@ class SettingTest(unittest.TestCase):
         with self.assertRaises(ValueError):
             self.uut = Setting('key', '1, a, 3')
             typed_ordered_dict(int, str, '')(self.uut)
+
+    def test_aspect_list(self):
+        self.uut = Setting('aspect', 'coalaCorrect, aspectYEAH')
+        self.assertEqual([Spelling.coalaCorrect,
+                          Spelling.aspectYEAH], aspect_list(self.uut))
+
+        with self.assertRaises(LookupError):
+            self.uut = Setting('aspect', 'nonexistentAspect')
+            aspect_list(self.uut)
 
     def test_inherited_conversions(self):
         self.uut = Setting('key', ' 22\n', '.', strip_whitespaces=True)


### PR DESCRIPTION
``aspect_list()`` could be used to convert a Setting object into aspectlist
instance.

```python
>>> section.get('aspects')
'coalaCorrect, aspectYEAH' 
>>> type(aspect_list(section.get('aspects')))
<class 'aspectlist'>
>>> Root.Spelling.coalaCorrect in aspect_list(section.get('aspects'))
True
```

It MUST be used for type hinting in all bears that want to support aspect.

```python
class SomeBear(LocalBear, aspects={
  'detect': [Root.Spelling.coalaCorrect, 
             Root.Spelling.aspectYEAH]
}):
    def run(self, filename, file, aspects:aspect_list):
        if Root.Spelling.coalaCorrect in aspects:
            # code to find incorrect coala spelling
        if Root.Spelling.aspectYEAH in aspects:
            # code to find incorrect aspectYEAH spelling
```

Closes https://github.com/coala/coala/issues/4324

@userzimmermann @Asnelchristian 