### PR TITLE
LocalBearTestHelper: Add **process_output_kwargs

### DIFF
--- a/coalib/testing/LocalBearTestHelper.py
+++ b/coalib/testing/LocalBearTestHelper.py
@@ -25,14 +25,16 @@ def execute_bear(bear, *args, **kwargs):
                                       'the following output:\n')
                 old_process_output = bear.process_output
 
-                def new_process_output(output, filename=None, file=None):
+                def new_process_output(output, filename=None, file=None,
+                                       **process_output_kwargs):
                     if isinstance(output, tuple):
                         stdout, stderr = output
                         console_output.append('Stdout:\n' + stdout)
                         console_output.append('Stderr:\n' + stderr)
                     else:
                         console_output.append(output)
-                    return old_process_output(output, filename, file)
+                    return old_process_output(output, filename, file,
+                                              **process_output_kwargs)
 
                 stack.enter_context(patch.object(
                     bear, 'process_output', wraps=new_process_output))


### PR DESCRIPTION
Add `**process_output_kwargs` argument to `new_process_output(...)`
and `old_process_output(...)` because the keyword arguments were
not taken care of in bbb99f95cd2c5530bae765b2b011e76d85d639b4.

Fixes https://github.com/coala/coala/issues/4576
Related to https://github.com/coala/docker-coala-base/issues/219

<!--
Thanks for your contribution!

Please take a quick look at those things down there. They're quite important.
Really! We wrote them for you. Yes you! With utmost care. Read them.
-->

**For short term contributors:** we understand that getting your commits well
defined like we require is a hard task and takes some learning. If you
look to help without wanting to contribute long term there's no need
for you to learn this. Just drop us a message and we'll take care of brushing
up your stuff for merge!

### Checklist

- [x] I read the [commit guidelines](http://coala.io/commit) and I've followed
      them.
- [x] I ran coala over my code locally. (*All commits have to pass
      individually.* It is not sufficient to have "fixup commits" on your PR,
      our bot will still report the issues for the previous commit.) You will
      likely receive a lot of bot comments and build failures if coala does not
      pass on every single commit!

After you submit your pull request, **DO NOT click the 'Update Branch' button.**
When asked for a rebase, consult [coala.io/rebase](https://coala.io/rebase)
instead.

Please consider helping us by reviewing other peoples pull requests as well:

- pick up any PR at <https://coala.io/review>
- review it (check <https://coala.io/reviewing> for more info)
- if you are sure that it needs work, use `cobot mark wip <URL>` to get it out
  of the review queue.

The more you review, the more your score will grow at coala.io and we will
review your PRs faster!
