### PR TITLE
DecoratorsTest.py: Import BEAR_KIND

### DIFF
--- a/tests/bearlib/aspects/DecoratorsTest.py
+++ b/tests/bearlib/aspects/DecoratorsTest.py
@@ -5,16 +5,12 @@ from coalib.bearlib.aspects import (
     get as get_aspect,
     map_setting_to_aspect,
 )
-from coalib.bears.Bear import Bear
+from coalib.bears.LocalBear import LocalBear
 from coalib.settings.Section import Section
 from coalib.settings.Setting import Setting
 
 
-class RunDecoratedBear(Bear):
-
-    @staticmethod
-    def kind():
-        return BEAR_KIND.LOCAL
+class RunDecoratedBear(LocalBear):
 
     @map_setting_to_aspect(
         remove_unreachable_code=get_aspect('UnreachableCode'),


### PR DESCRIPTION
BEAR_KIND was not imported in DecoratorsTest.py
and hence was showing undefined name error during
execution of kind function.

Fixes https://github.com/coala/coala/issues/4702

<!--
Thanks for your contribution!

Please take a quick look at those things down there. They're quite important.
Really! We wrote them for you. Yes you! With utmost care. Read them.
-->

**For short term contributors:** we understand that getting your commits well
defined like we require is a hard task and takes some learning. If you
look to help without wanting to contribute long term there's no need
for you to learn this. Just drop us a message and we'll take care of brushing
up your stuff for merge!

### Checklist

- [x] I read the [commit guidelines](http://coala.io/commit) and I've followed
      them.
- [x] I ran coala over my code locally. (*All commits have to pass
      individually.* It is not sufficient to have "fixup commits" on your PR,
      our bot will still report the issues for the previous commit.) You will
      likely receive a lot of bot comments and build failures if coala does not
      pass on every single commit!

After you submit your pull request, **DO NOT click the 'Update Branch' button.**
When asked for a rebase, consult [coala.io/rebase](https://coala.io/rebase)
instead.

Please consider helping us by reviewing other peoples pull requests as well:

- pick up any PR at <https://coala.io/review>
- review it (check <https://coala.io/reviewing> for more info)
- if you are sure that it needs work, use `cobot mark wip <URL>` to get it out
  of the review queue.

The more you review, the more your score will grow at coala.io and we will
review your PRs faster!
