### PR TITLE
Interactions.py: Modify docstring to correct param name

### DIFF
--- a/coalib/output/Interactions.py
+++ b/coalib/output/Interactions.py
@@ -5,13 +5,14 @@ def fail_acquire_settings(log_printer, settings_names_dict, section):
     """
     This method throws an exception if any setting needs to be acquired.
 
-    :param log_printer:     Printer responsible for logging the messages.
-    :param settings:        A dictionary with the settings name as key and
-                            a list containing a description in [0] and the
-                            name of the bears who need this setting in [1]
-                            and following.
-    :raises AssertionError: If any setting is required.
-    :raises TypeError:      If ``settings_names_dict`` is not a dictionary.
+    :param log_printer:         Printer responsible for logging the messages.
+    :param settings_names_dict: A dictionary with the settings name as key and
+                                a list containing a description in [0] and the
+                                name of the bears who need this setting in [1]
+                                and following.
+    :raises AssertionError:     If any setting is required.
+    :raises TypeError:          If ``settings_names_dict`` is not a
+                                dictionary.
     """
     if not isinstance(settings_names_dict, dict):
         raise TypeError('The settings_names_dict parameter has to be a '


### PR DESCRIPTION
Function declaration declares settings_names_dict as an input parameter, but docstring references this parameter as settings. This commit changes the docstring to correctly reference settings_names_dict.

Closes https://github.com/coala/coala/issues/4739

<!--
Thanks for your contribution!

Please take a quick look at those things down there. They're quite important.
Really! We wrote them for you. Yes you! With utmost care. Read them.
-->

**For short term contributors:** we understand that getting your commits well
defined like we require is a hard task and takes some learning. If you
look to help without wanting to contribute long term there's no need
for you to learn this. Just drop us a message and we'll take care of brushing
up your stuff for merge!

### Checklist

- [x] I read the [commit guidelines](http://coala.io/commit) and I've followed
      them.
- [x] I ran coala over my code locally. (*All commits have to pass
      individually.* It is not sufficient to have "fixup commits" on your PR,
      our bot will still report the issues for the previous commit.) You will
      likely receive a lot of bot comments and build failures if coala does not
      pass on every single commit!

After you submit your pull request, **DO NOT click the 'Update Branch' button.**
When asked for a rebase, consult [coala.io/rebase](https://coala.io/rebase)
instead.

Please consider helping us by reviewing other peoples pull requests as well:

- pick up any PR at <https://coala.io/review>
- review it (check <https://coala.io/reviewing> for more info)
- if you are sure that it needs work, use `cobot mark wip <URL>` to get it out
  of the review queue.

The more you review, the more your score will grow at coala.io and we will
review your PRs faster!
