### PR TITLE
Build setup.py and requirements.txt using moban

### DIFF
--- a/.coafile
+++ b/.coafile
@@ -124,6 +124,10 @@ files =
     **.sh, .travis.yml, circle.yml, setup.cfg, ./docs/_static/custom.css
 ignore = node_modules/**
 
+[jinja2]
+bears = Jinja2Bear
+files = **.jj2
+
 [TODOS]
 enabled = False
 

--- a/.moban.dt/core-setup.py.jj2
+++ b/.moban.dt/core-setup.py.jj2
@@ -1,0 +1,41 @@
+{% extends 'coala-setup.py.jj2' %}
+
+{% block local_exec_block_1 %}
+assert_supported_version()
+
+
+class BuildPyCommand(setuptools.command.build_py.build_py):
+
+    def run(self):
+        if platform.system() != 'Windows':
+            self.run_command('build_manpage')
+        setuptools.command.build_py.build_py.run(self)
+
+{% endblock %}
+
+{% block local_exec_block_2 %}
+
+# Generate API documentation only if we are running on readthedocs.io
+on_rtd = getenv('READTHEDOCS', None) is not None
+if on_rtd:
+    call(BuildDocsCommand.apidoc_command)
+    if 'dev' in '{{ build_version }}':
+        current_version = datetime.datetime.now().strftime('%Y%m%d%H%M%S')
+        call(['python3', '.misc/adjust_version_number.py', 'coalib/VERSION',
+              '-b {}'.format(current_version)])
+        VERSION = get_version()
+
+{% endblock %}
+
+{% block custom_requirements %}
+if __name__ == '__main__':
+    if platform.system() != 'Windows':
+        data_files = [('man/man1', ['coala.1'])]
+    else:
+        data_files = None
+{% endblock %}
+
+{% block custom_setup_commands %}
+                    'build_manpage': BuildManPage,
+                    'build_py': BuildPyCommand,
+{% endblock %}

--- a/.moban.yaml
+++ b/.moban.yaml
@@ -1,0 +1,46 @@
+overrides: coala.yaml
+
+name: coala
+contact: coala.analyzer@gmail.com
+description: Linting and Fixing Code for All Languages
+build_version: 0.12.0.dev99999999999999
+current_version: 0.12.0.dev
+version: 0.12.0.dev
+release: 0.12.0.dev
+branch: master
+command_line_interface: coala
+package_module: coalib
+rtd_maintainer: L.S., F.N., M.K.
+
+entry_points:
+  console_scripts:
+    - coala = coalib.coala:main
+    - coala-ci = coalib.coala_ci:main
+    - coala-json = coalib.coala_json:main
+    - coala-format = coalib.coala_format:main
+    - coala-delete-orig = coalib.coala_delete_orig:main
+
+dependencies:
+  - appdirs~=1.4
+  - coala_utils~=0.7.0
+  - colorlog>=2.7,<4.0
+  - dependency_management~=0.4.0
+  - packaging>=16.8
+  - Pygments~=2.1
+  - PyPrint~=0.2.6
+  - requests~=2.12
+  - setuptools>=21.0.0
+  - testfixtures~=5.3.1
+  - unidiff~=0.5.2
+
+configuration:
+  template_dir:
+    - .moban.dt/
+    - ../coala-mobans/templates/
+    - ../setupmobans/templates/
+  configuration: .moban.yaml
+  configuration_dir: ../coala-mobans/
+targets:
+  - setup.py: core-setup.py.jj2
+  - requirements.txt: requirements.txt.jj2
+  - coalib/VERSION: VERSION.jj2

--- a/.travis.yml
+++ b/.travis.yml
@@ -67,6 +67,10 @@ before_script:
   # Restore the original requirements.txt
   - mv requirements.orig requirements.txt
   - python .misc/check_setuptools.py
+  - git clone https://github.com/moremoban/setupmobans ../setupmobans
+  - git clone https://gitlab.com/coala/mobans ../coala-mobans
+  - moban
+  - git diff --exit-code
 
 script:
   - py.test

--- a/.travis.yml
+++ b/.travis.yml
@@ -61,7 +61,7 @@ before_install:
   - if [[ $TRAVIS_OS_NAME == osx ]]; then pip install -r requirements.txt; fi
 
   # For bears in .coafile requiring npm dependencies
-  - npm install
+  - npm install --no-save
 
 before_script:
   # Restore the original requirements.txt

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -4,6 +4,7 @@ coverage-env-plugin~=0.1
 coverage-config-reload-plugin~=0.2
 codecov~=2.0.5
 freezegun~=0.3.9
+moban~=0.0.9
 pytest~=3.1.1
 pytest-cov~=2.2
 pytest-env~=0.6.0


### PR DESCRIPTION
coala-mobans provides a set of metadata common to
all repositories, with local overrides.

requirements.txt is generated using the default
moban provided requirements.txt.jj2.
