### PR TITLE
Core: Allow custom executor to run session

### DIFF
--- a/coalib/core/Core.py
+++ b/coalib/core/Core.py
@@ -327,7 +327,7 @@ def initialize_dependencies(bears):
     return dependency_tracker, bears
 
 
-def run(bears, result_callback):
+def run(bears, result_callback, executor=None):
     """
     Runs a coala session.
 
@@ -339,14 +339,13 @@ def run(bears, result_callback):
 
             def result_callback(result):
                 pass
+    :param executor:
+        Custom executor used to run the bears.
     """
-    # FIXME Allow to pass different executors nicely, for example to execute
-    # FIXME   coala with less cores, or to schedule jobs on distributed systems
-    # FIXME   (for example Mesos).
-
     # Set up event loop and executor.
     event_loop = asyncio.SelectorEventLoop()
-    executor = concurrent.futures.ProcessPoolExecutor()
+    if executor is None:
+        executor = concurrent.futures.ProcessPoolExecutor()
 
     # Initialize dependency tracking.
     dependency_tracker, bears_to_schedule = initialize_dependencies(bears)

--- a/tests/core/CoreTest.py
+++ b/tests/core/CoreTest.py
@@ -377,13 +377,13 @@ class CoreTest(unittest.TestCase):
         self.filedict1 = {'f1': []}
 
     @staticmethod
-    def execute_run(bears):
+    def execute_run(bears, executor=None):
         results = []
 
         def on_result(result):
             results.append(result)
 
-        run(bears, on_result)
+        run(bears, on_result, executor)
 
         return results
 
@@ -609,6 +609,18 @@ class CoreTest(unittest.TestCase):
         bear = MultiTaskBear(self.section1, self.filedict1, tasks_count=100)
 
         results = self.execute_run({bear})
+
+        result_set = set(results)
+        self.assertEqual(len(result_set), len(results))
+        self.assertEqual(result_set, {i for i in range(100)})
+        self.assertEqual(bear.dependency_results, {})
+
+    def test_custom_executor(self):
+        bear = MultiTaskBear(self.section1, self.filedict1, tasks_count=100)
+
+        import concurrent.futures
+        results = self.execute_run(
+            {bear}, concurrent.futures.ThreadPoolExecutor(max_workers=10))
 
         result_set = set(results)
         self.assertEqual(len(result_set), len(results))


### PR DESCRIPTION
This patch enables user to pass custom executor
to be passed to run session

Closes: https://github.com/coala/coala/issues/4349

<!--
Thanks for your contribution!

Please take a quick look at those things down there. They're quite important.
Really! We wrote them for you. Yes you! With utmost care. Read them.
-->

**For short term contributors:** we understand that getting your commits well
defined like we require is a hard task and takes some learning. If you
look to help without wanting to contribute long term there's no need
for you to learn this. Just drop us a message and we'll take care of brushing
up your stuff for merge!

### Checklist

- [ ] I read the [commit guidelines](http://coala.io/commit) and I've followed
      them.
- [ ] I ran coala over my code locally. (*All commits have to pass
      individually.* It is not sufficient to have "fixup commits" on your PR,
      our bot will still report the issues for the previous commit.) You will
      likely receive a lot of bot comments and build failures if coala does not
      pass on every single commit!

After you submit your pull request, **DO NOT click the 'Update Branch' button.**
When asked for a rebase, consult [coala.io/rebase](https://coala.io/rebase)
instead.

Please consider helping us by reviewing other peoples pull requests as well:

- pick up any PR at <https://coala.io/review>
- review it (check <https://coala.io/reviewing> for more info)
- if you are sure that it needs work, use `cobot mark wip <URL>` to get it out
  of the review queue.

The more you review, the more your score will grow at coala.io and we will
review your PRs faster!
