### PR TITLE
coalib/abstractions: Add LinterClass.py

### DIFF
--- a/coalib/bearlib/abstractions/Linter.py
+++ b/coalib/bearlib/abstractions/Linter.py
@@ -8,6 +8,7 @@ import shutil
 from subprocess import check_call, CalledProcessError, DEVNULL
 from types import MappingProxyType
 
+from coalib.bearlib.abstractions.LinterClass import LinterClass
 from coalib.bears.LocalBear import LocalBear
 from coalib.bears.GlobalBear import GlobalBear
 from coala_utils.ContextManagers import make_temp
@@ -737,6 +738,7 @@ def _create_linter(klass, options):
     result_klass = type(klass.__name__, (klass, LinterBaseClass), {
         '__module__': klass.__module__})
     result_klass.__doc__ = klass.__doc__ or ''
+    LinterClass.register(result_klass)
     return result_klass
 
 
@@ -834,6 +836,11 @@ def linter(executable: str,
     inputs a tuple with ``(stdout, stderr)``. Providing ``use_stdout=False``
     and ``use_stderr=False`` raises a ``ValueError``. By default ``use_stdout``
     is ``True`` and ``use_stderr`` is ``False``.
+
+    Every ``linter`` is also a subclass of the ``LinterClass`` class.
+
+    >>> issubclass(XLintBear, LinterClass)
+    True
 
     Documentation:
     Bear description shall be provided at class level.

--- a/coalib/bearlib/abstractions/LinterClass.py
+++ b/coalib/bearlib/abstractions/LinterClass.py
@@ -1,0 +1,7 @@
+from abc import ABCMeta
+
+
+class LinterClass(metaclass=ABCMeta):
+    """
+    Every ``linter`` is also a subclass of the ``LinterClass`` class.
+    """

--- a/coalib/testing/LocalBearTestHelper.py
+++ b/coalib/testing/LocalBearTestHelper.py
@@ -5,6 +5,7 @@ from unittest.mock import patch
 
 import pytest
 
+from coalib.bearlib.abstractions.LinterClass import LinterClass
 from coalib.testing.BearTestHelper import generate_skip_decorator
 from coalib.bears.LocalBear import LocalBear
 from coala_utils.ContextManagers import prepare_file
@@ -20,7 +21,7 @@ def execute_bear(bear, *args, **kwargs):
         # For linters provide additional information, such as
         # stdout and stderr.
         with ExitStack() as stack:
-            if hasattr(bear, 'process_output'):
+            if isinstance(bear, LinterClass):
                 console_output.append('The program yielded '
                                       'the following output:\n')
                 old_process_output = bear.process_output


### PR DESCRIPTION
Introduce a virtual base class for linters and use it to
improve the check inside `LocalBearTestHelper`.
i.e. Instead of checking `hasattr(cls, 'process_output')`, an
`isinstance(cls, LinterClass)` is safer and easier to understand.

Closes https://github.com/coala/coala/issues/4594

<!--
Thanks for your contribution!

Please take a quick look at those things down there. They're quite important.
Really! We wrote them for you. Yes you! With utmost care. Read them.
-->

**For short term contributors:** we understand that getting your commits well
defined like we require is a hard task and takes some learning. If you
look to help without wanting to contribute long term there's no need
for you to learn this. Just drop us a message and we'll take care of brushing
up your stuff for merge!

### Checklist

- [x] I read the [commit guidelines](http://coala.io/commit) and I've followed
      them.
- [x] I ran coala over my code locally. (*All commits have to pass
      individually.* It is not sufficient to have "fixup commits" on your PR,
      our bot will still report the issues for the previous commit.) You will
      likely receive a lot of bot comments and build failures if coala does not
      pass on every single commit!

After you submit your pull request, **DO NOT click the 'Update Branch' button.**
When asked for a rebase, consult [coala.io/rebase](https://coala.io/rebase)
instead.

Please consider helping us by reviewing other peoples pull requests as well:

- pick up any PR at <https://coala.io/review>
- review it (check <https://coala.io/reviewing> for more info)
- if you are sure that it needs work, use `cobot mark wip <URL>` to get it out
  of the review queue.

The more you review, the more your score will grow at coala.io and we will
review your PRs faster!
