### PR TITLE
DefaultArgParser: Uni(xi)fy directory separators

### DIFF
--- a/coalib/parsing/DefaultArgParser.py
+++ b/coalib/parsing/DefaultArgParser.py
@@ -1,4 +1,5 @@
 import argparse
+import os
 
 from coalib.misc import Constants
 from coalib.collecting.Collectors import get_all_bears_names
@@ -20,6 +21,23 @@ class CustomFormatter(argparse.RawDescriptionHelpFormatter):
             # Option string arguments (like "-f, --files")
             parts = action.option_strings
             return ', '.join(parts)
+
+
+class PathArg(str):
+    """
+    Uni(xi)fying OS-native directory separators in path arguments.
+
+    Removing the pain from interactively using coala in a Windows cmdline,
+    because backslashes are interpreted as escaping syntax and therefore
+    removed when arguments are turned into coala settings
+
+    >>> import os
+    >>> PathArg(os.path.join('path', 'with', 'separators'))
+    'path/with/separators'
+    """
+
+    def __new__(cls, path):
+        return str.__new__(cls, path.replace(os.path.sep, '/'))
 
 
 def default_arg_parser(formatter_class=None):
@@ -142,19 +160,19 @@ To run coala without user interaction, run the `coala --non-interactive`,
             lambda *args, **kwargs: get_all_bears_names())  # pragma: no cover
 
     inputs_group.add_argument(
-        '-f', '--files', nargs='+', metavar='FILE',
+        '-f', '--files', type=PathArg, nargs='+', metavar='FILE',
         help='files that should be checked')
 
     inputs_group.add_argument(
-        '-i', '--ignore', nargs='+', metavar='FILE',
+        '-i', '--ignore', type=PathArg, nargs='+', metavar='FILE',
         help='files that should be ignored')
 
     inputs_group.add_argument(
-        '--limit-files', nargs='+', metavar='FILE',
+        '--limit-files', type=PathArg, nargs='+', metavar='FILE',
         help="filter the `--files` argument's matches further")
 
     inputs_group.add_argument(
-        '-d', '--bear-dirs', nargs='+', metavar='DIR',
+        '-d', '--bear-dirs', type=PathArg, nargs='+', metavar='DIR',
         help='additional directories which may contain bears')
 
     outputs_group = arg_parser.add_argument_group('Outputs')

--- a/tests/coalaCITest.py
+++ b/tests/coalaCITest.py
@@ -61,7 +61,7 @@ class coalaCITest(unittest.TestCase):
             retval, stdout, stderr = execute_coala(coala.main, 'coala',
                                                    '--non-interactive',
                                                    '-c', os.devnull,
-                                                   '-f', re.escape(filename),
+                                                   '-f', filename,
                                                    '-b',
                                                    'SpaceConsistencyTestBear',
                                                    '--settings',
@@ -87,7 +87,7 @@ class coalaCITest(unittest.TestCase):
                                                    '--non-interactive',
                                                    '-c', os.devnull,
                                                    '-b', 'LineCountTestBear',
-                                                   '-f', re.escape(filename),
+                                                   '-f', filename,
                                                    debug=debug)
             self.assertIn('This file has 1 lines.',
                           stdout,
@@ -105,7 +105,7 @@ class coalaCITest(unittest.TestCase):
             retval, stdout, stderr = execute_coala(
                 coala.main, 'coala', '--non-interactive',
                 '-c', os.devnull,
-                '-f', re.escape(filename),
+                '-f', filename,
                 '-b', 'SpaceConsistencyTestBear',
                 '--settings', 'use_spaces=True',
                 debug=debug)
@@ -168,7 +168,7 @@ class coalaCITest(unittest.TestCase):
                 coala.main, 'coala', '--non-interactive',
                 '-c', os.devnull,
                 '--limit-files', 'some_pattern',
-                '-f', re.escape(filename),
+                '-f', filename,
                 '-b', 'SpaceConsistencyTestBear',
                 '--settings', 'use_spaces=True',)
             self.assertEqual('Executing section cli...\n', stdout)

--- a/tests/coalaDebugFlagTest.py
+++ b/tests/coalaDebugFlagTest.py
@@ -1,5 +1,4 @@
 import os
-import re
 import sys
 
 import unittest
@@ -68,7 +67,7 @@ class coalaDebugFlagTest(unittest.TestCase):
             status, stdout, stderr = execute_coala(
                 coala.main, 'coala', '--debug', '--json',
                 '-c', os.devnull,
-                '-f', re.escape(filename),
+                '-f', filename,
                 '-b', 'RaiseTestBear')
         assert status == 13
         assert not stdout
@@ -88,7 +87,7 @@ class coalaDebugFlagTest(unittest.TestCase):
             execute_coala(
                 coala.main, 'coala', '--debug',
                 '-c', os.devnull,
-                '-f', re.escape(filename),
+                '-f', filename,
                 '-b', 'ErrorTestBear')
 
         mocked_ipdb.launch_ipdb_on_exception.assert_called_once_with()
@@ -105,7 +104,7 @@ class coalaDebugFlagTest(unittest.TestCase):
             execute_coala(
                 coala.main, 'coala', '--debug',
                 '-c', os.devnull,
-                '-f', re.escape(filename),
+                '-f', filename,
                 '-b', 'RaiseTestBear')
 
         mocked_ipdb.launch_ipdb_on_exception.assert_called_once_with()
@@ -124,7 +123,7 @@ class coalaDebugFlagTest(unittest.TestCase):
             execute_coala(
                 coala.main, 'coala', '--debug', '--json',
                 '-c', os.devnull,
-                '-f', re.escape(filename),
+                '-f', filename,
                 '-b', 'RaiseTestBear')
 
         mocked_ipdb.launch_ipdb_on_exception.assert_called_once_with()

--- a/tests/coalaDebugTest.py
+++ b/tests/coalaDebugTest.py
@@ -1,5 +1,4 @@
 import os
-import re
 import sys
 
 import unittest
@@ -33,7 +32,7 @@ class coalaDebugTest(unittest.TestCase):
             execute_coala(
                 coala.main, 'coala',
                 '-c', os.devnull,
-                '-f', re.escape(filename),
+                '-f', filename,
                 '-b', 'ErrorTestBear',
                 debug=True)
 
@@ -50,7 +49,7 @@ class coalaDebugTest(unittest.TestCase):
                 log_printer=LogPrinter(),
                 arg_list=(
                     '-c', os.devnull,
-                    '-f', re.escape(filename),
+                    '-f', filename,
                     '-b', 'ErrorTestBear'
                 ),
                 debug=True)
@@ -63,7 +62,7 @@ class coalaDebugTest(unittest.TestCase):
             execute_coala(
                 coala.main, 'coala',
                 '-c', os.devnull,
-                '-f', re.escape(filename),
+                '-f', filename,
                 '-b', 'RaiseTestBear',
                 debug=True)
 
@@ -78,7 +77,7 @@ class coalaDebugTest(unittest.TestCase):
                 log_printer=LogPrinter(),
                 arg_list=(
                     '-c', os.devnull,
-                    '-f', re.escape(filename),
+                    '-f', filename,
                     '-b', 'RaiseTestBear'
                 ),
                 debug=True)
@@ -96,6 +95,6 @@ class coalaDebugTest(unittest.TestCase):
             execute_coala(
                 coala.main, 'coala', '--json',
                 '-c', os.devnull,
-                '-f', re.escape(filename),
+                '-f', filename,
                 '-b', 'RaiseTestBear',
                 debug=True)

--- a/tests/coalaFormatTest.py
+++ b/tests/coalaFormatTest.py
@@ -1,5 +1,4 @@
 import os
-import re
 import sys
 import unittest
 
@@ -27,8 +26,7 @@ class coalaFormatTest(unittest.TestCase):
                 prepare_file(['#fixme'], None) as (lines, filename):
             retval, stdout, stderr = execute_coala(coala.main, 'coala',
                                                    '--format', '-c',
-                                                   os.devnull, '-f',
-                                                   re.escape(filename),
+                                                   os.devnull, '-f', filename,
                                                    '-b', 'LineCountTestBear')
             self.assertRegex(stdout, r'message:This file has [0-9]+ lines.',
                              'coala-format output for line count should '
@@ -43,8 +41,7 @@ class coalaFormatTest(unittest.TestCase):
                 prepare_file(['#fixme'], None) as (lines, filename):
             retval, stdout, stderr = execute_coala(coala.main, 'coala',
                                                    '--format', '--ci', '-c',
-                                                   os.devnull, '-f',
-                                                   re.escape(filename),
+                                                   os.devnull, '-f', filename,
                                                    '-b', 'LineCountTestBear')
             self.assertRegex(stdout, r'message:This file has [0-9]+ lines.',
                              'coala --format --ci output for line count should '

--- a/tests/coalaJSONTest.py
+++ b/tests/coalaJSONTest.py
@@ -1,6 +1,5 @@
 import json
 import os
-import re
 import sys
 import unittest
 import unittest.mock
@@ -44,7 +43,7 @@ class coalaJSONTest(unittest.TestCase):
             retval, stdout, stderr = execute_coala(coala.main, 'coala',
                                                    '--json', '-c', os.devnull,
                                                    '-b', 'LineCountTestBear',
-                                                   '-f', re.escape(filename))
+                                                   '-f', filename)
             output = json.loads(stdout)
             self.assertEqual(output['results']['cli'][0]['message'],
                              'This file has 1 lines.')
@@ -130,7 +129,7 @@ class coalaJSONTest(unittest.TestCase):
     def test_output_file(self):
         with prepare_file(['#todo this is todo'], None) as (lines, filename):
             args = (coala.main, 'coala', '--json', '-c', os.devnull, '-b',
-                    'LineCountTestBear', '-f', re.escape(filename),
+                    'LineCountTestBear', '-f', filename,
                     '--log-json')
             retval1, stdout1, stderr1 = execute_coala(*args)
             retval2, stdout2, stderr2 = execute_coala(*(args +
@@ -155,7 +154,7 @@ class coalaJSONTest(unittest.TestCase):
     def test_output_file_overwriting(self):
         with prepare_file(['#todo this is todo'], None) as (lines, filename):
             args = (coala.main, 'coala', '--json', '-c', os.devnull, '-b',
-                    'LineCountTestBear', '-f', re.escape(filename),
+                    'LineCountTestBear', '-f', filename,
                     '--log-json', '-o', 'file.json')
             execute_coala(*args)
 

--- a/tests/coalaTest.py
+++ b/tests/coalaTest.py
@@ -1,5 +1,4 @@
 import os
-import re
 import sys
 import unittest
 import unittest.mock
@@ -36,7 +35,7 @@ class coalaTest(unittest.TestCase):
                              coala.main,
                              'coala', '-c', os.devnull,
                              '--non-interactive', '--no-color',
-                             '-f', re.escape(filename),
+                             '-f', filename,
                              '-b', 'LineCountTestBear')
             self.assertIn('This file has 1 lines.',
                           stdout,
@@ -57,7 +56,7 @@ class coalaTest(unittest.TestCase):
                                  coala.main,
                                  'coala', '-c', os.devnull,
                                  '--non-interactive', '--no-color',
-                                 '-f', re.escape(filename),
+                                 '-f', filename,
                                  '-b', 'LineCountTestBear', '-A')
                 self.assertIn('',
                               stdout,
@@ -79,7 +78,7 @@ class coalaTest(unittest.TestCase):
                                  coala.main,
                                  'coala', '-c', os.devnull,
                                  '--non-interactive', '--no-color',
-                                 '-f', re.escape(filename),
+                                 '-f', filename,
                                  '-b', 'LineCountTestBear', '-A')
                 self.assertIn('',
                               stdout,
@@ -101,7 +100,7 @@ class coalaTest(unittest.TestCase):
                                  coala.main,
                                  'coala', '-c', os.devnull,
                                  '--non-interactive', '--no-color',
-                                 '-f', re.escape(filename),
+                                 '-f', filename,
                                  '-b', 'LineCountTestBear', '-A')
                 self.assertIn('',
                               stdout,
@@ -121,7 +120,7 @@ class coalaTest(unittest.TestCase):
                              coala.main,
                              'coala', '-c', os.devnull,
                              '--non-interactive', '--no-color',
-                             '-f', re.escape(filename),
+                             '-f', filename,
                              '-S', 'cli.aspects=UnusedLocalVariable',
                              'cli.language=Python')
             self.assertIn(
@@ -251,7 +250,7 @@ class coalaTest(unittest.TestCase):
                     log_printer=LogPrinter(),
                     arg_list=(
                         '-c', os.devnull,
-                        '-f', re.escape(filename),
+                        '-f', filename,
                         '-b', 'SpaceConsistencyTestBear',
                         '--apply-patches',
                         '-S', 'use_spaces=yeah'
@@ -268,7 +267,7 @@ class coalaTest(unittest.TestCase):
                     log_printer=LogPrinter(),
                     arg_list=(
                         '-c', os.devnull,
-                        '-f', re.escape(filename),
+                        '-f', filename,
                         '-b', 'SpaceConsistencyTestBear',
                         '--apply-patches',
                         '-S', 'use_spaces=yeah'
@@ -289,7 +288,7 @@ class coalaTest(unittest.TestCase):
                 log_printer=LogPrinter(),
                 arg_list=(
                     '-c', os.devnull,
-                    '-f', re.escape(filename),
+                    '-f', filename,
                     '-b', 'ErrorTestBear'
                 ),
                 autoapply=False

--- a/tests/misc/CachingTest.py
+++ b/tests/misc/CachingTest.py
@@ -1,5 +1,4 @@
 import unittest
-import re
 import os
 from unittest.mock import patch
 
@@ -110,7 +109,7 @@ class CachingTest(unittest.TestCase):
                     '-c', os.devnull,
                     '--disable-caching',
                     '--flush-cache',
-                    '-f', re.escape(filename),
+                    '-f', filename,
                     '-b', 'LineCountTestBear',
                     '-L', 'DEBUG')
                 self.assertIn('This file has', stdout)
@@ -124,7 +123,7 @@ class CachingTest(unittest.TestCase):
                 'coala',
                 '--non-interactive', '--no-color',
                 '-c', os.devnull,
-                '-f', re.escape(filename),
+                '-f', filename,
                 '-b', 'LineCountTestBear')
             self.assertIn('This file has', stdout)
             self.assertEqual(1, len(stderr.splitlines()))
@@ -137,7 +136,7 @@ class CachingTest(unittest.TestCase):
                 'coala',
                 '--non-interactive', '--no-color',
                 '-c', os.devnull,
-                '-f', re.escape(filename),
+                '-f', filename,
                 '-b', 'LineCountTestBear')
             self.assertIn('This file has', stdout)
             self.assertEqual(1, len(stderr.splitlines()))


### PR DESCRIPTION
Use a new `PathArg` type for all cmdline arguments that represent file system paths. It replaces OS-native directory separators with Unix-style forward slashes. Windows-style backslashes would otherwise be interpreted as escaping syntax and therefore removed when turning cmdline arguments into coala settings, what makes interactively working with coala in a Windows cmdline a pain ;)

Closes https://github.com/coala/coala/issues/4356

cc @Makman2 @jayvdb 