### PR TITLE
requirements.txt: Upgrade to colorlog 3.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 appdirs~=1.4
 coala_utils~=0.7.0
-colorlog~=2.7
+colorlog>=2.7,<4.0
 dependency_management~=0.4.0
 packaging>=16.8
 Pygments~=2.1


### PR DESCRIPTION
colorlog was pinned to 2.x. colorlog 3.0 has been released for a
few months, and is now starting to cause conflicts in versions,
which causes coala to fail.
The changes in colorlog 3.0 and 3.1 do not adversely effect coala.

Closes https://github.com/coala/coala/issues/4992