### PR TITLE
core: Make bear dependencies instance bound

### DIFF
--- a/coalib/core/Bear.py
+++ b/coalib/core/Bear.py
@@ -195,6 +195,10 @@ class Bear:
         self.section = section
         self.file_dict = file_dict
 
+        # Copy the bears specified in Bear.BEAR_DEPS to this instance, so
+        # runtime modifications are allowed.
+        self.BEAR_DEPS = set(self.BEAR_DEPS)
+
         self._dependency_results = defaultdict(list)
 
         self.setup_dependencies()

--- a/coalib/core/Core.py
+++ b/coalib/core/Core.py
@@ -125,17 +125,21 @@ def initialize_dependencies(bears):
             type_to_instance_map[bear] = bear
             type_to_instance_map[type(bear)] = bear
 
-        def instantiate_and_track(prev_bear_type, next_bear_type):
-            if next_bear_type not in type_to_instance_map:
-                type_to_instance_map[next_bear_type] = (
-                    next_bear_type(section, file_dict))
+        def get_successive_nodes_and_track(bear):
+            for dependency_bear_type in bear.BEAR_DEPS:
+                if dependency_bear_type not in type_to_instance_map:
+                    dependency_bear = dependency_bear_type(section, file_dict)
+                    type_to_instance_map[dependency_bear_type] = dependency_bear
 
-            dependency_tracker.add(type_to_instance_map[next_bear_type],
-                                   type_to_instance_map[prev_bear_type])
+                dependency_tracker.add(
+                    type_to_instance_map[dependency_bear_type], bear)
 
-        traverse_graph(bears_per_section,
-                       lambda bear: bear.BEAR_DEPS,
-                       instantiate_and_track)
+            # Return the dependencies of the instances instead of the types, so
+            # bears are capable to specify dependencies at runtime.
+            return (type_to_instance_map[dependency_bear_type]
+                    for dependency_bear_type in bear.BEAR_DEPS)
+
+        traverse_graph(bears_per_section, get_successive_nodes_and_track)
 
     # Get all bears that aren't resolved and exclude those from scheduler set.
     bears -= {bear for bear in bears

--- a/tests/core/BearTest.py
+++ b/tests/core/BearTest.py
@@ -26,6 +26,10 @@ class Bear2(Bear):
     pass
 
 
+class BearWithDependencies(Bear):
+    BEAR_DEPS = {Bear1}
+
+
 class BearWithAnalysis(Bear):
 
     def analyze(self, x: int, y: int, z: int=33):
@@ -254,3 +258,18 @@ class BearTest(unittest.TestCase):
             'REQUIREMENTS': set()}
 
         self.assertEqual(result, expected)
+
+    def test_class_bear_deps_immutability(self):
+        section = Section('test-section')
+        uut = BearWithDependencies(section, {})
+
+        self.assertIsNot(uut.BEAR_DEPS,
+                         BearWithDependencies.BEAR_DEPS)
+
+        self.assertEqual(BearWithDependencies.BEAR_DEPS, {Bear1})
+        self.assertEqual(uut.BEAR_DEPS, {Bear1})
+
+        uut.BEAR_DEPS.add(Bear2)
+
+        self.assertEqual(BearWithDependencies.BEAR_DEPS, {Bear1})
+        self.assertEqual(uut.BEAR_DEPS, {Bear1, Bear2})

--- a/tests/core/CoreTest.py
+++ b/tests/core/CoreTest.py
@@ -1,5 +1,6 @@
 from concurrent.futures import ThreadPoolExecutor
 import logging
+import sys
 import unittest
 import unittest.mock
 
@@ -93,6 +94,19 @@ class BearH_NeedsG(TestBearBase):
     BEAR_DEPS = {BearG_NeedsF}
 
 
+class BearI_NeedsA_NeedsBDuringRuntime(TestBearBase):
+    BEAR_DEPS = {BearA}
+
+    def __init__(self, section, filedict):
+        super().__init__(section, filedict)
+
+        self.BEAR_DEPS.add(BearB)
+
+
+class BearJ_NeedsI(TestBearBase):
+    BEAR_DEPS = {BearI_NeedsA_NeedsBDuringRuntime}
+
+
 class MultiResultBear(TestBearBase):
 
     def analyze(self, bear, section_name, file_dict):
@@ -115,10 +129,18 @@ class DynamicTaskBear(TestBearBase):
         return (((i,), {}) for i in range(tasks_count))
 
 
+# Define those classes at module level to make them picklable.
+for i in range(100):
+    classname = 'NoTasksBear{}'.format(i)
+    generated_type = type(classname,
+                          (Bear,),
+                          dict(generate_tasks=lambda self: tuple()))
+
+    setattr(sys.modules[__name__], classname, generated_type)
+
+
 class DependentOnMultipleZeroTaskBearsTestBear(TestBearBase):
-    BEAR_DEPS = {type('NoTasksBear{}'.format(i),
-                      (Bear,),
-                      dict(generate_tasks=lambda self: tuple()))
+    BEAR_DEPS = {getattr(sys.modules[__name__], 'NoTasksBear{}'.format(i))
                  for i in range(100)} | {MultiResultBear}
 
 
@@ -643,6 +665,49 @@ class CoreTest(CoreTestBase):
 
     def test_run_empty(self):
         self.execute_run(set())
+
+    def test_bears_with_runtime_dependencies(self):
+        bear = BearI_NeedsA_NeedsBDuringRuntime(self.section1, self.filedict1)
+
+        results = self.execute_run({bear})
+
+        self.assertTestResultsEqual(
+            results,
+            [(BearA.name, self.section1.name, self.filedict1),
+             (BearB.name, self.section1.name, self.filedict1),
+             (BearI_NeedsA_NeedsBDuringRuntime.name, self.section1.name,
+              self.filedict1)])
+
+        self.assertEqual(len(bear.dependency_results), 2)
+
+        self.assertTestResultsEqual(
+            bear.dependency_results[BearA],
+            [(BearA.name, self.section1.name, self.filedict1)])
+
+        self.assertTestResultsEqual(
+            bear.dependency_results[BearB],
+            [(BearB.name, self.section1.name, self.filedict1)])
+
+        # See whether this also works with a bear using the bear with runtime
+        # dependencies itself as a dependency.
+        bear = BearJ_NeedsI(self.section1, self.filedict1)
+
+        results = self.execute_run({bear})
+
+        self.assertTestResultsEqual(
+            results,
+            [(BearA.name, self.section1.name, self.filedict1),
+             (BearB.name, self.section1.name, self.filedict1),
+             (BearI_NeedsA_NeedsBDuringRuntime.name, self.section1.name,
+              self.filedict1),
+             (BearJ_NeedsI.name, self.section1.name, self.filedict1)])
+
+        self.assertEqual(len(bear.dependency_results), 1)
+
+        self.assertTestResultsEqual(
+            bear.dependency_results[BearI_NeedsA_NeedsBDuringRuntime],
+            [(BearI_NeedsA_NeedsBDuringRuntime.name, self.section1.name,
+              self.filedict1)])
 
 
 # Execute the same tests from CoreTest, but use a ThreadPoolExecutor instead.


### PR DESCRIPTION
Bears can now define dependencies at instantiation for `BEAR_DEPS`,
depending on different section settings.

The Bear class makes now a copy of the dependencies specified in
`BEAR_DEPS`, so users can directly modify the set inside `__init__`
(which prevents modifying the class wide dependencies that are always
needed).

For that, the core test bears had to be adapted, because before
picklibility of those test bears was not necessary to run the
core.

Closes https://github.com/coala/coala/issues/4560