### PR TITLE
Newcomers_Guide.rst: Fix inline code 

### DIFF
--- a/docs/Developers/Newcomers_Guide.rst
+++ b/docs/Developers/Newcomers_Guide.rst
@@ -244,6 +244,7 @@ fork repository.
    will work.
 
    ::
+
         $ git checkout -b <branchname>
 
 Now you need to make sure your change is actually working. For this, you will


### PR DESCRIPTION
Fixes: #3276 

- Fix Newcomers_Guide, `$ git checkout -b <branchname>` now appears as inline code.