### PR TITLE
LocalBearTestHelper: Add get dependency mechanism

### DIFF
--- a/coalib/bears/Bear.py
+++ b/coalib/bears/Bear.py
@@ -288,6 +288,16 @@ class Bear(Printer, LogPrinterMixin, metaclass=bearclass):
         name = self.name
         try:
             self.debug('Running bear {}...'.format(name))
+
+            # If `dependency_results` kwargs is defined but there are no
+            # dependency results (usually in Bear that has no dependency)
+            # delete the `dependency_results` kwargs, since most Bears don't
+            # define `dependency_results` kwargs in its `run()` function.
+            if ('dependency_results' in kwargs and
+                    kwargs['dependency_results'] is None and
+                    not self.BEAR_DEPS):
+                del kwargs['dependency_results']
+
             # If it's already a list it won't change it
             result = self.run_bear_from_section(args, kwargs)
             return [] if result is None else list(result)

--- a/coalib/testing/LocalBearTestHelper.py
+++ b/coalib/testing/LocalBearTestHelper.py
@@ -33,12 +33,28 @@ def get_results(local_bear,
                 create_tempfile=True,
                 tempfile_kwargs={},
                 settings={}):
+    if local_bear.BEAR_DEPS:
+        # Get results of bear's dependencies first
+        deps_results = dict()
+        for bear in local_bear.BEAR_DEPS:
+            uut = bear(local_bear.section, queue.Queue())
+            deps_results[bear.name] = get_results(uut,
+                                                  lines,
+                                                  filename,
+                                                  force_linebreaks,
+                                                  create_tempfile,
+                                                  tempfile_kwargs,
+                                                  settings)
+    else:
+        deps_results = None
+
     with prepare_file(lines, filename,
                       force_linebreaks=force_linebreaks,
                       create_tempfile=create_tempfile,
                       tempfile_kwargs=tempfile_kwargs) as (file, fname), \
-        execute_bear(local_bear, fname, file,
-                     **settings) as bear_output:
+        execute_bear(local_bear, fname, file, dependency_results=deps_results,
+                     **local_bear.get_metadata().filter_parameters(settings)
+                     ) as bear_output:
         return bear_output
 
 

--- a/tests/coalaJSONTest.py
+++ b/tests/coalaJSONTest.py
@@ -71,7 +71,7 @@ class coalaJSONTest(unittest.TestCase):
                 coala.main, 'coala', '--json', '-B', '-I')
             self.assertEqual(retval, 0)
             output = json.loads(stdout)
-            self.assertEqual(len(output['bears']), 8)
+            self.assertEqual(len(output['bears']), 13)
             self.assertFalse(stderr)
 
     def test_show_language_bears(self):

--- a/tests/coalaTest.py
+++ b/tests/coalaTest.py
@@ -83,7 +83,7 @@ class coalaTest(unittest.TestCase):
                 coala.main, 'coala', '-B', '-I', debug=debug)
             self.assertEqual(retval, 0)
             # 8 bears plus 1 line holding the closing colour escape sequence.
-            self.assertEqual(len(stdout.strip().splitlines()), 9)
+            self.assertEqual(len(stdout.strip().splitlines()), 14)
             self.assertFalse(stderr)
 
     def test_show_all_bears_debug(self):

--- a/tests/collecting/CollectorsTest.py
+++ b/tests/collecting/CollectorsTest.py
@@ -317,7 +317,12 @@ class CollectorsTests(unittest.TestCase):
                  'SpaceConsistencyTestBear',
                  'TestBear',
                  'ErrorTestBear',
-                 'RaiseTestBear'})
+                 'RaiseTestBear',
+                 'TestDepBearA',
+                 'TestDepBearBDependsA',
+                 'TestDepBearCDependsB',
+                 'TestDepBearAA',
+                 'TestDepBearDependsAAndAA'})
 
     def test_get_all_bears_names(self):
         with bear_test_module():
@@ -332,4 +337,9 @@ class CollectorsTests(unittest.TestCase):
                  'SpaceConsistencyTestBear',
                  'TestBear',
                  'ErrorTestBear',
-                 'RaiseTestBear'})
+                 'RaiseTestBear',
+                 'TestDepBearA',
+                 'TestDepBearBDependsA',
+                 'TestDepBearCDependsB',
+                 'TestDepBearAA',
+                 'TestDepBearDependsAAndAA'})

--- a/tests/test_bears/TestBearDep.py
+++ b/tests/test_bears/TestBearDep.py
@@ -1,0 +1,43 @@
+from coalib.bears.LocalBear import LocalBear
+
+
+class TestDepBearA(LocalBear):
+
+    def run(self, filename, file, settings1='', settings2=''):
+        yield [settings1, settings2]
+
+
+class TestDepBearAA(LocalBear):
+
+    def run(self, filename, file, settings3='', settings4=''):
+        yield [settings3, settings4]
+
+
+class TestDepBearDependsAAndAA(LocalBear):
+
+    BEAR_DEPS = {TestDepBearA, TestDepBearAA}
+
+    def run(self, filename, file, dependency_results):
+        dep_resultA = dependency_results[TestDepBearA.name][0]
+        dep_resultAA = dependency_results[TestDepBearAA.name][0]
+        yield dep_resultA + dep_resultAA
+
+
+class TestDepBearBDependsA(LocalBear):
+
+    BEAR_DEPS = {TestDepBearA}
+
+    def run(self, filename, file, dependency_results,
+            settings3='', settings4=''):
+        dep_result = dependency_results[TestDepBearA.name][0]
+        yield dep_result + [settings3, settings4]
+
+
+class TestDepBearCDependsB(LocalBear):
+
+    BEAR_DEPS = {TestDepBearBDependsA}
+
+    def run(self, filename, file, dependency_results,
+            settings5='', settings6=''):
+        dep_result = dependency_results[TestDepBearBDependsA.name][0]
+        yield dep_result + [settings5, settings6]

--- a/tests/testing/LocalBearTestHelperTest.py
+++ b/tests/testing/LocalBearTestHelperTest.py
@@ -2,6 +2,9 @@ from queue import Queue
 import unittest
 
 from tests.test_bears.TestBear import TestBear
+from tests.test_bears.TestBearDep import (TestDepBearBDependsA,
+                                          TestDepBearCDependsB,
+                                          TestDepBearDependsAAndAA)
 from coalib.settings.Section import Section
 from coalib.settings.Setting import Setting
 from coalib.testing.LocalBearTestHelper import verify_local_bear, execute_bear
@@ -46,6 +49,49 @@ class LocalBearTestCheckLineResultCountTest(Helper):
         self.check_line_result_count(self.uut,
                                      ['a', '', 'b', '   ', '# abc', '1'],
                                      [1, 1, 1])
+
+
+class LocalBearTestDependency(Helper):
+
+    def setUp(self):
+        self.section = Section('')
+
+    def test_check_results_bear_with_dependency(self):
+        bear = TestDepBearBDependsA(self.section, Queue())
+        self.check_results(bear, [], [['settings1',
+                                       'settings2',
+                                       'settings3',
+                                       'settings4']],
+                           settings={'settings1': 'settings1',
+                                     'settings2': 'settings2',
+                                     'settings3': 'settings3',
+                                     'settings4': 'settings4'})
+
+    def test_check_results_bear_with_2_deep_dependency(self):
+        bear = TestDepBearCDependsB(self.section, Queue())
+        self.check_results(bear, [], [['settings1',
+                                       'settings2',
+                                       'settings3',
+                                       'settings4',
+                                       'settings5',
+                                       'settings6']],
+                           settings={'settings1': 'settings1',
+                                     'settings2': 'settings2',
+                                     'settings3': 'settings3',
+                                     'settings4': 'settings4',
+                                     'settings5': 'settings5',
+                                     'settings6': 'settings6'})
+
+    def test_check_results_bear_with_two_dependencies(self):
+        bear = TestDepBearDependsAAndAA(self.section, Queue())
+        self.check_results(bear, [], [['settings1',
+                                       'settings2',
+                                       'settings3',
+                                       'settings4']],
+                           settings={'settings1': 'settings1',
+                                     'settings2': 'settings2',
+                                     'settings3': 'settings3',
+                                     'settings4': 'settings4'})
 
 
 class LocalBearTestHelper(unittest.TestCase):


### PR DESCRIPTION
Add mechanism to get bear dependencies in
`LocalBearTestHelper.get_results()`.

Closes https://github.com/coala/coala/issues/2860

<!--
Thanks for your contribution!

Please take a quick look at those things down there. They're quite important.
Really! We wrote them for you. Yes you! With utmost care. Read them.
-->

**For short term contributors:** we understand that getting your commits well
defined like we require is a hard task and takes some learning. If you
look to help without wanting to contribute long term there's no need
for you to learn this. Just drop us a message and we'll take care of brushing
up your stuff for merge!

### Checklist

- [x] I read the [commit guidelines](http://coala.io/commit) and I've followed
      them.
- [x] I ran coala over my code locally. (*All commits have to pass
      individually.* It is not sufficient to have "fixup commits" on your PR,
      our bot will still report the issues for the previous commit.) You will
      likely receive a lot of bot comments and build failures if coala does not
      pass on every single commit!

After you submit your pull request, **DO NOT click the 'Update Branch' button.**
When asked for a rebase, consult [coala.io/rebase](https://coala.io/rebase)
instead.

Please consider helping us by reviewing other peoples pull requests as well:

- pick up any PR at <https://coala.io/review>
- review it (check <https://coala.io/reviewing> for more info)
- if you are sure that it needs work, use `cobot mark wip <URL>` to get it out
  of the review queue.

The more you review, the more your score will grow at coala.io and we will
review your PRs faster!
