### PR TITLE
core: Explicitly shutdown executor

### DIFF
--- a/coalib/core/Core.py
+++ b/coalib/core/Core.py
@@ -173,7 +173,8 @@ class Session:
         :param executor:
             Custom executor used to run the bears. If ``None``, a
             ``ProcessPoolExecutor`` is used using as many processes as cores
-            available on the system.
+            available on the system. Note that a passed custom executor is
+            closed after the core has finished.
         """
         self.bears = bears
         self.result_callback = result_callback
@@ -193,12 +194,15 @@ class Session:
         """
         Runs the coala session.
         """
-        if self.bears:
-            self._schedule_bears(self.bears_to_schedule)
-            try:
-                self.event_loop.run_forever()
-            finally:
-                self.event_loop.close()
+        try:
+            if self.bears:
+                self._schedule_bears(self.bears_to_schedule)
+                try:
+                    self.event_loop.run_forever()
+                finally:
+                    self.event_loop.close()
+        finally:
+            self.executor.shutdown()
 
     def _schedule_bears(self, bears):
         """

--- a/tests/core/CoreTest.py
+++ b/tests/core/CoreTest.py
@@ -619,3 +619,23 @@ class CoreOnThreadPoolExecutorTest(CoreTest):
     def setUp(self):
         super().setUp()
         self.executor = ThreadPoolExecutor, tuple(), dict(max_workers=8)
+
+
+# This test class only runs test cases once, as the tests here rely on specific
+# executors / having the control over executors.
+class CoreOnSpecificExecutorTest(CoreTestBase):
+    def test_custom_executor_closed_after_run(self):
+        bear = MultiTaskBear(Section('test-section'),
+                             {'some-file': []},
+                             tasks_count=1)
+
+        # The executor should be closed regardless how many bears are passed.
+        for bears in [set(), {bear}]:
+            executor = ThreadPoolExecutor(max_workers=1)
+
+            self.execute_run(bears, executor)
+
+            # Submitting new tasks should raise an exception now.
+            with self.assertRaisesRegex(
+                    RuntimeError, 'cannot schedule new futures after shutdown'):
+                executor.submit(lambda: None)


### PR DESCRIPTION
The event-loop can't know that is has to close the executor, as it's
always passed explicitly to `run_in_executor()`.