### PR TITLE
aspectbase: Recursively instance aspect children

### DIFF
--- a/coalib/bearlib/aspects/base.py
+++ b/coalib/bearlib/aspects/base.py
@@ -31,15 +31,10 @@ def get_subaspect(parent, subaspect):
     >>> get_subaspect(metadata, 'shortlog')
     <aspectclass 'Root.Metadata.CommitMessage.Shortlog'>
 
-    Trying to access children of aspect instance will raise
-    NotImplementedError because of instanced aspect doesn't instance
-    its children and will cause wrong result.
-    See https://github.com/coala/coala/issues/4388
+    We can also get child instance of an aspect instance.
 
     >>> get_subaspect(metadata('Python'), commit_msg)
-    Traceback (most recent call last):
-    ...
-    NotImplementedError: Cannot access children of aspect instance.
+    <...CommitMessage object at 0x...>
 
     But, passing subaspect instance as argument is prohibited, because
     it doesn't really make sense.
@@ -63,9 +58,6 @@ def get_subaspect(parent, subaspect):
     if isinstance(subaspect, aspectbase):
         raise AttributeError('Cannot search an aspect instance using '
                              'another aspect instance as argument.')
-    if isinstance(parent, aspectbase):
-        raise NotImplementedError('Cannot access children of aspect '
-                                  'instance.')
 
     parent_qualname = (type(parent).__qualname__ if isinstance(
                        parent, aspectbase) else parent.__qualname__)
@@ -129,10 +121,10 @@ class aspectbase:
             else:
                 setattr(self, name, taste_values.get(name, taste.default))
         # Recursively instance its subaspects too
-            instanced_child = {}
-            for name, child in self.subaspects.items():
-                instanced_child[name] = child(language, **taste_values)
-            self.__dict__['subaspects'] = instanced_child
+        instanced_child = {}
+        for name, child in self.subaspects.items():
+            instanced_child[name] = child(language, **taste_values)
+        self.__dict__['subaspects'] = instanced_child
 
     def __eq__(self, other):
         return type(self) is type(other) and self.tastes == other.tastes

--- a/coalib/bearlib/aspects/base.py
+++ b/coalib/bearlib/aspects/base.py
@@ -128,6 +128,11 @@ class aspectbase:
                         type(self).__qualname__, name, language))
             else:
                 setattr(self, name, taste_values.get(name, taste.default))
+        # Recursively instance its subaspects too
+            instanced_child = {}
+            for name, child in self.subaspects.items():
+                instanced_child[name] = child(language, **taste_values)
+            self.__dict__['subaspects'] = instanced_child
 
     def __eq__(self, other):
         return type(self) is type(other) and self.tastes == other.tastes

--- a/tests/bearlib/aspects/InstanceTest.py
+++ b/tests/bearlib/aspects/InstanceTest.py
@@ -5,6 +5,21 @@ import coalib.bearlib.aspects
 
 class AspectInstanceTest:
 
+    def test_instantiation(self, RootAspect, SubAspect, SubSubAspect):
+        root_instance = RootAspect('py')
+        instance_counter = 0
+
+        def test_child(aspects):
+            for aspect in aspects:
+                assert isinstance(aspect, coalib.bearlib.aspects.aspectbase)
+                nonlocal instance_counter
+                instance_counter += 1
+                if aspect.subaspects:
+                    test_child(aspect.subaspects.values())
+        test_child([root_instance])
+        # RootAspect itself + 2 of its recursive subaspects
+        assert instance_counter == 3
+
     def test_tastes(
             self, SubAspect, SubAspect_tastes, SubAspect_taste_values):
         using_default_values = SubAspect('py')

--- a/tests/bearlib/aspects/InstanceTest.py
+++ b/tests/bearlib/aspects/InstanceTest.py
@@ -54,9 +54,8 @@ class AspectInstanceTest:
 
         assert SubAspect.get(RootAspect) is None
 
-        with pytest.raises(NotImplementedError) as exc:
-            RootAspect('py').get(SubAspect)
-        exc.match('Cannot access children of aspect instance.')
+        assert RootAspect('py').get(SubAspect) == SubAspect('py')
+        assert RootAspect('py').get(SubSubAspect) == SubSubAspect('py')
 
         with pytest.raises(AttributeError) as exc:
             RootAspect.get(SubAspect('py'))


### PR DESCRIPTION
Modify aspectbase constructor to recursively init their children
subaspects.

Note that accessing child instance MUST be done through `.subaspects`
dict.

```python
>>> commit_msg = coala_aspects['CommitMessage']('py')
>>> commit_msg
<...Metadata.CommitMessage object at 0x...>
>>> commit_msg.subaspects
{'Emptiness': <...CommitMessage.Emptiness object at 0x...>,
'Shortlog': <...CommitMessage.Shortlog object at 0x...>, ...}
>>> commit_msg.subaspects['Emptiness'] # Got instance
<..CommitMessage.Emptiness object at 0x...>
>>> commit_msg.Emptiness # Got aspectclass instead
<aspectclass 'Root.Metadata.CommitMessage.Emptiness'>
```

We can also set children taste through its parent.

```python
>>> commit_msg = coala_aspects['CommitMessage'] ('py', shortlog_tense='past')
>>> commit_msg.subaspects['Shortlog'].subaspects['Tense']
<Tense object(shortlog_tense='past') at 0x...>
```

Fixes https://github.com/coala/coala/issues/4388

area/aspects @userzimmermann