### PR TITLE
LocalBearTestHelperTest.py: Display command line

### DIFF
--- a/tests/testing/LocalBearTestHelperTest.py
+++ b/tests/testing/LocalBearTestHelperTest.py
@@ -125,11 +125,15 @@ class LocalBearTestHelper(unittest.TestCase):
             with execute_bear(uut, 'filename', ['file']) as result:
                 raise AssertionError
         except AssertionError as ex:
-            self.assertIn('The program yielded the following output:', str(ex))
-            self.assertIn('Stdout:', str(ex))
-            self.assertIn('hello stdout', str(ex))
-            self.assertIn('Stderr:', str(ex))
-            self.assertIn('hello stderr', str(ex))
+            self.assertIn('Program arguments:\n'
+                          "('-c', \"import sys\\n"
+                          "print('hello stdout')\\n"
+                          "print('hello stderr', file=sys.stderr)\")\n"
+                          'The program yielded the following output:\n\n'
+                          'Stdout:\n'
+                          'hello stdout\n\n'
+                          'Stderr:\n'
+                          'hello stderr', str(ex))
 
         # Testing with only stdout enabled
         uut = (linter(sys.executable, use_stdout=True)
@@ -139,8 +143,12 @@ class LocalBearTestHelper(unittest.TestCase):
             with execute_bear(uut, 'filename', ['file']) as result:
                 raise AssertionError
         except AssertionError as ex:
-            self.assertIn('The program yielded the following output:', str(ex))
-            self.assertIn('hello stdout', str(ex))
+            self.assertIn('Program arguments:\n'
+                          "('-c', \"import sys\\n"
+                          "print('hello stdout')\\n"
+                          "print('hello stderr', file=sys.stderr)\")\n"
+                          'The program yielded the following output:\n\n'
+                          'hello stdout', str(ex))
 
     def test_exception(self):
 


### PR DESCRIPTION
The command line is not displayed in case of
test-fail in execute_bears function when a
linter is used. This commit fixes that issue.

Closes https://github.com/coala/coala/issues/4901

<!--
Thanks for your contribution!

Please take a quick look at those things down there. They're quite important.
Really! We wrote them for you. Yes you! With utmost care. Read them.
-->

**For short term contributors:** we understand that getting your commits well
defined like we require is a hard task and takes some learning. If you
look to help without wanting to contribute long term there's no need
for you to learn this. Just drop us a message and we'll take care of brushing
up your stuff for merge!

### Checklist

- [x] I read the [commit guidelines](http://coala.io/commit) and I've followed
      them.
- [x] I ran coala over my code locally. (*All commits have to pass
      individually.* It is not sufficient to have "fixup commits" on your PR,
      our bot will still report the issues for the previous commit.) You will
      likely receive a lot of bot comments and build failures if coala does not
      pass on every single commit!

After you submit your pull request, **DO NOT click the 'Update Branch' button.**
When asked for a rebase, consult [coala.io/rebase](https://coala.io/rebase)
instead.

Please consider helping us by reviewing other peoples pull requests as well:

- pick up any PR at <https://coala.io/review>
- review it (check <https://coala.io/reviewing> for more info)
- if you are sure that it needs work, use `cobot mark wip <URL>` to get it out
  of the review queue.

The more you review, the more your score will grow at coala.io and we will
review your PRs faster!
