### PR TITLE
DocumentationAPI: Add `padding`

### DIFF
--- a/coalib/bearlib/languages/documentation/DocumentationComment.py
+++ b/coalib/bearlib/languages/documentation/DocumentationComment.py
@@ -19,6 +19,7 @@ class DocumentationComment:
     Description = namedtuple('Description', 'desc')
     top_padding = 0
     bottom_padding = 0
+    docstring_type = 'others'
 
     def __init__(self, documentation, docstyle_definition,
                  indent, marker, position):

--- a/coalib/bearlib/languages/documentation/default.coalang
+++ b/coalib/bearlib/languages/documentation/default.coalang
@@ -5,6 +5,10 @@ param_end = :
 exception_start = :raises\ # here's a space
 exception_end = :
 return_sep = :return:
+docstring_type_regex = class, def # defines class and function signature.
+docstring_position = top # defines position where docstring regex is found.
+class_padding = 0, 1
+function_padding = 0, 0
 
 [PYTHON3]
 doc-marker = """, , """
@@ -13,6 +17,10 @@ param_end = :
 exception_start = :raises\ # here's a space
 exception_end = :
 return_sep = :return:
+docstring_type_regex = class, def # defines class and function signature.
+docstring_position = top # defines position where docstring regex is found.
+class_padding = 0, 1
+function_padding = 0, 0
 
 [JAVA]
 doc-marker1 = /**, \ *, \ */

--- a/coalib/bearlib/languages/documentation/doxygen.coalang
+++ b/coalib/bearlib/languages/documentation/doxygen.coalang
@@ -39,6 +39,10 @@ param_end = \ # here's a space
 exception_start = @raises\ # here's a space
 exception_end = \ # here's a space
 return_sep = @return\ # here's a space
+docstring_type_regex = class, def # defines class and function signature.
+docstring_position = bottom # defines position where docstring regex is found.
+class_padding = 1, 0
+function_padding = 1, 0
 
 [PYTHON3]
 doc-marker1 = """, , """
@@ -48,6 +52,10 @@ param_end = \ # here's a space
 exception_start = @raises\ # here's a space
 exception_end = \ # here's a space
 return_sep = @return\ # here's a space
+docstring_type_regex = class, def # defines class and function signature.
+docstring_position = bottom # defines position where docstring regex is found.
+class_padding = 1, 0
+function_padding = 1, 0
 
 [TCL]
 doc-marker = \#\#, \#, \#

--- a/tests/bearlib/languages/documentation/DocBaseClassTest.py
+++ b/tests/bearlib/languages/documentation/DocBaseClassTest.py
@@ -273,6 +273,151 @@ class DocBaseClassTest(unittest.TestCase):
                                   docstyle_PYTHON3_default.markers[0],
                                   TextPosition(1, 2))])
 
+    def test_DocBaseClass_instantiate_padding_PYTHON3_6(self):
+        data = ['def some_function:\n',
+                '\n',
+                '   """ documentation in single line """\n',
+                '\n',
+                '\n',
+                'print(1)']
+
+        docstyle_PYTHON3_default = DocstyleDefinition.load('PYTHON3',
+                                                           'default')
+
+        for doc in DocBaseClass.extract(data, 'PYTHON3', 'default'):
+            self.assertEqual([doc.top_padding, doc.bottom_padding],
+                             [1, 2])
+
+    def test_DocBaseClass_instantiate_padding_PYTHON3_7(self):
+        data = ['class some_class:\n',
+                '\n',
+                '\n',
+                '   """ documentation in single line """\n',
+                '\n',
+                '\n',
+                'print(1)\n']
+
+        docstyle_PYTHON3_default = DocstyleDefinition.load('PYTHON3',
+                                                           'default')
+
+        for doc in DocBaseClass.extract(data, 'PYTHON3', 'default'):
+            self.assertEqual([doc.top_padding, doc.bottom_padding],
+                             [2, 2])
+
+    def test_DocBaseClass_instantiate_padding_inline_PYTHON3_8(self):
+        # To test that bottom_padding sets to nothing if docstring is
+        # followed by inline docstring.
+        data = ['def some_function:\n',
+                '\n',
+                '   """\n',
+                '   documentation in single line\n',
+                '   """ # This is inline docstring',
+                '\n',
+                '\n',
+                'print(1)']
+
+        docstyle_PYTHON3_default = DocstyleDefinition.load('PYTHON3',
+                                                           'default')
+
+        for doc in DocBaseClass.extract(data, 'PYTHON3', 'default'):
+            self.assertEqual([doc.top_padding, doc.bottom_padding],
+                             [1, 0])
+
+    def test_DocBaseClass_instantiate_padding_inline_PYTHON3_9(self):
+        # Paddings will not be instantiated for docstring_type=others
+        data = ['\n',
+                '   """\n',
+                '   documentation in single line\n',
+                '   """ # This is inline docstring',
+                '\n',
+                '\n',
+                'print(1)']
+
+        docstyle_PYTHON3_default = DocstyleDefinition.load('PYTHON3',
+                                                           'default')
+
+        for doc in DocBaseClass.extract(data, 'PYTHON3', 'default'):
+            self.assertEqual([doc.top_padding, doc.bottom_padding],
+                             [0, 0])
+
+    def test_DocBaseClass_instantiate_docstring_type_PYTHON3_10(self):
+        data = ['class xyz:\n',
+                '   """\n',
+                '   This docstring is of docstring_type class\n',
+                '   """\n']
+
+        docstyle_PYTHON3_default = DocstyleDefinition.load('PYTHON3',
+                                                           'default')
+
+        for doc in DocBaseClass.extract(data, 'PYTHON3', 'default'):
+            self.assertEqual(doc.docstring_type, 'class')
+
+    def test_DocBaseClass_instantiate_docstring_type_PYTHON3_11(self):
+        data = ['def xyz:\n',
+                '   """\n',
+                '   This docstring is of docstring_type function\n',
+                '   """\n']
+
+        docstyle_PYTHON3_default = DocstyleDefinition.load('PYTHON3',
+                                                           'default')
+
+        for doc in DocBaseClass.extract(data, 'PYTHON3', 'default'):
+            self.assertEqual(doc.docstring_type, 'function')
+
+    def test_DocBaseClass_instantiate_docstring_type_PYTHON3_12(self):
+        data = ['\n',
+                '   """\n',
+                '   This docstring is of docstring_type others\n',
+                '   """\n',
+                '\n',
+                'print(1)']
+
+        docstyle_PYTHON3_default = DocstyleDefinition.load('PYTHON3',
+                                                           'default')
+
+        for doc in DocBaseClass.extract(data, 'PYTHON3', 'default'):
+            self.assertEqual(doc.docstring_type, 'others')
+
+    def test_DocBaseClass_instantiate_docstring_type_PYTHON3_13(self):
+        data = ['## Documentation for a function.\n',
+                '#\n',
+                '#  More details.\n',
+                'def func():\n',
+                '    pass\n']
+
+        docstyle_PYTHON3_doxygen = DocstyleDefinition.load('PYTHON3',
+                                                           'doxygen')
+
+        for doc in DocBaseClass.extract(data, 'PYTHON3', 'doxygen'):
+            self.assertEqual(doc.docstring_type, 'function')
+
+    def test_DocBaseClass_instantiate_docstring_type_PYTHON3_14(self):
+        data = ['## Documentation for a class.\n',
+                '#\n',
+                '#  More details.\n',
+                'class PyClass:\n',
+                '\n']
+
+        docstyle_PYTHON3_doxygen = DocstyleDefinition.load('PYTHON3',
+                                                           'doxygen')
+
+        for doc in DocBaseClass.extract(data, 'PYTHON3', 'doxygen'):
+            self.assertEqual(doc.docstring_type, 'class')
+
+    def test_DocBaseClass_instantiate_docstring_type_PYTHON3_15(self):
+        data = ['def some_function():\n',
+                '"""\n',
+                'documentation\n',
+                '"""\n',
+                'class myPrivateClass:\n',
+                '    pass']
+
+        docstyle_PYTHON3_default = DocstyleDefinition.load('PYTHON3',
+                                                           'default')
+
+        for doc in DocBaseClass.extract(data, 'PYTHON3', 'default'):
+            self.assertEqual(doc.docstring_type, 'function')
+
     def test_generate_diff(self):
         data_old = ['\n', '""" documentation in single line  """\n']
         for doc_comment in DocBaseClass.extract(

--- a/tests/bearlib/languages/documentation/DocstyleDefinitionTest.py
+++ b/tests/bearlib/languages/documentation/DocstyleDefinitionTest.py
@@ -8,44 +8,81 @@ from coalib.bearlib.languages.documentation.DocstyleDefinition import (
 class DocstyleDefinitionTest(unittest.TestCase):
 
     Metadata = DocstyleDefinition.Metadata
+    ClassPadding = DocstyleDefinition.ClassPadding
+    FunctionPadding = DocstyleDefinition.FunctionPadding
+    DocstringTypeRegex = DocstyleDefinition.DocstringTypeRegex
     dummy_metadata = Metadata(':param ', ':', ':raises ', ':', ':return:')
+    dummy_class_padding = ClassPadding(1, 1)
+    dummy_function_padding = FunctionPadding(0, 1)
+    dummy_docstring_type_regex = DocstringTypeRegex('class', 'def')
+    dummy_docstring_position = 'top'
 
     def test_fail_instantation(self):
         with self.assertRaises(ValueError):
             DocstyleDefinition('PYTHON', 'doxyGEN',
-                               (('##', '#'),), self.dummy_metadata)
+                               (('##', '#'),), self.dummy_metadata,
+                               self.dummy_class_padding,
+                               self.dummy_function_padding,
+                               self.dummy_docstring_type_regex,
+                               self.dummy_docstring_position)
 
         with self.assertRaises(ValueError):
             DocstyleDefinition('WEIRD-PY',
                                'schloxygen',
                                (('##+', 'x', 'y', 'z'),),
-                               self.dummy_metadata)
+                               self.dummy_metadata,
+                               self.dummy_class_padding,
+                               self.dummy_function_padding,
+                               self.dummy_docstring_type_regex,
+                               self.dummy_docstring_position)
 
         with self.assertRaises(ValueError):
             DocstyleDefinition('PYTHON',
                                'doxygen',
                                (('##', '', '#'), ('"""', '"""')),
-                               self.dummy_metadata)
+                               self.dummy_metadata,
+                               self.dummy_class_padding,
+                               self.dummy_function_padding,
+                               self.dummy_docstring_type_regex,
+                               self.dummy_docstring_position)
 
         with self.assertRaises(TypeError):
             DocstyleDefinition(123, ['doxygen'], (('"""', '"""')),
-                               self.dummy_metadata)
+                               self.dummy_metadata,
+                               self.dummy_class_padding,
+                               self.dummy_function_padding,
+                               self.dummy_docstring_type_regex,
+                               self.dummy_docstring_position)
 
         with self.assertRaises(TypeError):
             DocstyleDefinition('language', ['doxygen'], (('"""', '"""')),
-                               'metdata')
+                               'metdata', 'clpading', 'dfpadding', 'kind')
 
     def test_properties(self):
         uut = DocstyleDefinition('C', 'doxygen',
-                                 (('/**', '*', '*/'),), self.dummy_metadata)
+                                 (('/**', '*', '*/'),), self.dummy_metadata,
+                                 self.dummy_class_padding,
+                                 self.dummy_function_padding,
+                                 self.dummy_docstring_type_regex,
+                                 self.dummy_docstring_position)
 
         self.assertEqual(uut.language, 'c')
         self.assertEqual(uut.docstyle, 'doxygen')
         self.assertEqual(uut.markers, (('/**', '*', '*/'),))
         self.assertEqual(uut.metadata, self.dummy_metadata)
+        self.assertEqual(uut.class_padding, self.dummy_class_padding)
+        self.assertEqual(uut.function_padding, self.dummy_function_padding)
+        self.assertEqual(uut.docstring_type_regex,
+                         self.dummy_docstring_type_regex)
+        self.assertEqual(uut.docstring_position,
+                         self.dummy_docstring_position)
 
         uut = DocstyleDefinition('PYTHON', 'doxyGEN',
-                                 [('##', '', '#')], self.dummy_metadata)
+                                 [('##', '', '#')], self.dummy_metadata,
+                                 self.dummy_class_padding,
+                                 self.dummy_function_padding,
+                                 self.dummy_docstring_type_regex,
+                                 self.dummy_docstring_position)
 
         self.assertEqual(uut.language, 'python')
         self.assertEqual(uut.docstyle, 'doxygen')
@@ -55,7 +92,11 @@ class DocstyleDefinitionTest(unittest.TestCase):
         uut = DocstyleDefinition('I2C',
                                  'my-custom-tool',
                                  (['~~', '/~', '/~'], ('>!', '>>', '>>')),
-                                 self.dummy_metadata)
+                                 self.dummy_metadata,
+                                 self.dummy_class_padding,
+                                 self.dummy_function_padding,
+                                 self.dummy_docstring_type_regex,
+                                 self.dummy_docstring_position)
 
         self.assertEqual(uut.language, 'i2c')
         self.assertEqual(uut.docstyle, 'my-custom-tool')
@@ -63,7 +104,11 @@ class DocstyleDefinitionTest(unittest.TestCase):
         self.assertEqual(uut.metadata, self.dummy_metadata)
 
         uut = DocstyleDefinition('Cpp', 'doxygen',
-                                 ('~~', '/~', '/~'), self.dummy_metadata)
+                                 ('~~', '/~', '/~'), self.dummy_metadata,
+                                 self.dummy_class_padding,
+                                 self.dummy_function_padding,
+                                 self.dummy_docstring_type_regex,
+                                 self.dummy_docstring_position)
 
         self.assertEqual(uut.language, 'cpp')
         self.assertEqual(uut.docstyle, 'doxygen')

--- a/tests/bearlib/languages/documentation/DocumentationCommentTest.py
+++ b/tests/bearlib/languages/documentation/DocumentationCommentTest.py
@@ -19,6 +19,9 @@ class DocumentationCommentTest(unittest.TestCase):
     ReturnValue = DocumentationComment.ReturnValue
 
     Metadata = DocstyleDefinition.Metadata
+    ClassPadding = DocstyleDefinition.ClassPadding
+    FunctionPadding = DocstyleDefinition.FunctionPadding
+    DocstringTypeRegex = DocstyleDefinition.DocstringTypeRegex
 
 
 class GeneralDocumentationCommentTest(DocumentationCommentTest):
@@ -63,7 +66,11 @@ class GeneralDocumentationCommentTest(DocumentationCommentTest):
 
     def test_not_implemented(self):
         raw_docstyle = DocstyleDefinition('nolang', 'nostyle', ('', '', ''),
-                                          self.Metadata('', '', '', '', ''))
+                                          self.Metadata('', '', '', '', ''),
+                                          self.ClassPadding('', ''),
+                                          self.FunctionPadding('', ''),
+                                          self.DocstringTypeRegex('', ''),
+                                          '')
         not_implemented = DocumentationComment(
             'some docs', raw_docstyle, None, None, None)
         with self.assertRaises(NotImplementedError):
@@ -274,8 +281,6 @@ class DocumentationAssemblyTest(unittest.TestCase):
         docs = ''.join(data)
 
         for doc in DocBaseClass.extract(data, 'python', 'default'):
-            doc.bottom_padding = 2
-            doc.assemble.cache_clear()
             self.assertIn(doc.assemble(), docs)
 
     def test_doxygen_assembly(self):
@@ -293,3 +298,49 @@ class DocumentationAssemblyTest(unittest.TestCase):
             doc.top_padding = 1
             doc.assemble.cache_clear()
             self.assertIn(doc.assemble(), docs)
+
+    def test_python_default_padding_amend_assembly_1(self):
+        data = ['\n', '\n', '""" documentation in single line """\n',
+                '\n', '\n', 'print(1)\n']
+
+        for doc in DocBaseClass.extract(data, 'python', 'default'):
+            doc.top_padding = 1
+            doc.bottom_padding = 0
+            doc.assemble.cache_clear()
+            self.assertEqual(doc.assemble(),
+                             '\n""" documentation in single line """')
+
+    def test_python_default_padding_amend_assembly_2(self):
+        data = ['""" documentation in single line """\n']
+
+        for doc in DocBaseClass.extract(data, 'python', 'default'):
+            doc.top_padding = 2
+            doc.bottom_padding = 3
+            doc.assemble.cache_clear()
+            self.assertEqual(doc.assemble(),
+                             '\n\n""" documentation in single line """\n\n\n')
+
+    def test_python_doxygen_padding_amend_assembly(self):
+        data = ['## documentation in single line without return at end.']
+
+        for doc in DocBaseClass.extract(data, 'python', 'doxygen'):
+            doc.top_padding = 0
+            doc.bottom_padding = 2
+            doc.assemble.cache_clear()
+            self.assertEqual(doc.assemble(),
+                             '## documentation in single line '
+                             'without return at end.\n\n')
+
+    def test_c_default_padding_amend_assembly(self):
+        data = ['/**\n',
+                ' * This is the main function.\n',
+                ' */\n']
+
+        for doc in DocBaseClass.extract(data, 'c', 'doxygen'):
+            doc.top_padding = 1
+            doc.bottom_padding = 2
+            doc.assemble.cache_clear()
+            self.assertEqual(doc.assemble(),
+                             '\n/**\n'
+                             ' * This is the main function.\n'
+                             ' */\n\n')

--- a/tests/bearlib/languages/documentation/documentation_extraction_testdata/default.py
+++ b/tests/bearlib/languages/documentation/documentation_extraction_testdata/default.py
@@ -9,14 +9,12 @@ def foobar_explosion(radius):
     """
     A nice and neat way of documenting code.
     :param radius: The explosion radius. """
-
-
     def get_55():
         """A function that returns 55."""
-
-
         return 55
+
     return get_55() * radius
+
 
 """
 Docstring with layouted text.
@@ -42,9 +40,8 @@ def best_docstring(param1, param2):
     :return: Long Return Description That Makes No Sense And Will
              Cut to the Next Line.
     """
-
-
     return None
+
 
 def docstring_find(filename):
     """
@@ -72,8 +69,6 @@ def foobar_triangle(side_A, side_B, side_C):
 
     :return: returns perimeter
     """
-
-
     return side_A + side_B + side_C
 
     # This example of triple quote string literal is ignored.


### PR DESCRIPTION
Add `padding` in DocstyleDefinition which
are now acquired from `.coalang`. Add
`top_padding` and `bottom_padding` which
automatically instantiate from
`instantiate_padding` in DocBaseClass. Add
supporting test cases.

Related to https://github.com/coala/coala/issues/4200

<!--
Thanks for your contribution!

Please take a quick look at those things down there. They're quite important.
Really! We wrote them for you. Yes you! With utmost care. Read them.
-->

**For short term contributors:** we understand that getting your commits well
defined like we require is a hard task and takes some learning. If you
look to help without wanting to contribute long term there's no need
for you to learn this. Just drop us a message and we'll take care of brushing
up your stuff for merge!

### Checklist

- [x] I read the [commit guidelines](http://coala.io/commit) and I've followed
      them.
- [x] I ran coala over my code locally. (*All commits have to pass
      individually.* It is not sufficient to have "fixup commits" on your PR,
      our bot will still report the issues for the previous commit.) You will
      likely receive a lot of bot comments and build failures if coala does not
      pass on every single commit!

After you submit your pull request, **DO NOT click the 'Update Branch' button.**
When asked for a rebase, consult [coala.io/rebase](https://coala.io/rebase)
instead.

Please consider helping us by reviewing other peoples pull requests as well:

- pick up any PR at <https://coala.io/review>
- review it (check <https://coala.io/reviewing> for more info)
- if you are sure that it needs work, use `cobot mark wip <URL>` to get it out
  of the review queue.

The more you review, the more your score will grow at coala.io and we will
review your PRs faster!
