### PR TITLE
FilterError.py: Change class and exception name

### DIFF
--- a/coalib/coala.py
+++ b/coalib/coala.py
@@ -19,7 +19,7 @@ from pyprint.ConsolePrinter import ConsolePrinter
 from dependency_management.requirements.PipRequirement import PipRequirement
 
 from coalib.parsing.FilterHelper import (
-    apply_filter, apply_filters, InvalidFilterException)
+    apply_filter, apply_filters, BearFilterError)
 from coalib.output.Logging import configure_logging
 from coalib.parsing.DefaultArgParser import default_arg_parser
 from coalib.misc.Exceptions import get_exitcode
@@ -70,7 +70,7 @@ def main(debug=False):
                 try:
                     filtered_bears = apply_filters(
                         args.filter_by, filtered_bears)
-                except InvalidFilterException as ex:
+                except BearFilterError as ex:
                     # If filter is not available
                     console_printer.print(ex)
                     return 2

--- a/coalib/parsing/BearFilterError.py
+++ b/coalib/parsing/BearFilterError.py
@@ -1,0 +1,2 @@
+class BearFilterError(LookupError):
+    pass

--- a/coalib/parsing/FilterHelper.py
+++ b/coalib/parsing/FilterHelper.py
@@ -1,4 +1,4 @@
-from coalib.parsing.InvalidFilterException import InvalidFilterException
+from coalib.parsing.BearFilterError import BearFilterError
 
 from coalib.parsing.filters.LanguageFilter import language_filter
 from coalib.parsing.filters.CanDetectFilter import can_detect_filter
@@ -20,8 +20,8 @@ def apply_filter(filter_name, filter_args, all_bears=None):
             get_all_bears)
         all_bears = get_all_bears()
     if not is_valid_filter(filter_name):
-        raise InvalidFilterException('{!r} is an invalid filter. '
-                                     'Available filters: {}'.format(
+        raise BearFilterError('{!r} is an invalid filter. '
+                              'Available filters: {}'.format(
                                          filter_name,
                                          ', '.join(sorted(
                                              available_filters))))

--- a/coalib/parsing/InvalidFilterException.py
+++ b/coalib/parsing/InvalidFilterException.py
@@ -1,2 +1,0 @@
-class InvalidFilterException(Exception):
-    pass

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,26 @@
+{
+  "name": "coala",
+  "requires": true,
+  "lockfileVersion": 1,
+  "dependencies": {
+    "clone": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.1.tgz",
+      "integrity": "sha1-0hfR6WERjjrJpLi7oyhVU79kfNs="
+    },
+    "csslint": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/csslint/-/csslint-1.0.5.tgz",
+      "integrity": "sha1-Gcw+2jIhYP0/cjKvHLKjYOiYouk=",
+      "requires": {
+        "clone": "2.1.1",
+        "parserlib": "1.1.1"
+      }
+    },
+    "parserlib": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/parserlib/-/parserlib-1.1.1.tgz",
+      "integrity": "sha1-pkz6ckBiQ0/fw1HJpOwtkrlMBvQ="
+    }
+  }
+}

--- a/tests/parsing/FilterTest.py
+++ b/tests/parsing/FilterTest.py
@@ -2,7 +2,7 @@ import unittest
 
 from coalib import coala
 from coalib.parsing.FilterHelper import (
-    available_filters, InvalidFilterException)
+    available_filters, BearFilterError)
 from tests.TestUtilities import (
     bear_test_module,
     execute_coala,


### PR DESCRIPTION
`FilterError.py`: Change class and exception name

This ensures that class name and file name are `FilterError`
Exception is now based on `LookupError`

Closes https://github.com/coala/coala/issues/4848