### PR TITLE
Linter.py: Stop TypeError raised on debug logging

### DIFF
--- a/coalib/bearlib/abstractions/Linter.py
+++ b/coalib/bearlib/abstractions/Linter.py
@@ -654,7 +654,8 @@ def _create_linter(klass, options):
                     return
 
                 arguments = (self.get_executable(),) + args
-                self.debug("Running '{}'".format(' '.join(arguments)))
+                self.debug("Running '{}'".format(
+                    ' '.join(str(arg) for arg in arguments)))
 
                 output = run_shell_command(
                     arguments,


### PR DESCRIPTION
Pass through arguments list to avoid arguments
that are None.
If argument is None, 'None' gets added to the
arguments string for verbosity.

Closes https://github.com/coala/coala/issues/4433