### PR TITLE
BearTest: Remove urllib3 ProtocolError

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,10 @@ matrix:
       env: UNSUPPORTED=true
       script: .misc/check_unsupported.sh
 
+env:
+  global:
+    - PATH="$PATH:$TRAVIS_BUILD_DIR/node_modules/.bin"
+
 cache:
   pip: true
   directories:

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -17,4 +17,3 @@ pytest-xdist~=1.14
 requests-mock~=1.2
 pip>=9.0.0
 wheel~=0.29
-urllib3~=1.21

--- a/tests/bears/BearTest.py
+++ b/tests/bears/BearTest.py
@@ -10,7 +10,6 @@ from freezegun import freeze_time
 
 import requests
 import requests_mock
-import urllib3
 
 from coalib.bearlib.aspects.collections import AspectList
 from coalib.bearlib.aspects.Metadata import CommitMessage
@@ -371,7 +370,6 @@ class BearDownloadTest(BearTestBase):
     def test_read_broken(self):
         exc = (
             requests.exceptions.RequestException,
-            urllib3.exceptions.ProtocolError,
         )
         fake_content = [b'Fake read data', b'Another line']
         fake_content_provider = BrokenReadHTTPResponse(fake_content)


### PR DESCRIPTION


When requests was undergoing frequent breakages, a `ProtocolError`

was being raise unexpectedly when provoking a broken read scenario.
This exception was added as an alternative as it was at least
a predictable error occurring, allowing the remainder of the
test method to verify the resulting behaviour of the method,
and there were far bigger problems occurring at the time
due to `requests` being broken several time a day.

Depending on urllib3 for this ProtocolError is problematic,
as requests has its own version requirements for urllib3,
and those must take precedence over coala testing needs.
A conflict between requests and urllib3 has broken the
docker image.

It seems ProtocolError is not being thrown any longer,
and removing it bypasses the urllib3 conflict.
Should a ProtocolError occur again, it should be
investigated.

Fixes coala#4512