### PR TITLE
coalaTest.py: Add test for bear dir (-d) flag

### DIFF
--- a/tests/coalaTest.py
+++ b/tests/coalaTest.py
@@ -323,3 +323,20 @@ class coalaTest(unittest.TestCase):
                 self.assertRegex(err, '^\[WARNING\]')
             self.assertEqual(
                 retval, 0, 'coala must return zero when there are no errors')
+
+    def test_coala_add_bear_dir(self):
+        with bear_test_module(), \
+             prepare_file(['#fixme'], None) as (lines, filename):
+            retval, stdout, stderr = execute_coala(
+                coala.main, 'coala', '-c', os.devnull,
+                '--non-interactive',
+                '-f', re.escape(filename),
+                '-d', 'tests/hidden_bear_dir',
+                '-b', 'HiddenBear',
+            )
+            self.assertIn('-d flag works!', stdout)
+            if "This result has no patch attached" not in stderr:
+                self.assertEqual(
+                    retval, 0, 'coala must return zero when there are no errors')
+            self.assertEqual(
+                retval, 1, "no patch attached error kludge")

--- a/tests/coalaTest.py
+++ b/tests/coalaTest.py
@@ -337,6 +337,7 @@ class coalaTest(unittest.TestCase):
             self.assertIn('-d flag works!', stdout)
             if "This result has no patch attached" not in stderr:
                 self.assertEqual(
-                    retval, 0, 'coala must return zero when there are no errors')
+                    retval, 0, 
+                    'coala must return zero when there are no errors')
             self.assertEqual(
                 retval, 1, "no patch attached error kludge")

--- a/tests/coalaTest.py
+++ b/tests/coalaTest.py
@@ -335,9 +335,9 @@ class coalaTest(unittest.TestCase):
                 '-b', 'HiddenBear',
             )
             self.assertIn('-d flag works!', stdout)
-            if "This result has no patch attached" not in stderr:
+            if 'This result has no patch attached' not in stderr:
                 self.assertEqual(
-                    retval, 0, 
+                    retval, 0,
                     'coala must return zero when there are no errors')
             self.assertEqual(
-                retval, 1, "no patch attached error kludge")
+                retval, 1, 'no patch attached error kludge')

--- a/tests/hidden_bear_dir/HiddenBear.py
+++ b/tests/hidden_bear_dir/HiddenBear.py
@@ -1,0 +1,18 @@
+from coalib.bears.LocalBear import LocalBear
+from coalib.results.Result import Result
+from coalib.results.RESULT_SEVERITY import RESULT_SEVERITY
+
+
+class HiddenBear(LocalBear):
+
+    LANGUAGES = {'all'}
+
+    def run(self, filename, file):
+        """
+        Is hidden from coala until -d is used.
+        """
+        yield Result.from_values(
+            origin=self,
+            message='-d flag works!',
+            severity=RESULT_SEVERITY.INFO,
+            file=filename)


### PR DESCRIPTION
Tries to run a small bear hidden in a directory.
If the -d flag doesn't work, this unit test will fail.

Fixes https://github.com/coala/coala/issues/4888

<!--
Thanks for your contribution!

Please take a quick look at those things down there. They're quite important.
Really! We wrote them for you. Yes you! With utmost care. Read them.
-->

**For short term contributors:** we understand that getting your commits well
defined like we require is a hard task and takes some learning. If you
look to help without wanting to contribute long term there's no need
for you to learn this. Just drop us a message and we'll take care of brushing
up your stuff for merge!

### Checklist

- [ ] I read the [commit guidelines](http://coala.io/commit) and I've followed
      them.
- [ ] I ran coala over my code locally. (*All commits have to pass
      individually.* It is not sufficient to have "fixup commits" on your PR,
      our bot will still report the issues for the previous commit.) You will
      likely receive a lot of bot comments and build failures if coala does not
      pass on every single commit!

After you submit your pull request, **DO NOT click the 'Update Branch' button.**
When asked for a rebase, consult [coala.io/rebase](https://coala.io/rebase)
instead.

Please consider helping us by reviewing other peoples pull requests as well:

- pick up any PR at <https://coala.io/review>
- review it (check <https://coala.io/reviewing> for more info)
- if you are sure that it needs work, use `cobot mark wip <URL>` to get it out
  of the review queue.

The more you review, the more your score will grow at coala.io and we will
review your PRs faster!
