### PR TITLE
InvalidFilterException should change name and base class and solves issue #4848

### DIFF
--- a/coalib/parsing/InvalidFilterException.py
+++ b/coalib/parsing/InvalidFilterException.py
@@ -1,2 +1,2 @@
-class InvalidFilterException(Exception):
+class FilterError(LookupError):
     pass


### PR DESCRIPTION
`coalib.parsing.InvalidFilterException.InvalidFilterException`: Change exception name and exception is based on `LookupError` instead of `Exception`

This change ensures that exception is based on `LookupError` and since `Exception` suffix was untypical it has been replaced by `FilterError`
It helps to read the exceptions easily as it makes it more intuitive

Closes https://github.com/coala/coala/issues/4848

