### PR TITLE
Interactions.fail_acquire_settings: Remove section parameter

### DIFF
--- a/coalib/output/Interactions.py
+++ b/coalib/output/Interactions.py
@@ -1,7 +1,7 @@
 import logging
 
 
-def fail_acquire_settings(log_printer, settings_names_dict, section=None):
+def fail_acquire_settings(log_printer, settings_names_dict):
     """
     This method throws an exception if any setting needs to be acquired.
 
@@ -10,16 +10,10 @@ def fail_acquire_settings(log_printer, settings_names_dict, section=None):
                                 a list containing a description in [0] and the
                                 name of the bears who need this setting in [1]
                                 and following.
-    :param section:             This parameter is deprecated and is no longer
-                                required.
     :raises AssertionError:     If any setting is required.
     :raises TypeError:          If ``settings_names_dict`` is not a
                                 dictionary.
     """
-    if section is not None:
-        logging.warning('fail_acquire_settings: section parameter is '
-                        'deprecated.')
-
     if not isinstance(settings_names_dict, dict):
         raise TypeError('The settings_names_dict parameter has to be a '
                         'dictionary.')

--- a/coalib/settings/SectionFilling.py
+++ b/coalib/settings/SectionFilling.py
@@ -1,4 +1,6 @@
 import copy
+from inspect import signature
+import logging
 
 from coalib.bears.BEAR_KIND import BEAR_KIND
 from coalib.collecting import Dependencies
@@ -45,7 +47,13 @@ def fill_section(section, acquire_settings, log_printer, bears):
 
     # Get missing ones.
     if len(needed_settings) > 0:
-        new_vals = acquire_settings(None, needed_settings, section)
+        if len(signature(acquire_settings).parameters) == 2:
+            new_vals = acquire_settings(None, needed_settings)
+        else:
+            logging.warning('acquire_settings: section parameter is '
+                            'deprecated.')
+            new_vals = acquire_settings(None, needed_settings, section)
+
         for setting, help_text in new_vals.items():
             section.append(Setting(setting, help_text))
 

--- a/tests/output/InteractionsTest.py
+++ b/tests/output/InteractionsTest.py
@@ -1,11 +1,9 @@
 import unittest
 
 from pyprint.NullPrinter import NullPrinter
-from testfixtures import LogCapture
 
 from coalib.output.Interactions import fail_acquire_settings
 from coalib.output.printers.LogPrinter import LogPrinter
-from coalib.settings.Section import Section
 
 
 class InteractionsTest(unittest.TestCase):
@@ -18,15 +16,3 @@ class InteractionsTest(unittest.TestCase):
                           log_printer,
                           {'setting': ['description', 'bear']})
         self.assertEqual(fail_acquire_settings(log_printer, {}), None)
-
-    def test_section_deprecation(self):
-        section = Section('')
-        log_printer = LogPrinter(NullPrinter())
-        with LogCapture() as capture:
-            fail_acquire_settings(log_printer, {}, section)
-            capture.check(
-                ('root',
-                 'WARNING',
-                 'fail_acquire_settings: section parameter '
-                 'is deprecated.')
-            )

--- a/tests/settings/SectionFillingTest.py
+++ b/tests/settings/SectionFillingTest.py
@@ -1,6 +1,7 @@
 import unittest
 
 from pyprint.ConsolePrinter import ConsolePrinter
+from testfixtures import LogCapture
 
 from coalib.bears.GlobalBear import GlobalBear
 from coalib.bears.LocalBear import LocalBear
@@ -40,6 +41,7 @@ class SectionFillingTest(unittest.TestCase):
         self.log_printer = LogPrinter(ConsolePrinter())
         self.section = Section('test')
         self.section.append(Setting('key', 'val'))
+        self.empty_section = Section('')
 
     def test_fill_settings(self):
         sections = {'test': self.section}
@@ -86,6 +88,25 @@ class SectionFillingTest(unittest.TestCase):
         self.assertTrue('global name' in new_section)
         self.assertEqual(new_section['key'].value, 'val')
         self.assertEqual(len(new_section.contents), 3)
+
+        # test the deprecation of calling acquire_settings
+        with LogCapture() as capture:
+            fill_section(self.empty_section,
+                         lambda param_1, param_2: {},
+                         self.log_printer,
+                         [LocalTestBear, GlobalTestBear])
+            capture.check()
+
+        with LogCapture() as capture:
+            fill_section(self.empty_section,
+                         lambda param_1, param_2, param_3: {},
+                         self.log_printer,
+                         [LocalTestBear, GlobalTestBear])
+            capture.check(
+                ('root',
+                 'WARNING',
+                 'acquire_settings: section parameter is deprecated.')
+            )
 
     def test_dependency_resolving(self):
         sections = {'test': self.section}


### PR DESCRIPTION
The section parameter in fail_acquire_setting
is deprecated.This commit adapts all calls to
the function without the section parameter.

Closes https://github.com/coala/coala/issues/4866

<!--
Thanks for your contribution!

Please take a quick look at those things down there. They're quite important.
Really! We wrote them for you. Yes you! With utmost care. Read them.
-->

**For short term contributors:** we understand that getting your commits well
defined like we require is a hard task and takes some learning. If you
look to help without wanting to contribute long term there's no need
for you to learn this. Just drop us a message and we'll take care of brushing
up your stuff for merge!

### Checklist

- [x] I read the [commit guidelines](http://coala.io/commit) and I've followed
      them.
- [x] I ran coala over my code locally. (*All commits have to pass
      individually.* It is not sufficient to have "fixup commits" on your PR,
      our bot will still report the issues for the previous commit.) You will
      likely receive a lot of bot comments and build failures if coala does not
      pass on every single commit!

After you submit your pull request, **DO NOT click the 'Update Branch' button.**
When asked for a rebase, consult [coala.io/rebase](https://coala.io/rebase)
instead.

Please consider helping us by reviewing other peoples pull requests as well:

- pick up any PR at <https://coala.io/review>
- review it (check <https://coala.io/reviewing> for more info)
- if you are sure that it needs work, use `cobot mark wip <URL>` to get it out
  of the review queue.

The more you review, the more your score will grow at coala.io and we will
review your PRs faster!
