### PR TITLE
Fix FilterTest.test_filter_by_unknown

### DIFF
--- a/tests/parsing/FilterTest.py
+++ b/tests/parsing/FilterTest.py
@@ -103,11 +103,9 @@ class FilterTest(unittest.TestCase):
             retval, stdout, stderr = execute_coala(
                 coala.main, 'coala', '-B', '--filter-by', 'unknown', 'arg1')
             self.assertEqual(retval, 2)
-            self.assertRaisesRegex(InvalidFilterException,
-                                   '{!r} is an invalid filter. Available '
-                                   'filters: {}'.format(
-                                       filter,
-                                       ', '.join(sorted(available_filters))))
+            self.assertIn("'unknown' is an invalid filter. Available "
+                          'filters: ' + ', '.join(sorted(available_filters)),
+                          stdout)
 
     def test_filter_by_can_fix_null(self):
         with bear_test_module():


### PR DESCRIPTION
Fixes https://github.com/coala/coala/issues/4845

Changes `assertRaisesRegex` to `assertIn(..., stdout)` in:

https://github.com/coala/coala/blob/539a4e5c626e7ee839793ce5f29c62a96284359b/tests/parsing/FilterTest.py#L101-L110