### PR TITLE
.rultor.yml: Do not install pip3

### DIFF
--- a/.rultor.yml
+++ b/.rultor.yml
@@ -1,5 +1,4 @@
 install:
-  - if ! pip3 -V ; then wget -O - https://bootstrap.pypa.io/get-pip.py | python3; fi
   - pip3 install -r requirements.txt
 
 docker:


### PR DESCRIPTION
The docker `coala/rultor-python` installs `pip3`.  If it doesnt,
something larger has failed and installing `pip3` isnt helpful.

Closes https://github.com/coala/coala/issues/4393
