### PR TITLE
Restore functions removed in bear filter rewrite

### DIFF
--- a/coalib/collecting/Collectors.py
+++ b/coalib/collecting/Collectors.py
@@ -184,6 +184,26 @@ def collect_bears(bear_dirs, bear_globs, kinds, log_printer,
     return bears_found
 
 
+def filter_section_bears_by_languages(bears, languages):
+    """
+    Filters the bears by languages.
+
+    :param bears:       The dictionary of the sections as keys and list of
+                        bears as values.
+    :param languages:   Languages that bears are being filtered on.
+    :return:            New dictionary with filtered out bears that don't match
+                        any language from languages.
+    """
+    new_bears = {}
+    # All bears with "all" languages supported shall be shown
+    languages = set(language.lower() for language in languages) | {'all'}
+    for section in bears.keys():
+        new_bears[section] = tuple(
+            bear for bear in bears[section]
+            if {language.lower() for language in bear.LANGUAGES} & languages)
+    return new_bears
+
+
 def filter_capabilities_by_languages(bears, languages):
     """
     Filters the bears capabilities by languages.

--- a/coalib/settings/ConfigurationGathering.py
+++ b/coalib/settings/ConfigurationGathering.py
@@ -3,7 +3,8 @@ import re
 import sys
 import logging
 
-from coalib.collecting.Collectors import collect_all_bears_from_sections
+from coalib.collecting.Collectors import (
+    collect_all_bears_from_sections, filter_section_bears_by_languages)
 from coalib.misc import Constants
 from coalib.output.ConfWriter import ConfWriter
 from coalib.output.printers.LOG_LEVEL import LOG_LEVEL
@@ -346,6 +347,23 @@ def get_all_bears(log_printer, arg_parser=None):
                                      arg_parser=arg_parser)
     local_bears, global_bears = collect_all_bears_from_sections(
         sections, log_printer)
+    return local_bears, global_bears
+
+
+def get_filtered_bears(languages, log_printer, arg_parser=None):
+    """
+    :param languages:   List of languages.
+    :param log_printer: The log_printer to handle logging.
+    :param arg_parser:  An ``ArgParser`` object.
+    :return:            Tuple containing dictionaries of local bears
+                        and global bears.
+    """
+    local_bears, global_bears = get_all_bears(log_printer, arg_parser)
+    if languages:
+        local_bears = filter_section_bears_by_languages(
+            local_bears, languages)
+        global_bears = filter_section_bears_by_languages(
+            global_bears, languages)
     return local_bears, global_bears
 
 

--- a/tests/collecting/CollectorsTest.py
+++ b/tests/collecting/CollectorsTest.py
@@ -6,9 +6,9 @@ from pyprint.ConsolePrinter import ConsolePrinter
 
 from coalib.bears.Bear import Bear
 from coalib.collecting.Collectors import (
-    collect_all_bears_from_sections, collect_bears, collect_dirs,
-    collect_files, collect_registered_bears_dirs, get_all_bears,
-    get_all_bears_names)
+    collect_all_bears_from_sections, collect_bears, collect_dirs, collect_files,
+    collect_registered_bears_dirs, filter_section_bears_by_languages,
+    get_all_bears, get_all_bears_names)
 from coalib.output.printers.LogPrinter import LogPrinter
 from coalib.output.printers.ListLogPrinter import ListLogPrinter
 from coalib.settings.Section import Section
@@ -283,6 +283,24 @@ class CollectorsTests(unittest.TestCase):
         self.collectors_test_dir = os.path.join(current_dir,
                                                 'collectors_test_dir')
         self.log_printer = LogPrinter(ConsolePrinter())
+
+    def test_filter_section_bears_by_languages(self):
+        test_section = Section('test_section')
+        test_section.bear_dirs = lambda: os.path.join(self.collectors_test_dir,
+                                                      'bears_local_global',
+                                                      '**')
+        local_bears, global_bears = collect_all_bears_from_sections(
+            {'test_section': test_section},
+            self.log_printer)
+        local_bears = filter_section_bears_by_languages(local_bears, ['C'])
+        self.assertEqual(len(local_bears['test_section']), 1)
+        self.assertEqual(str(local_bears['test_section'][0]),
+                         "<class 'bears2.Test2LocalBear'>")
+
+        global_bears = filter_section_bears_by_languages(global_bears, ['Java'])
+        self.assertEqual(len(global_bears['test_section']), 1)
+        self.assertEqual(str(global_bears['test_section'][0]),
+                         "<class 'bears1.Test1GlobalBear'>")
 
     def test_get_all_bears(self):
         with bear_test_module():


### PR DESCRIPTION
These functions were removed in 498c731, breaking
coala-quickstart.
CollectorsTest is also restored.
New test added to ConfigurationGatheringTest, as the previous
covered code path no longer uses get_filtered_bears.

Fixes https://github.com/coala/coala/issues/4519
