### PR TITLE
DocBaseClass: Fix java docstyle bug

### DIFF
--- a/coalib/bearlib/languages/documentation/DocBaseClass.py
+++ b/coalib/bearlib/languages/documentation/DocBaseClass.py
@@ -127,21 +127,22 @@ def _extract_doc_comment_standard(content, line, column, markers):
     line += 1
 
     while line < len(content):
-        pos = content[line].find(markers[2])
-        each_line_pos = content[line].find(markers[1])
+        pos = content[line].find(markers[2].strip())
+        each_line_pos = content[line].find(markers[1].strip())
 
         if pos == -1:
             if each_line_pos == -1:
                 # If the first text occurrence is not the each-line marker
                 # now we violate the doc-comment layout.
                 return None
-            doc_comment += content[line][each_line_pos + len(markers[1]):]
+            doc_comment += content[line][
+                           each_line_pos + len(markers[1].strip()):]
         else:
             # If no each-line marker found or it's located past the end marker:
             # extract no further and end the doc-comment.
             if each_line_pos != -1 and each_line_pos + 1 < pos:
                 doc_comment += content[line][each_line_pos +
-                                             len(markers[1]):pos]
+                                             len(markers[1].strip()):pos]
 
             return line, pos + len(markers[2]), doc_comment
 

--- a/tests/bearlib/languages/documentation/DocBaseClassTest.py
+++ b/tests/bearlib/languages/documentation/DocBaseClassTest.py
@@ -72,7 +72,7 @@ class DocBaseClassTest(unittest.TestCase):
 
         self.assertEqual(
             list(DocBaseClass.extract(data, 'C', 'doxygen')),
-            [DocumentationComment(' my main description\n continues here',
+            [DocumentationComment(' my main description\n continues here ',
                                   docstyle_C_doxygen, '',
                                   docstyle_C_doxygen.markers[0],
                                   TextPosition(1, 1))])

--- a/tests/bearlib/languages/documentation/DocumentationCommentTest.py
+++ b/tests/bearlib/languages/documentation/DocumentationCommentTest.py
@@ -243,7 +243,12 @@ class JavaDocumentationCommentTest(DocumentationCommentTest):
                      self.ExceptionValue(name='IOException',
                                          desc='throws IOException\n'),
                      self.ReturnValue(
-                         desc='     the concatenated string\n')]]
+                         desc='     the concatenated string\n')],
+                    [self.Description(
+                     desc='\n Returns Area of a square.\n\n'),
+                     self.Parameter(name='side', desc='side of square\n'),
+                     self.ReturnValue(desc=' area of a square\n')],
+                    ]
 
         self.assertEqual(expected, parsed_docs)
 

--- a/tests/bearlib/languages/documentation/documentation_extraction_testdata/default.c
+++ b/tests/bearlib/languages/documentation/documentation_extraction_testdata/default.c
@@ -33,7 +33,8 @@ int foobar(int x) {
 }
 
      /** line 1
-      *  line2 */
+      *  line2
+      */
 
     /** */
 

--- a/tests/bearlib/languages/documentation/documentation_extraction_testdata/default.java
+++ b/tests/bearlib/languages/documentation/documentation_extraction_testdata/default.java
@@ -11,3 +11,16 @@ class HelloWorld {
         return "Hello, " + name;
     }
 }
+
+class AreaSquare {
+
+/**
+* Returns Area of a square.
+*
+* @param  side side of square
+* @return  area of a square
+*/
+    public String sayHello(int side) {
+        return side * side;
+    }
+}


### PR DESCRIPTION
Bug fix for java docstyles having no trailing
spaces before marker[1] and marker[2]

Fixes https://github.com/coala/coala/issues/4029

<!--
Thanks for your contribution!

Please take a quick look at those things down there. They're quite important.
Really! We wrote them for you. Yes you! With utmost care. Read them.
-->

**For short term contributors:** we understand that getting your commits well
defined like we require is a hard task and takes some learning. If you
look to help without wanting to contribute long term there's no need
for you to learn this. Just drop us a message and we'll take care of brushing
up your stuff for merge!

### Checklist

- [x] I read the [commit guidelines](http://coala.io/commit) and I've followed
      them.
- [x] I ran coala over my code locally. (*All commits have to pass
      individually.* It is not sufficient to have "fixup commits" on your PR,
      our bot will still report the issues for the previous commit.) You will
      likely receive a lot of bot comments and build failures if coala does not
      pass on every single commit!

After you submit your pull request, **DO NOT click the 'Update Branch' button.**
When asked for a rebase, consult [coala.io/rebase](https://coala.io/rebase)
instead.

Please consider helping us by reviewing other peoples pull requests as well:

- pick up any PR at <https://coala.io/review>
- review it (check <https://coala.io/reviewing> for more info)
- if you are sure that it needs work, use `cobot mark wip <URL>` to get it out
  of the review queue.

The more you review, the more your score will grow at coala.io and we will
review your PRs faster!
