### PR TITLE
AspectList: Add ``exclude`` attribute

### DIFF
--- a/coalib/bearlib/aspects/collections.py
+++ b/coalib/bearlib/aspects/collections.py
@@ -7,7 +7,7 @@ class AspectList(list):
     List-derived container to hold aspects.
     """
 
-    def __init__(self, seq=()):
+    def __init__(self, seq=(), exclude=None):
         """
         Initialize a new AspectList.
 
@@ -21,14 +21,18 @@ class AspectList(list):
 
         :param seq: A sequence containing either aspectclass, aspectclass
                     instance, or string of partial/full qualified aspect name.
+        :param exclude: A sequence of either aspectclass or string of aspect
+                        name that marked as excluded from the list.
         """
         super().__init__((item if isaspect(item) else
                           coalib.bearlib.aspects[item] for item in seq))
 
+        self.exclude = AspectList(exclude) if exclude is not None else []
+
     def __contains__(self, aspect):
         for item in self:
             if issubaspect(aspect, item):
-                return True
+                return aspect not in self.exclude
         return False
 
     def get(self, aspect):
@@ -42,6 +46,8 @@ class AspectList(list):
         """
         if not isaspect(aspect):
             aspect = coalib.bearlib.aspects[aspect]
+        if aspect in self.exclude:
+            return None
         try:
             return next(filter(None, (item.get(aspect) for item in self)))
         except StopIteration:

--- a/tests/bearlib/aspects/CollectionsTest.py
+++ b/tests/bearlib/aspects/CollectionsTest.py
@@ -10,6 +10,18 @@ from coalib.bearlib.aspects.Metadata import Metadata
 
 class AspectListTest(unittest.TestCase):
 
+    def setUp(self):
+        self.aspectlist_excludes = AspectList(
+            seq=[Metadata.CommitMessage.Shortlog,
+                 Metadata.CommitMessage.Body],
+            exclude=[Metadata.CommitMessage.Shortlog.TrailingPeriod,
+                     Metadata.CommitMessage.Body.Existence])
+        self.instancelist_excludes = AspectList(
+            seq=[Metadata.CommitMessage.Shortlog('py'),
+                 Metadata.CommitMessage.Body('py')],
+            exclude=[Metadata.CommitMessage.Shortlog.TrailingPeriod,
+                     Metadata.CommitMessage.Body.Existence])
+
     def test__init__(self):
         list_of_aspect = AspectList(['CommitMessage.Shortlog',
                                      'CommitMessage.Body'])
@@ -44,6 +56,14 @@ class AspectListTest(unittest.TestCase):
         exc.match("<class 'str'> is not an "
                   'aspectclass or an instance of an aspectclass')
 
+    def test__contains__excludes(self):
+        self.assertIn(Metadata.CommitMessage.Shortlog.ColonExistence,
+                      self.aspectlist_excludes)
+        self.assertNotIn(Metadata.CommitMessage.Shortlog.TrailingPeriod,
+                         self.aspectlist_excludes)
+        self.assertNotIn(Metadata.CommitMessage.Body.Existence,
+                         self.aspectlist_excludes)
+
     def test_get(self):
         list_of_aspect = AspectList(
             [Metadata.CommitMessage.Shortlog, Metadata.CommitMessage.Body])
@@ -54,3 +74,21 @@ class AspectListTest(unittest.TestCase):
         self.assertIs(list_of_aspect.get('Body.Length'),
                       Metadata.CommitMessage.Body.Length)
         self.assertIsNone(list_of_aspect.get(Metadata))
+
+    def test_get_excludes(self):
+        CommitMessage = Metadata.CommitMessage
+        ColonExistence = Metadata.CommitMessage.Shortlog.ColonExistence
+
+        self.assertIs(self.aspectlist_excludes.get(ColonExistence),
+                      ColonExistence)
+        self.assertIsNone(self.aspectlist_excludes.get(
+                          CommitMessage.Shortlog.TrailingPeriod))
+        self.assertIsNone(self.aspectlist_excludes.get(
+                          CommitMessage.Body.Existence))
+
+        self.assertEqual(self.instancelist_excludes.get(ColonExistence),
+                         ColonExistence('py'))
+        self.assertIsNone(self.instancelist_excludes.get(
+                          CommitMessage.Shortlog.TrailingPeriod))
+        self.assertIsNone(self.instancelist_excludes.get(
+                          CommitMessage.Body.Existence))


### PR DESCRIPTION
Extend AspectList class to have `excludes` attribute that hold list of
aspect that marked as exception of the list. Trying to access aspect
or subaspect of item in `excludes` will always give False/None.

```.python
>>> Metadata not in AspectList([Root], excludes=[Metadata])
True
>>> AspectList([Root], excludes=[Metadata]).get('metadata')
None
```

This feature will be used to excluding ("deactivate") an aspect that
was defined in user's coala configuration.

Closes https://github.com/coala/coala/issues/4438

Note that this PR is dependent (and blocked) by https://github.com/coala/coala/pull/4427 and contain commit from that PR too.