### PR TITLE
DocstyleDefinition.py: Align init docstring

### DIFF
--- a/coalib/bearlib/languages/documentation/DocstyleDefinition.py
+++ b/coalib/bearlib/languages/documentation/DocstyleDefinition.py
@@ -34,32 +34,40 @@ class DocstyleDefinition:
         """
         Instantiates a new DocstyleDefinition.
 
-        :param language: The case insensitive programming language of the
-                         documentation comment, e.g. ``"CPP"`` for C++ or
-                         ``"PYTHON3"``.
-        :param docstyle: The case insensitive documentation style/tool used
-                         to document code, e.g. ``"default"`` or ``"doxygen"``.
-        :param markers:  An iterable of marker/delimiter string iterables
-                         or a single marker/delimiter string iterable that
-                         identify a documentation comment. See ``markers``
-                         property for more details on markers.
-        :param metadata: A namedtuple consisting of certain attributes that
-                         form the layout of the certain documentation comment
-                         e.g. ``param_start`` defining the start symbol of
-                         the parameter fields and ``param_end`` defining the
-                         end.
-        :param class_padding: A namedtuple consisting of values about
-                         blank lines before and after the documentation of
-                         ``docstring_type`` class.
-        :param function_padding: A namedtuple consisting of values about
-                         blank lines before and after the documentation of
-                         ``docstring_type`` function.
-        :param docstring_type_regex: A namedtuple consisting of regex
-                         about ``class`` and ``function`` of a language, which
-                         is used to determine ``docstring_type`` of
-                         DocumentationComment.
-        :param docstring_position: Defines the position where the regex of
-                         docstring type is present(i.e. ``top`` or ``bottom``).
+        :param language:
+            The case insensitive programming language of the
+            documentation comment, e.g. ``"CPP"`` for C++ or
+            ``"PYTHON3"``.
+        :param docstyle:
+            The case insensitive documentation style/tool used
+            to document code, e.g. ``"default"`` or ``"doxygen"``.
+        :param markers:
+            An iterable of marker/delimiter string iterables
+            or a single marker/delimiter string iterable that
+            identify a documentation comment. See ``markers``
+            property for more details on markers.
+        :param metadata:
+            A namedtuple consisting of certain attributes that
+            form the layout of the certain documentation comment
+            e.g. ``param_start`` defining the start symbol of
+            the parameter fields and ``param_end`` defining the
+            end.
+        :param class_padding:
+            A namedtuple consisting of values about
+            blank lines before and after the documentation of
+            ``docstring_type`` class.
+        :param function_padding:
+            A namedtuple consisting of values about
+            blank lines before and after the documentation of
+            ``docstring_type`` function.
+        :param docstring_type_regex:
+            A namedtuple consisting of regex
+            about ``class`` and ``function`` of a language, which
+            is used to determine ``docstring_type`` of
+            DocumentationComment.
+        :param docstring_position:
+            Defines the position where the regex of
+            docstring type is present(i.e. ``top`` or ``bottom``).
         """
         self._language = language.lower()
         self._docstyle = docstyle.lower()


### PR DESCRIPTION
<!--
Thanks for your contribution!

Please take a quick look at those things down there. They're quite important.
Really! We wrote them for you. Yes you! With utmost care. Read them.


**For short term contributors:** we understand that getting your commits well
defined like we require is a hard task and takes some learning. If you
look to help without wanting to contribute long term there's no need
for you to learn this. Just drop us a message and we'll take care of brushing
up your stuff for merge!
-->

DocstyleDefinition.py: Align init docstring

I have aligned the init docstring according to the codestyle given at http://api.coala.io/en/latest/Developers/Codestyle.html.

Closes https://github.com/coala/coala/issues/4645

### Checklist

- [x] I read the [commit guidelines](http://coala.io/commit) and I've followed
      them.
- [x] I ran coala over my code locally. (*All commits have to pass
      individually.* It is not sufficient to have "fixup commits" on your PR,
      our bot will still report the issues for the previous commit.) You will
      likely receive a lot of bot comments and build failures if coala does not
      pass on every single commit!
<!--
After you submit your pull request, **DO NOT click the 'Update Branch' button.**
When asked for a rebase, consult [coala.io/rebase](https://coala.io/rebase)
instead.

Please consider helping us by reviewing other peoples pull requests as well:

- pick up any PR at <https://coala.io/review>
- review it (check <https://coala.io/reviewing> for more info)
- if you are sure that it needs work, use `cobot mark wip <URL>` to get it out
  of the review queue.

The more you review, the more your score will grow at coala.io and we will
review your PRs faster!
-->