### PR TITLE
.travis.yml: Add csslint to PATH

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,10 @@ matrix:
       env: UNSUPPORTED=true
       script: .misc/check_unsupported.sh
 
+env:
+  global:
+    - PATH="$PATH:$TRAVIS_BUILD_DIR/node_modules/.bin"
+
 cache:
   pip: true
   directories:


### PR DESCRIPTION
The old precise workers, using Node.js v0.10.36, are
being replaced with Trusty workers that use nvm and
have v7 as default.  Install csslint globally in nvm
and cache $HOME/.nvm.

Fixes https://github.com/coala/coala/issues/4513
