### PR TITLE
doctest: Remove unnecessary +ELLIPSIS

### DIFF
--- a/coalib/bearlib/__init__.py
+++ b/coalib/bearlib/__init__.py
@@ -52,7 +52,7 @@ def deprecate_settings(**depr_args):
     >>> @deprecate_settings(new='old')
     ... def run(new):
     ...     print(new)
-    >>> # doctest: +ELLIPSIS
+    >>> # doctest:
     ... run(old="Hello!", new='coala is always written with lowercase `c`.')
     WARNING:root:The setting `old` is deprecated. Please use `new` instead.
     WARNING:root:The value of `old` and `new` are conflicting. `new` will...

--- a/coalib/bearlib/languages/Language.py
+++ b/coalib/bearlib/languages/Language.py
@@ -33,11 +33,11 @@ def parse_lang_str(string):
     ('Python', [3.6, '3.3.1'])
     >>> parse_lang_str("Objective C 3.6, 3")
     ('Objective C', [3.6, 3])
-    >>> parse_lang_str("Cobol, stupid!")  # +ELLIPSIS
+    >>> parse_lang_str("Cobol, stupid!")
     Traceback (most recent call last):
      ...
     packaging.version.InvalidVersion: Invalid version: 'stupid!'
-    >>> parse_lang_str("Cobol seems at least stupid ;)")  # +ELLIPSIS
+    >>> parse_lang_str("Cobol seems at least stupid ;)")
     ('Cobol seems at least stupid ;)', [])
     """
     name, *str_versions = re.split(r'\s*,\s*', str(string).strip())

--- a/coalib/results/Diff.py
+++ b/coalib/results/Diff.py
@@ -531,8 +531,7 @@ class Diff:
         However, if we change something that has been changed before, we'll get
         a conflict:
 
-        >>> diff.modify_line(1,  # +ELLIPSIS
-        ...                  'Hello. This is not ok. Gorgeous.\n')
+        >>> diff.modify_line(1, 'Hello. This is not ok. Gorgeous.\n')
         Traceback (most recent call last):
          ...
         coalib.results.LineDiff.ConflictError: ...


### PR DESCRIPTION
doctest option +ELLIPSIS is enabled by default in pytest

Fixes https://github.com/coala/coala/issues/3065
