### PR TITLE
IgnoreResultAction.py: Eliminate extra spaces

### DIFF
--- a/coalib/results/result_actions/IgnoreResultAction.py
+++ b/coalib/results/result_actions/IgnoreResultAction.py
@@ -54,7 +54,7 @@ class IgnoreResultAction(ResultAction):
             source_range.start.line,
             original_file_dict[filename][source_range.start.line-1],
             original_file_dict[filename][source_range.start.line-1].rstrip() +
-            '  ' + ignore_comment)
+            ignore_comment)
 
         if filename in file_diff_dict:
             ignore_diff = file_diff_dict[filename] + ignore_diff

--- a/tests/results/result_actions/IgnoreResultActionTest.py
+++ b/tests/results/result_actions/IgnoreResultActionTest.py
@@ -64,7 +64,7 @@ class IgnoreResultActionTest(unittest.TestCase):
                       file_dict, file_diff_dict, 'c')
             self.assertEqual(
                 file_diff_dict[f_a].modified,
-                ['1\n', '2  // Ignore origin\n', '3\n'])
+                ['1\n', '2// Ignore origin\n', '3\n'])
             with open(f_a, 'r') as f:
                 self.assertEqual(file_diff_dict[f_a].modified, f.readlines())
             self.assertTrue(exists(f_a + '.orig'))
@@ -74,7 +74,7 @@ class IgnoreResultActionTest(unittest.TestCase):
                       file_dict, file_diff_dict, 'css')
             self.assertEqual(
                 file_diff_dict[f_a].modified,
-                ['1  /* Ignore else */\n', '2  // Ignore origin\n', '3\n'])
+                ['1/* Ignore else */\n', '2// Ignore origin\n', '3\n'])
             with open(f_a, 'r') as f:
                 self.assertEqual(file_diff_dict[f_a].modified, f.readlines())
 


### PR DESCRIPTION
IgnoreResultAction.py: Eliminate extra spaces

This removes the trailing spaces in
ignore comment and updates the test
accordingly.

Closes https://github.com/coala/coala-bears/issues/2110

### Checklist

- [x] I read the [commit guidelines](http://coala.io/commit) and I've followed
      them.
- [x] I ran coala over my code locally. (*All commits have to pass
      individually.* It is not sufficient to have "fixup commits" on your PR,
      our bot will still report the issues for the previous commit.) You will
      likely receive a lot of bot comments and build failures if coala does not
      pass on every single commit!

