### PR TITLE
  Bear.py: Promotes log entry from warning to error 

### DIFF
--- a/coalib/bears/Bear.py
+++ b/coalib/bears/Bear.py
@@ -306,13 +306,13 @@ class Bear(Printer, LogPrinterMixin, metaclass=bearclass):
                 raise
 
             if self.kind() == BEAR_KIND.LOCAL:
-                self.warn('Bear {} failed to run on file {}. Take a look '
-                          'at debug messages (`-V`) for further '
-                          'information.'.format(name, args[0]))
+                self.err('Bear {} failed to run on file {}. Take a look '
+                         'at debug messages (`-V`) for further '
+                         'information.'.format(name, args[0]))
             else:
-                self.warn('Bear {} failed to run. Take a look '
-                          'at debug messages (`-V`) for further '
-                          'information.'.format(name))
+                self.err('Bear {} failed to run. Take a look '
+                         'at debug messages (`-V`) for further '
+                         'information.'.format(name))
             self.debug(
                 'The bear {bear} raised an exception. If you are the author '
                 'of this bear, please make sure to catch all exceptions. If '

--- a/tests/bears/BearTest.py
+++ b/tests/bears/BearTest.py
@@ -209,7 +209,7 @@ class BearTest(BearTestBase):
         self.uut = BadTestBear(self.settings, self.queue)
         self.uut.execute()
         self.check_message(LOG_LEVEL.DEBUG)
-        self.check_message(LOG_LEVEL.WARNING,
+        self.check_message(LOG_LEVEL.ERROR,
                            'Bear BadTestBear failed to run. Take a look at '
                            'debug messages (`-V`) for further '
                            'information.')
@@ -221,7 +221,7 @@ class BearTest(BearTestBase):
         self.uut.execute('filename.py', 'file\n')
         self.check_message(LOG_LEVEL.DEBUG)
         # Fails because of no run() implementation
-        self.check_message(LOG_LEVEL.WARNING,
+        self.check_message(LOG_LEVEL.ERROR,
                            'Bear LocalBear failed to run on file filename.py. '
                            'Take a look at debug messages (`-V`) for further '
                            'information.')
@@ -231,7 +231,7 @@ class BearTest(BearTestBase):
         self.uut.execute()
         self.check_message(LOG_LEVEL.DEBUG)
         # Fails because of no run() implementation
-        self.check_message(LOG_LEVEL.WARNING,
+        self.check_message(LOG_LEVEL.ERROR,
                            'Bear GlobalBear failed to run. Take a look at '
                            'debug messages (`-V`) for further '
                            'information.')

--- a/tests/processes/BearRunningTest.py
+++ b/tests/processes/BearRunningTest.py
@@ -214,7 +214,7 @@ class BearRunningUnitTest(unittest.TestCase):
                              LOG_LEVEL.ERROR,
                              LOG_LEVEL.DEBUG,
                              LOG_LEVEL.DEBUG,
-                             LOG_LEVEL.WARNING]
+                             LOG_LEVEL.ERROR]
 
         for msg in expected_messages:
             self.assertEqual(msg, self.message_queue.get(timeout=0).log_level)
@@ -271,7 +271,7 @@ d
             self.control_queue)
 
         expected_messages = [LOG_LEVEL.DEBUG,
-                             LOG_LEVEL.WARNING,
+                             LOG_LEVEL.ERROR,
                              LOG_LEVEL.DEBUG,
                              LOG_LEVEL.WARNING,
                              LOG_LEVEL.DEBUG,


### PR DESCRIPTION
GitCommitBear fails but the exit status is not set. This PR solves this problem by promoting the warning to error

Fixes: #4567

**For short term contributors:** we understand that getting your commits well
defined like we require is a hard task and takes some learning. If you
look to help without wanting to contribute long term there's no need
for you to learn this. Just drop us a message and we'll take care of brushing
up your stuff for merge!

### Checklist

- [x] I read the [commit guidelines](http://coala.io/commit) and I've followed
      them.
- [ ] I ran coala over my code locally. (*All commits have to pass
      individually.* It is not sufficient to have "fixup commits" on your PR,
      our bot will still report the issues for the previous commit.) You will
      likely receive a lot of bot comments and build failures if coala does not
      pass on every single commit!

After you submit your pull request, **DO NOT click the 'Update Branch' button.**
When asked for a rebase, consult [coala.io/rebase](https://coala.io/rebase)
instead.

Please consider helping us by reviewing other peoples pull requests as well:

- pick up any PR at <https://coala.io/review>
- review it (check <https://coala.io/reviewing> for more info)
- if you are sure that it needs work, use `cobot mark wip <URL>` to get it out
  of the review queue.

The more you review, the more your score will grow at coala.io and we will
review your PRs faster!
