### PR TITLE
Linter_Bears_Advanced.rst: Explains return `None`

### DIFF
--- a/docs/Developers/Linter_Bears_Advanced.rst
+++ b/docs/Developers/Linter_Bears_Advanced.rst
@@ -21,8 +21,7 @@ easily by overriding ``generate_config()``.
             return config_file
 
 The string returned by this method is written into a temporary file before
-invoking ``create_arguments()``. If you return ``None``, no configuration file
-is generated.
+invoking ``create_arguments()``.
 
 The path of the temporary configuration file can be accessed inside
 ``create_arguments()`` via the ``config_file`` parameter:
@@ -40,6 +39,30 @@ The path of the temporary configuration file can be accessed inside
         @staticmethod
         def create_arguments(filename, file, config_file):
             return "--use-config", config_file
+
+If you return ``None``, no configuration file is generated. A common case
+where to explicitly return ``None`` is when you want to expose a setting
+for the user to use his own tool-specific config. In case the user specifies
+such a config file, we can avoid generating one again with ``generate_config``
+to reduce I/O load.
+
+::
+
+    @linter(executable='...')
+    class MyBear:
+        @staticmethod
+        def generate_config(filename, file,
+                            user_config: str='',
+                            setting_a: bool=False):
+            if user_config:
+                return None
+            else:
+                return 'A={}'.format(setting_a)
+
+        def create_arguments(filename, file, config_file,
+                             user_config: str=''):
+            return (filename, '--use-config',
+                    user_config if user_config else config_file)
 
 .. note::
 


### PR DESCRIPTION
Mentions how returning `None` inside `generate_config` works

Closes https://github.com/coala/coala/issues/4119

<!--
Thanks for your contribution!

Please take a quick look at those things down there. They're quite important.
Really! We wrote them for you. Yes you! With utmost care. Read them.
-->

**For short term contributors:** we understand that getting your commits well
defined like we require is a hard task and takes some learning. If you
look to help without wanting to contribute long term there's no need
for you to learn this. Just drop us a message and we'll take care of brushing
up your stuff for merge!

### Checklist

- [x] I read the [commit guidelines](http://coala.io/commit) and I've followed
      them.
- [x] I ran coala over my code locally. (*All commits have to pass
      individually.* It is not sufficient to have "fixup commits" on your PR,
      our bot will still report the issues for the previous commit.) You will
      likely receive a lot of bot comments and build failures if coala does not
      pass on every single commit!

After you submit your pull request, **DO NOT click the 'Update Branch' button.**
When asked for a rebase, consult [coala.io/rebase](https://coala.io/rebase)
instead.

Please consider helping us by reviewing other peoples pull requests as well:

- pick up any PR at <https://coala.io/review>
- review it (check <https://coala.io/reviewing> for more info)
- if you are sure that it needs work, use `cobot mark wip <URL>` to get it out
  of the review queue.

The more you review, the more your score will grow at coala.io and we will
review your PRs faster!
