### PR TITLE
aspectModule: Add ``get()`` method

### DIFF
--- a/coalib/bearlib/aspects/__init__.py
+++ b/coalib/bearlib/aspects/__init__.py
@@ -54,6 +54,24 @@ class aspectsModule(ModuleType):
                 subaspect = getattr(submod, submodname)
                 setattr(self, submodname, subaspect)
 
+    def get(self, aspectname):
+        """
+        Search and get an aspectclass from string of full or partial
+        qualified name of the aspect. Similiar to ``__getitem__``, but doesn't
+        raise exception for trying to search non existing aspect.
+
+        :param aspectname:
+            Name of the aspect that should be searched.
+        :raise MultipleAspectFoundError:
+            When multiple aspects with same name was found.
+        :return:
+            An aspectclass or None.
+        """
+        try:
+            return self[aspectname]
+        except AspectNotFoundError:
+            return None
+
     def __getitem__(self, aspectname):
         regex = re.compile('(^|\.)%s$' % aspectname.lower())
         matches = []

--- a/tests/bearlib/aspects/ModuleTest.py
+++ b/tests/bearlib/aspects/ModuleTest.py
@@ -5,9 +5,10 @@ from coalib.bearlib.aspects.exceptions import (AspectNotFoundError,
                                                MultipleAspectFoundError)
 
 import pytest
+import unittest
 
 
-class aspectsModuleTest:
+class aspectsModuleTest(unittest.TestCase):
 
     def test_module(self):
         # check that module is correctly wrapped
@@ -48,3 +49,34 @@ class aspectsModuleTest:
                       r' <aspectclass'
                       r" 'Root.Metadata.CommitMessage.Shortlog.Length'>"
                       r'\]$')
+
+    def test_get(self):
+        # check a leaf aspect
+        for aspectname in ['clone', 'redundancy.clone',
+                           'root.redundancy.clone']:
+            self.assertIs(coalib.bearlib.aspects.get(aspectname),
+                          coalib.bearlib.aspects.Root.Redundancy.Clone)
+        # check a container aspect
+        for aspectname in ['Spelling', 'SPELLING', 'ROOT.spelling']:
+            self.assertIs(coalib.bearlib.aspects.get(aspectname),
+                          coalib.bearlib.aspects.Root.Spelling)
+        # check root aspect
+        for aspectname in ['Root', 'root', 'ROOT']:
+            self.assertIs(coalib.bearlib.aspects.get(aspectname),
+                          coalib.bearlib.aspects.Root)
+
+    def test_get_no_match(self):
+        for aspectname in ['noaspect', 'NOASPECT', 'Root.aspectsYEAH']:
+            self.assertIsNone(coalib.bearlib.aspects.get(aspectname))
+
+    def test_get_multi_match(self):
+        with self.assertRaisesRegex(
+                MultipleAspectFoundError,
+                r"^Multiple aspects named 'length'. "
+                r'Choose from '
+                r'\[<aspectclass'
+                r" 'Root.Metadata.CommitMessage.Body.Length'>,"
+                r' <aspectclass'
+                r" 'Root.Metadata.CommitMessage.Shortlog.Length'>"
+                r'\]$'):
+            coalib.bearlib.aspects.get('length')


### PR DESCRIPTION
Create ``get()`` function as wrapper of ``__getitem__`` that doesn't 
raise error when trying to access non-existant aspect.

Closes https://github.com/coala/coala/issues/4411

Relates to https://gitlab.com/coala/GSoC-2017/issues/314