### PR TITLE
DocumentationComment.py: Add blankline padding

### DIFF
--- a/coalib/bearlib/languages/documentation/DocumentationComment.py
+++ b/coalib/bearlib/languages/documentation/DocumentationComment.py
@@ -17,6 +17,8 @@ class DocumentationComment:
     ExceptionValue = namedtuple('ExceptionValue', 'name, desc')
     ReturnValue = namedtuple('ReturnValue', 'desc')
     Description = namedtuple('Description', 'desc')
+    top_padding = 0
+    bottom_padding = 0
 
     def __init__(self, documentation, docstyle_definition,
                  indent, marker, position):
@@ -275,7 +277,10 @@ class DocumentationComment:
         assembled += ''.join('\n' if line == '\n' and not self.marker[1]
                              else self.indent + self.marker[1] + line
                              for line in lines[1:])
-        return (assembled if self.marker[1] == self.marker[2] else
-                (assembled +
-                 (self.indent if lines[-1][-1] == '\n' else '') +
-                 self.marker[2]))
+        assembled = (assembled if self.marker[1] == self.marker[2] else
+                     (assembled +
+                      (self.indent if lines[-1][-1] == '\n' else '') +
+                      self.marker[2]))
+        assembled = ('\n' * self.top_padding + assembled +
+                     '\n' * self.bottom_padding)
+        return assembled

--- a/tests/bearlib/languages/documentation/DocumentationCommentTest.py
+++ b/tests/bearlib/languages/documentation/DocumentationCommentTest.py
@@ -279,6 +279,8 @@ class DocumentationAssemblyTest(unittest.TestCase):
         docs = ''.join(data)
 
         for doc in DocBaseClass.extract(data, 'python', 'default'):
+            doc.bottom_padding = 2
+            doc.assemble.cache_clear()
             self.assertIn(doc.assemble(), docs)
 
     def test_doxygen_assembly(self):
@@ -293,4 +295,6 @@ class DocumentationAssemblyTest(unittest.TestCase):
         docs = ''.join(data)
 
         for doc in DocBaseClass.extract(data, 'c', 'doxygen'):
+            doc.top_padding = 1
+            doc.assemble.cache_clear()
             self.assertIn(doc.assemble(), docs)

--- a/tests/bearlib/languages/documentation/documentation_extraction_testdata/default.py
+++ b/tests/bearlib/languages/documentation/documentation_extraction_testdata/default.py
@@ -4,12 +4,17 @@ Module description.
 Some more foobar-like text.
 """
 
+
 def foobar_explosion(radius):
     """
     A nice and neat way of documenting code.
     :param radius: The explosion radius. """
+
+
     def get_55():
         """A function that returns 55."""
+
+
         return 55
     return get_55() * radius
 
@@ -19,6 +24,7 @@ Docstring with layouted text.
     layouts inside docs are preserved.
 this is intended.
 """
+
 
 """ Docstring inline with triple quotes.
     Continues here. """
@@ -36,6 +42,8 @@ def best_docstring(param1, param2):
     :return: Long Return Description That Makes No Sense And Will
              Cut to the Next Line.
     """
+
+
     return None
 
 def docstring_find(filename):
@@ -50,6 +58,7 @@ def docstring_find(filename):
     :return: returns all possible docstrings in a file
     """
 
+
 def foobar_triangle(side_A, side_B, side_C):
     """
     This returns perimeter of a triangle.   
@@ -63,6 +72,8 @@ def foobar_triangle(side_A, side_B, side_C):
 
     :return: returns perimeter
     """
+
+
     return side_A + side_B + side_C
 
     # This example of triple quote string literal is ignored.


### PR DESCRIPTION
`assemble()` now adds a blank line before or after
docstring based on top_padding and bottom_padding.

Closes https://github.com/coala/coala/issues/4200

<!--
Thanks for your contribution!

Please take a quick look at those things down there. They're quite important.
Really! We wrote them for you. Yes you! With utmost care. Read them.
-->

**For short term contributors:** we understand that getting your commits well
defined like we require is a hard task and takes some learning. If you
look to help without wanting to contribute long term there's no need
for you to learn this. Just drop us a message and we'll take care of brushing
up your stuff for merge!

### Checklist

- [x] I read the [commit guidelines](http://coala.io/commit) and I've followed
      them.
- [x] I ran coala over my code locally. (*All commits have to pass
      individually.* It is not sufficient to have "fixup commits" on your PR,
      our bot will still report the issues for the previous commit.) You will
      likely receive a lot of bot comments and build failures if coala does not
      pass on every single commit!

After you submit your pull request, **DO NOT click the 'Update Branch' button.**
When asked for a rebase, consult [coala.io/rebase](https://coala.io/rebase)
instead.

Please consider helping us by reviewing other peoples pull requests as well:

- pick up any PR at <https://coala.io/review>
- review it (check <https://coala.io/reviewing> for more info)
- if you are sure that it needs work, use `cobot mark wip <URL>` to get it out
  of the review queue.

The more you review, the more your score will grow at coala.io and we will
review your PRs faster!
