### PR TITLE
ConsoleInteractionTest.py : Remove dual definition

### DIFF
--- a/tests/output/ConsoleInteractionTest.py
+++ b/tests/output/ConsoleInteractionTest.py
@@ -490,24 +490,6 @@ class ConsoleInteractionTest(unittest.TestCase):
             self.assertEqual(generator.last_input, 3)
             self.assertNotIn('TestAction', failed_actions)
 
-    def test_ask_for_actions_and_apply(self):
-        failed_actions = set()
-        action = TestAction()
-        args = [self.console_printer, Section(''),
-                [action.get_metadata()], {'TestAction': action},
-                failed_actions, Result('origin', 'message'), {}, {}, {}]
-
-        with simulate_console_inputs('a', 'param1', 'a', 'param2') as generator:
-            action.apply = unittest.mock.Mock(side_effect=AssertionError)
-            ask_for_action_and_apply(*args)
-            self.assertEqual(generator.last_input, 1)
-            self.assertIn('TestAction', failed_actions)
-
-            action.apply = lambda *args, **kwargs: {}
-            ask_for_action_and_apply(*args)
-            self.assertEqual(generator.last_input, 3)
-            self.assertNotIn('TestAction', failed_actions)
-
     def test_default_input(self):
         action = TestAction()
         args = [self.console_printer, Section(''),


### PR DESCRIPTION
Two duplicate definitions of test_ask_for_actions_and_apply are present. I have removed one of them thereby eliminating confusion which arose due to double definitions of test_ask_for_actions_and_apply.

Closes https://github.com/coala/coala/issues/4861

<!--
Thanks for your contribution!

Please take a quick look at those things down there. They're quite important.
Really! We wrote them for you. Yes you! With utmost care. Read them.
-->

**For short term contributors:** we understand that getting your commits well
defined like we require is a hard task and takes some learning. If you
look to help without wanting to contribute long term there's no need
for you to learn this. Just drop us a message and we'll take care of brushing
up your stuff for merge!

### Checklist

- [✔️] I read the [commit guidelines](http://coala.io/commit) and I've followed
      them.
- [✔️] I ran coala over my code locally. (*All commits have to pass
      individually.* It is not sufficient to have "fixup commits" on your PR,
      our bot will still report the issues for the previous commit.) You will
      likely receive a lot of bot comments and build failures if coala does not
      pass on every single commit!

After you submit your pull request, **DO NOT click the 'Update Branch' button.**
When asked for a rebase, consult [coala.io/rebase](https://coala.io/rebase)
instead.

Please consider helping us by reviewing other peoples pull requests as well:

- pick up any PR at <https://coala.io/review>
- review it (check <https://coala.io/reviewing> for more info)
- if you are sure that it needs work, use `cobot mark wip <URL>` to get it out
  of the review queue.

The more you review, the more your score will grow at coala.io and we will
review your PRs faster!
