### PR TITLE
Interactions.py : Add deprecation message for section parameter

### DIFF
--- a/coalib/output/Interactions.py
+++ b/coalib/output/Interactions.py
@@ -1,7 +1,7 @@
 import logging
 
 
-def fail_acquire_settings(log_printer, settings_names_dict, section):
+def fail_acquire_settings(log_printer, settings_names_dict, section=None):
     """
     This method throws an exception if any setting needs to be acquired.
 
@@ -10,10 +10,16 @@ def fail_acquire_settings(log_printer, settings_names_dict, section):
                                 a list containing a description in [0] and the
                                 name of the bears who need this setting in [1]
                                 and following.
+    :param section:             This parameter is deprecated and is no longer
+                                required.
     :raises AssertionError:     If any setting is required.
     :raises TypeError:          If ``settings_names_dict`` is not a
                                 dictionary.
     """
+    if section is not None:
+        logging.warning('fail_acquire_settings: section parameter is '
+                        'deprecated.')
+
     if not isinstance(settings_names_dict, dict):
         raise TypeError('The settings_names_dict parameter has to be a '
                         'dictionary.')

--- a/tests/output/InteractionsTest.py
+++ b/tests/output/InteractionsTest.py
@@ -1,6 +1,7 @@
 import unittest
 
 from pyprint.NullPrinter import NullPrinter
+from testfixtures import LogCapture
 
 from coalib.output.Interactions import fail_acquire_settings
 from coalib.output.printers.LogPrinter import LogPrinter
@@ -11,11 +12,21 @@ class InteractionsTest(unittest.TestCase):
 
     def test_(self):
         log_printer = LogPrinter(NullPrinter())
-        section = Section('')
-        self.assertRaises(TypeError, fail_acquire_settings, log_printer, None,
-                          section)
+        self.assertRaises(TypeError, fail_acquire_settings, log_printer, None)
         self.assertRaises(AssertionError,
                           fail_acquire_settings,
                           log_printer,
-                          {'setting': ['description', 'bear']}, section)
-        self.assertEqual(fail_acquire_settings(log_printer, {}, section), None)
+                          {'setting': ['description', 'bear']})
+        self.assertEqual(fail_acquire_settings(log_printer, {}), None)
+
+    def test_section_deprecation(self):
+        section = Section('')
+        log_printer = LogPrinter(NullPrinter())
+        with LogCapture() as capture:
+            fail_acquire_settings(log_printer, {}, section)
+            capture.check(
+                ('root',
+                 'WARNING',
+                 'fail_acquire_settings: section parameter '
+                 'is deprecated.')
+            )

--- a/tests/output/InteractionsTest.py
+++ b/tests/output/InteractionsTest.py
@@ -18,5 +18,4 @@ class InteractionsTest(unittest.TestCase):
                           fail_acquire_settings,
                           log_printer,
                           {'setting': ['description', 'bear']}, section)
-        self.assertEqual(fail_acquire_settings(log_printer, {}, section), None,
-                         section)
+        self.assertEqual(fail_acquire_settings(log_printer, {}, section), None)


### PR DESCRIPTION
The documentation for section parameter was not provided
in the docstring. This commit adds the documentation.

Closes https://github.com/coala/coala/issues/4740

<!--
Thanks for your contribution!

Please take a quick look at those things down there. They're quite important.
Really! We wrote them for you. Yes you! With utmost care. Read them.
-->

**For short term contributors:** we understand that getting your commits well
defined like we require is a hard task and takes some learning. If you
look to help without wanting to contribute long term there's no need
for you to learn this. Just drop us a message and we'll take care of brushing
up your stuff for merge!

### Checklist

- [x] I read the [commit guidelines](http://coala.io/commit) and I've followed
      them.
- [x] I ran coala over my code locally. (*All commits have to pass
      individually.* It is not sufficient to have "fixup commits" on your PR,
      our bot will still report the issues for the previous commit.) You will
      likely receive a lot of bot comments and build failures if coala does not
      pass on every single commit!

After you submit your pull request, **DO NOT click the 'Update Branch' button.**
When asked for a rebase, consult [coala.io/rebase](https://coala.io/rebase)
instead.

Please consider helping us by reviewing other peoples pull requests as well:

- pick up any PR at <https://coala.io/review>
- review it (check <https://coala.io/reviewing> for more info)
- if you are sure that it needs work, use `cobot mark wip <URL>` to get it out
  of the review queue.

The more you review, the more your score will grow at coala.io and we will
review your PRs faster!
