### PR TITLE
Processing: Preprocess and pass aspects to bear

### DIFF
--- a/coalib/bearlib/aspects/__init__.py
+++ b/coalib/bearlib/aspects/__init__.py
@@ -9,6 +9,7 @@ from .base import aspectbase
 from .exceptions import (AspectTypeError, AspectNotFoundError,
                          MultipleAspectFoundError)
 from .meta import aspectclass
+from .collections import AspectList
 from .taste import Taste, TasteError
 
 # already import Root here to make it available in submodules that define
@@ -19,7 +20,8 @@ from .root import Root
 
 __all__ = ['Root', 'Taste', 'TasteError',
            'aspectclass', 'aspectbase', 'AspectTypeError',
-           'AspectNotFoundError', 'MultipleAspectFoundError']
+           'AspectNotFoundError', 'MultipleAspectFoundError',
+           'AspectList']
 
 
 class aspectsModule(ModuleType):

--- a/coalib/bearlib/languages/Language.py
+++ b/coalib/bearlib/languages/Language.py
@@ -416,6 +416,9 @@ class Language(metaclass=LanguageMeta):
         return (type(self) is type(item)
                 and set(item.versions).issubset(set(self.versions)))
 
+    def __reduce__(self):
+        return (Language.__getitem__, (str(self),))
+
     @property
     def attributes(self):
         """

--- a/coalib/settings/ConfigurationGathering.py
+++ b/coalib/settings/ConfigurationGathering.py
@@ -9,7 +9,7 @@ from coalib.output.ConfWriter import ConfWriter
 from coalib.output.printers.LOG_LEVEL import LOG_LEVEL
 from coalib.parsing.CliParsing import parse_cli, check_conflicts
 from coalib.parsing.ConfParser import ConfParser
-from coalib.settings.Section import Section
+from coalib.settings.Section import Section, extract_aspects_from_section
 from coalib.settings.SectionFilling import fill_settings
 from coalib.settings.Setting import Setting, path
 from string import Template
@@ -19,6 +19,19 @@ COAFILE_OUTPUT = Template('$type \'$file\' $found!\n'
                           '* add `--save` to generate a config file with '
                           'your current options\n'
                           '* add `-I` to suppress any use of config files\n')
+
+
+def aspectize_sections(sections):
+    """
+    Search for aspects related setting in a section, initialize it, and then
+    embed the aspects information as AspectList object into the section itself.
+
+    :param sections:  List of section that potentially contain aspects setting.
+    :return:          The new sections.
+    """
+    for _, section in sections.items():
+        section.aspects = extract_aspects_from_section(section)
+    return sections
 
 
 def merge_section_dicts(lower, higher):
@@ -385,6 +398,7 @@ def gather_configuration(acquire_settings,
         arg_list = sys.argv[1:] if arg_list is None else arg_list
     sections, targets = load_configuration(arg_list, log_printer, arg_parser,
                                            args=args)
+    aspectize_sections(sections)
     local_bears, global_bears = fill_settings(sections,
                                               acquire_settings,
                                               log_printer)

--- a/tests/bearlib/languages/LanguageTest.py
+++ b/tests/bearlib/languages/LanguageTest.py
@@ -1,3 +1,4 @@
+import pickle
 import unittest
 
 from coalib.bearlib.languages.Language import Language, LanguageMeta
@@ -9,6 +10,12 @@ class LanguageTest(unittest.TestCase):
         assert set(dir(Language)) == {
             l.__name__ for l in LanguageMeta.all
         }.union(type.__dir__(Language))
+
+    def test_pickle_ability(self):
+        cpp = Language['CPP']
+        cpp_str = pickle.dumps(cpp)
+        cpp_unpickled = pickle.loads(cpp_str)
+        self.assertEqual(str(cpp), str(cpp_unpickled))
 
 
 class LanguageAttributeErrorTest(unittest.TestCase):

--- a/tests/settings/ConfigurationGatheringTest.py
+++ b/tests/settings/ConfigurationGatheringTest.py
@@ -9,12 +9,14 @@ from pyprint.NullPrinter import NullPrinter
 import pytest
 
 from coalib.misc import Constants
+from coalib.settings.Section import Section
 from coala_utils.ContextManagers import (
     make_temp, change_directory, retrieve_stdout)
 from coalib.output.printers.LogPrinter import LogPrinter
 from coala_utils.string_processing import escape
 from coalib.settings.ConfigurationGathering import (
-    find_user_config, gather_configuration, load_configuration)
+    find_user_config, gather_configuration, load_configuration,
+    aspectize_sections)
 
 
 @pytest.mark.usefixtures('disable_bears')
@@ -332,3 +334,10 @@ class ConfigurationGatheringTest(unittest.TestCase):
         with retrieve_stdout() as stdout:
             load_configuration(['--no-config'], self.log_printer)
             self.assertNotIn('WARNING', stdout.getvalue())
+
+    def test_aspectize_sections(self):
+        section = Section('test')
+        sections = {'test': section}
+        aspectize_sections(sections)
+
+        self.assertIsNone(sections['test'].aspects)

--- a/tests/settings/SectionTest.py
+++ b/tests/settings/SectionTest.py
@@ -1,8 +1,11 @@
 import unittest
 import os
 
+from coalib.bearlib.aspects import AspectList, Root, get as get_aspect
+from coalib.bearlib.aspects.meta import issubaspect
 from coalib.misc import Constants
-from coalib.settings.Section import Section, Setting, append_to_sections
+from coalib.settings.Section import (
+    Section, Setting, append_to_sections, extract_aspects_from_section)
 from coalib.settings.ConfigurationGathering import get_config_directory
 from coalib.parsing.Globbing import glob_escape
 
@@ -204,3 +207,62 @@ class SectionTest(unittest.TestCase):
         sections['all.c.codestyle'].set_default_section(sections)
         self.assertEqual(sections['all.c.codestyle'].defaults,
                          sections['all'])
+
+    def test_extract_aspects_from_section(self):
+        section = Section('section')
+        section.append(Setting(
+            'aspects',
+            'spelling, commitmessage, methodsmell'))
+        # Custom taste for ColonExistence
+        section.append(Setting('commitmessage.shortlog_colon', 'false'))
+        section.append(Setting('language', 'py 3.4'))
+
+        aspects = extract_aspects_from_section(section)
+        spelling_instance = Root.Spelling('py 3.4')
+        colon_existence_instance = (
+            Root.Metadata.CommitMessage.Shortlog.ColonExistence(
+                'py 3.4', shortlog_colon=False))
+        method_smell_instance = Root.Smell.MethodSmell('py 3.4')
+        trailing_period_instance = (
+            Root.Metadata.CommitMessage.Shortlog.TrailingPeriod('py 3.4'))
+
+        self.assertIsInstance(aspects, AspectList)
+        self.assertEqual(aspects.get('spelling'), spelling_instance)
+        self.assertEqual(aspects.get('colonexistence'),
+                         colon_existence_instance)
+        self.assertEqual(aspects.get('methodsmell'), method_smell_instance)
+        self.assertEqual(aspects.get('TrailingPeriod'),
+                         trailing_period_instance)
+
+    def test_extract_aspects_from_section_with_exclude(self):
+        section = Section('section')
+        section.append(Setting('aspects', 'commitmessage'))
+        section.append(Setting('excludes', 'TrailingPeriod'))
+        section.append(Setting('language', 'py 3.4'))
+
+        aspects = extract_aspects_from_section(section)
+
+        self.assertTrue(issubaspect(get_aspect('trailingperiod'),
+                                    get_aspect('commitmessage')))
+        self.assertIsNone(aspects.get('trailingperiod'))
+
+    def test_extract_aspects_from_section_no_aspects(self):
+        section = Section('section')
+        self.assertIsNone(extract_aspects_from_section(section))
+
+    def test_extract_aspects_from_section_no_language(self):
+        section = Section('section')
+        section.append(Setting('aspects', 'commitmessage'))
+        with self.assertRaisesRegex(
+                AttributeError,
+                'Language was not found in configuration file. '
+                'Usage of aspect-based configuration must include '
+                'language information.'):
+            extract_aspects_from_section(section)
+
+    def test_extract_aspects_from_section_incorrect_language(self):
+        section = Section('section')
+        section.append(Setting('aspects', 'commitmessage'))
+        section.append(Setting('language', 'not a language'))
+        with self.assertRaises(AttributeError):
+            extract_aspects_from_section(section)


### PR DESCRIPTION
Enable bear to access aspects that defined in configuration files.

Given a coafile:

```
[all]
files = **.py
bears = coalaBear
aspects = coalaCorrect, shortlog.colonexistence
language = Python 3.6
shortlog_colon = false
```

Then, bears can access those aspects with defining a keyword argument
``aspects`` in ``run()`` method.

```python
class SomeBear(LocalBear):
    def run(self, filename, file, aspects:aspectlist=None):
        print(aspects)
        # [<...coalaCorrect object at 0x...>, <...ColonExistence
        # object at 0x...>]
        print(aspects[1])
        # <ColonExistence object(shortlog_colon=False) at
        #  0x7efcd5bf49e8>
        print(aspects[1].shortlog_colon)
        # False
```

Depends on https://github.com/coala/coala/pull/4389
Relates to https://gitlab.com/coala/GSoC-2017/issues/142
Closes https://github.com/coala/coala/issues/4324