### PR TITLE
Aspect: Create ``map_setting_to_aspect`` decorator

### DIFF
--- a/coalib/bearlib/aspects/__init__.py
+++ b/coalib/bearlib/aspects/__init__.py
@@ -6,6 +6,7 @@ from pkgutil import iter_modules
 from types import ModuleType
 
 from .base import aspectbase
+from .decorators import map_setting_to_aspect
 from .exceptions import (AspectTypeError, AspectNotFoundError,
                          MultipleAspectFoundError)
 from .meta import aspectclass
@@ -21,7 +22,8 @@ from .root import Root
 __all__ = ['Root', 'Taste', 'TasteError',
            'aspectclass', 'aspectbase', 'AspectTypeError',
            'AspectNotFoundError', 'MultipleAspectFoundError',
-           'AspectList']
+           'AspectList', 'map_setting_to_aspect',
+           ]
 
 
 class aspectsModule(ModuleType):

--- a/coalib/bearlib/aspects/decorators.py
+++ b/coalib/bearlib/aspects/decorators.py
@@ -1,0 +1,51 @@
+
+from functools import wraps
+
+from .taste import Taste
+from .meta import aspectclass
+from coalib.settings.FunctionMetadata import FunctionMetadata
+
+
+def map_setting_to_aspect(**aspectable_setting):
+    """
+    Map function arguments with aspect and override it if appropriate.
+
+    This decorator can be used by ``Bear.run()`` to automatically map and
+    override bear's setting value with their equivalent aspect or taste.
+
+    The order of setting override from the lowest to highest is:
+    - Setting default (in bear's run argument)
+    - Aspect/taste default (if aspect is activated in Section)
+    - Explicit aspect/taste default (if aspect is activated in Section)
+    - Explicit setting
+
+    :param aspectable_setting:
+        A dictionary of settings as keys and their equivalent aspect or taste
+        as value.
+    """
+    def _func_decorator(func):
+        @wraps(func)
+        def _new_func(self, *args, **kwargs):
+            if self.section.aspects:
+                aspects = self.section.aspects
+                for arg, aspect_value in aspectable_setting.items():
+                    # Explicit setting takes priority
+                    if arg in self.section:
+                        continue
+
+                    if isinstance(aspect_value, aspectclass):
+                        kwargs[arg] = aspects.get(aspect_value) is not None
+                    if isinstance(aspect_value, Taste):
+                        aspect_instance = aspects.get(aspect_value.aspect_name)
+                        if aspect_instance:
+                            kwargs[arg] = aspect_instance.tastes[
+                                aspect_value.name]
+
+            return func(self, *args, **kwargs)
+
+        # Keep metadata
+        _new_func.__metadata__ = FunctionMetadata.from_function(func)
+
+        return _new_func
+
+    return _func_decorator

--- a/coalib/bearlib/aspects/meta.py
+++ b/coalib/bearlib/aspects/meta.py
@@ -41,6 +41,7 @@ class aspectclass(type):
         and usage.
         """
         aspectname = subcls.__name__
+        sub_qualname = '%s.%s' % (cls.__qualname__, aspectname)
 
         docs = getattr(subcls, 'docs', None)
         aspectdocs = Documentation(subcls.__doc__, **{
@@ -53,6 +54,8 @@ class aspectclass(type):
             if isinstance(member, Taste):
                 # tell the taste its own name
                 member.name = name
+                # tell its owner name
+                member.aspect_name = sub_qualname
                 subtastes[name] = member
 
         class Sub(subcls, aspectbase, metaclass=aspectclass):
@@ -68,7 +71,7 @@ class aspectclass(type):
             Sub = generate_repr(*members)(Sub)
 
         Sub.__name__ = aspectname
-        Sub.__qualname__ = '%s.%s' % (cls.__qualname__, aspectname)
+        Sub.__qualname__ = sub_qualname
         cls.subaspects[aspectname] = Sub
         setattr(cls, aspectname, Sub)
         return Sub

--- a/tests/bearlib/aspects/DecoratorsTest.py
+++ b/tests/bearlib/aspects/DecoratorsTest.py
@@ -1,0 +1,71 @@
+import unittest
+
+from coalib.bearlib.aspects import (
+    AspectList,
+    get as get_aspect,
+    map_setting_to_aspect,
+)
+from coalib.bears.Bear import Bear
+from coalib.settings.Section import Section
+from coalib.settings.Setting import Setting
+
+
+class RunDecoratedBear(Bear):
+
+    @staticmethod
+    def kind():
+        return BEAR_KIND.LOCAL
+
+    @map_setting_to_aspect(
+        remove_unreachable_code=get_aspect('UnreachableCode'),
+        minimum_clone_tokens=get_aspect('Clone').min_clone_tokens,
+    )
+    def run(self,
+            remove_unreachable_code: bool=False,
+            minimum_clone_tokens: int=10,
+            ):
+        return [remove_unreachable_code, minimum_clone_tokens]
+
+
+class MapSettingToAspectTest(unittest.TestCase):
+
+    def setUp(self):
+        self.section = Section('aspect section')
+        self.bear = RunDecoratedBear(self.section, None)
+
+    def test_mapping(self):
+        self.section.aspects = AspectList([
+            get_aspect('UnreachableCode')('py'),
+            get_aspect('Clone')('py', min_clone_tokens=30),
+        ])
+        result = self.bear.execute()
+        self.assertEqual([True, 30], result)
+
+    def test_setting_priority(self):
+        self.section.aspects = AspectList([
+            get_aspect('UnreachableCode')('py'),
+            get_aspect('Clone')('py', min_clone_tokens=30),
+        ])
+        self.section.append(
+            Setting('remove_unreachable_code', 'False'))
+        self.section.append(
+            Setting('minimum_clone_tokens', 40))
+        result = self.bear.execute()
+        self.assertEqual([False, 40], result)
+
+    def test_partial_mapping(self):
+        self.section.aspects = AspectList([
+            get_aspect('UnreachableCode')('py'),
+        ])
+        result = self.bear.execute()
+        self.assertEqual([True, 10], result)
+
+    def test_no_mapping(self):
+        self.section.aspects = AspectList([])
+        result = self.bear.execute()
+        self.assertEqual([False, 10], result)
+
+    def test_skip_mapping(self):
+        self.section.aspects = None
+        result = self.bear.execute()
+        self.assertEqual([False, 10], result)


### PR DESCRIPTION
```python
@map_setting_to_aspect(
        remove_all_unused_imports=(get_aspect('UnusedImport')
                                   .remove_non_standard_import),
        remove_unused_variables=get_aspect('UnusedLocalVariable'))
def run(self, filename, file,
        remove_all_unused_imports: bool=True,
        remove_unused_variables: bool=True):
    pass
```

The `run` argument will be overrided by aspect's setting 
(only if it present). This make bear's aspectization much more easy.

Closes https://github.com/coala/coala/issues/4661