### PR TITLE
core: Do not close event loop too early

### DIFF
--- a/coalib/core/Core.py
+++ b/coalib/core/Core.py
@@ -230,19 +230,21 @@ class Session:
 
                 self.running_tasks[bear] = tasks
 
+                # Cleanup bears without tasks after all bears had the chance to
+                # schedule their tasks. Not doing so might stop the run too
+                # early, as the cleanup is also responsible for stopping the
+                # event-loop when no more tasks do exist.
+                if not tasks:
+                    logging.debug('{!r} scheduled no tasks.'.format(bear))
+                    bears_without_tasks.append(bear)
+                    continue
+
                 for task in tasks:
                     task.add_done_callback(functools.partial(
                         self._finish_task, bear))
 
                 logging.debug('Scheduled {!r} (tasks: {})'.format(bear,
                                                                   len(tasks)))
-
-                # Cleanup bears without tasks after all bears had the chance to
-                # schedule their tasks. Not doing so might stop the run too
-                # early, as the cleanup is also responsible for stopping the
-                # event-loop when no more tasks do exist.
-                if not tasks:
-                    bears_without_tasks.append(bear)
 
         for bear in bears_without_tasks:
             self._cleanup_bear(bear)

--- a/coalib/core/Core.py
+++ b/coalib/core/Core.py
@@ -211,6 +211,8 @@ class Session:
         :param bears:
             A list of bear instances to be scheduled onto the process pool.
         """
+        bears_without_tasks = []
+
         for bear in bears:
             if self.dependency_tracker.get_dependencies(
                     bear):  # pragma: no cover
@@ -235,11 +237,15 @@ class Session:
                 logging.debug('Scheduled {!r} (tasks: {})'.format(bear,
                                                                   len(tasks)))
 
+                # Cleanup bears without tasks after all bears had the chance to
+                # schedule their tasks. Not doing so might stop the run too
+                # early, as the cleanup is also responsible for stopping the
+                # event-loop when no more tasks do exist.
                 if not tasks:
-                    # We need to recheck our runtime if something is left to
-                    # process, as when no tasks were offloaded the event-loop
-                    # could hang up otherwise.
-                    self._cleanup_bear(bear)
+                    bears_without_tasks.append(bear)
+
+        for bear in bears_without_tasks:
+            self._cleanup_bear(bear)
 
     def _cleanup_bear(self, bear):
         """

--- a/tests/core/CoreTest.py
+++ b/tests/core/CoreTest.py
@@ -120,6 +120,13 @@ class DynamicTaskBear(TestBearBase):
         return (((i,), {}) for i in range(tasks_count))
 
 
+class DependentOnMultipleZeroTaskBearsTestBear(TestBearBase):
+    BEAR_DEPS = {type('NoTasksBear{}'.format(i),
+                      (Bear,),
+                      dict(generate_tasks=lambda self: tuple()))
+                 for i in range(100)} | {MultiResultBear}
+
+
 def get_next_instance(typ, iterable):
     """
     Reads all elements in the iterable and returns the first occurrence
@@ -594,6 +601,33 @@ class CoreTest(CoreTestBase):
             len(bear.dependency_results[MultiResultBear]), 2)
         self.assertEqual(
             len(bear.dependency_results[BearA]), 1)
+
+    def test_run_multiple_dependency_bears_with_zero_tasks(self):
+        # The core shall not stop too early because some of the bears have
+        # offloaded no tasks, while others have not. This is a non-deterministic
+        # issue, so we can only provoke it by offloading a huge amount of bears
+        # without tasks.
+
+        # Because bear dependencies are type-bound, we need to create many new
+        # bear types doing the same so the core treats them actually as
+        # different bear dependencies. Otherwise it would merge them together
+        # into a single instance in the dependency-tree.
+        uut = DependentOnMultipleZeroTaskBearsTestBear(self.section1,
+                                                       self.filedict1)
+
+        results = self.execute_run({uut})
+
+        self.assertEqual(len(results), 3)
+        self.assertIn(1, results)
+        self.assertIn(2, results)
+
+        uut_result = get_next_instance(TestResult, results)
+        self.assertEqual(uut_result.bear.name, uut.name)
+        self.assertEqual(uut_result.section_name, self.section1.name)
+        self.assertEqual(uut_result.file_dict, self.filedict1)
+
+        self.assertEqual(len(uut.dependency_results), 1)
+        self.assertEqual(uut.dependency_results[MultiResultBear], [1, 2])
 
     def test_run_heavy_cpu_load(self):
         # No normal computer should expose 100 cores at once, so we can test


### PR DESCRIPTION
... when scheduling all dependency bears. Bears that offload no tasks
may cause the event-loop to close too early while other bears had no
chance to submit their tasks.

Fixes https://github.com/coala/coala/issues/4505