### PR TITLE
AspectList: Overload __init__ to accept strings

### DIFF
--- a/coalib/bearlib/aspects/collections.py
+++ b/coalib/bearlib/aspects/collections.py
@@ -1,4 +1,5 @@
-from coalib.bearlib.aspects.meta import issubaspect, assert_aspect
+import coalib.bearlib.aspects
+from coalib.bearlib.aspects.meta import isaspect, issubaspect
 
 
 class AspectList(list):
@@ -7,7 +8,22 @@ class AspectList(list):
     """
 
     def __init__(self, seq=()):
-        super().__init__(map(assert_aspect, seq))
+        """
+        Initialize a new AspectList.
+
+        >>> from .Metadata import CommitMessage
+        >>> AspectList([CommitMessage.Shortlog, CommitMessage.Body])
+        [<aspectclass '...Shortlog'>, <aspectclass '...Body'>]
+        >>> AspectList(['Shortlog', 'CommitMessage.Body'])
+        [<aspectclass '...Shortlog'>, <aspectclass '...Body'>]
+        >>> AspectList([CommitMessage.Shortlog, 'CommitMessage.Body'])
+        [<aspectclass '...Shortlog'>, <aspectclass '...Body'>]
+
+        :param seq: A sequence containing either aspectclass, aspectclass
+                    instance, or string of partial/full qualified aspect name.
+        """
+        super().__init__((item if isaspect(item) else
+                          coalib.bearlib.aspects[item] for item in seq))
 
     def __contains__(self, aspect):
         for item in self:

--- a/tests/bearlib/aspects/CollectionsTest.py
+++ b/tests/bearlib/aspects/CollectionsTest.py
@@ -1,18 +1,28 @@
 import pytest
+import unittest
 
-from coalib.bearlib.aspects import AspectTypeError as aspectTypeError
+from coalib.bearlib.aspects import (
+    AspectNotFoundError, AspectTypeError as aspectTypeError)
 from coalib.bearlib.aspects.collections import AspectList
 from coalib.bearlib.aspects.meta import isaspect
 from coalib.bearlib.aspects.Metadata import Metadata
 
 
-class AspectListTest:
+class AspectListTest(unittest.TestCase):
 
     def test__init__(self):
-        with pytest.raises(aspectTypeError) as exc:
+        list_of_aspect = AspectList(['CommitMessage.Shortlog',
+                                     'CommitMessage.Body'])
+        mix_of_aspect = AspectList(['CommitMessage.Shortlog',
+                                    Metadata.CommitMessage.Body])
+        self.assertIsInstance(list_of_aspect, AspectList)
+        self.assertIs(list_of_aspect[0], Metadata.CommitMessage.Shortlog)
+        self.assertIs(list_of_aspect[1], Metadata.CommitMessage.Body)
+        self.assertEqual(list_of_aspect, mix_of_aspect)
+
+        with self.assertRaisesRegex(AspectNotFoundError,
+                                    "^No aspect named 'String'$"):
             AspectList(['String'])
-        exc.match("'String' is not an aspectclass or "
-                  'an instance of an aspectclass')
 
     def test__contains__(self):
         list_of_aspect = AspectList(


### PR DESCRIPTION
Overload aspectlist so it could be instanced from a list of string
containing aspects name. The reason of this overloading is to make
it possible to instanced list of desired aspects found in coafile.

```python
>>> aspectlist(['coalaCorrect', 'aspectsYEAH'])
[<aspectclass '...coalaCorrect'>, <aspectclass '...aspectsYEAH'>]
```

Replacement of https://github.com/coala/coala/pull/4379
Closes https://github.com/coala/coala/issues/4382