### PR TITLE
LocalBearTestHelper.py: Removed redundant return.

### DIFF
--- a/coalib/testing/LocalBearTestHelper.py
+++ b/coalib/testing/LocalBearTestHelper.py
@@ -51,7 +51,6 @@ def execute_bear(bear, *args, **kwargs):
             msg.append(bear.message_queue.get().message)
         msg += console_output
         raise AssertionError(str(err) + ''.join('\n' + m for m in msg))
-    return list(bear_output_generator)
 
 
 def get_results(local_bear,


### PR DESCRIPTION
Return call is redundant and hence removed.
This could also cause confusing to python 2 users 
where this is invalid syntax.

Closes https://github.com/coala/coala/issues/4735

### Checklist

- [x] I read the [commit guidelines](http://coala.io/commit) and I've followed
      them.
- [x] I ran coala over my code locally. (*All commits have to pass
      individually.* It is not sufficient to have "fixup commits" on your PR,
      our bot will still report the issues for the previous commit.) You will
      likely receive a lot of bot comments and build failures if coala does not
      pass on every single commit!