### PR TITLE
DocstyleDefinition .get_available_definitions: Renew parser foreach *.coalang

### DIFF
--- a/coalib/bearlib/languages/documentation/DocstyleDefinition.py
+++ b/coalib/bearlib/languages/documentation/DocstyleDefinition.py
@@ -202,12 +202,12 @@ class DocstyleDefinition:
 
         :return: A sequence of pairs with ``(docstyle, language)``.
         """
-        language_config_parser = ConfParser(remove_empty_iter_elements=False)
         pattern = os.path.join(os.path.dirname(__file__), '*.coalang')
 
         for coalang_file in iglob(pattern):
             docstyle = os.path.splitext(os.path.basename(coalang_file))[0]
             # Ignore files that are not lowercase, as coalang files have to be.
             if docstyle.lower() == docstyle:
-                for language in language_config_parser.parse(coalang_file):
+                parser = ConfParser(remove_empty_iter_elements=False)
+                for language in parser.parse(coalang_file):
                     yield docstyle, language.lower()


### PR DESCRIPTION
To avoid ConfParser warnings resulting from section overrides with common keys, resulting in `coala-bears` CI **FAIL** on building docs with `sphinx-build -W`, like mentioned in https://github.com/coala/coala-bears/pull/1819#issuecomment-309059574 :

https://circleci.com/gh/coala/coala-bears/6570#tests/containers/1 :

```
Warning, treated as error:
param_start setting has already been defined in section PYTHON. The previous setting will be overridden.
make: *** [html] Error 1
make: Leaving directory `/home/ubuntu/coala-bears/docs'
```

Fixes https://github.com/coala/coala/issues/4470

Prerequisite for https://github.com/coala/coala-bears/pull/1819

@sils @Makman2