### PR TITLE
Newcomers_Guide.rst: Allow only one newcomer issue

### DIFF
--- a/docs/Developers/Newcomers_Guide.rst
+++ b/docs/Developers/Newcomers_Guide.rst
@@ -23,6 +23,9 @@ following tasks, you will become a developer at coala:
   - merge a ``difficulty/low`` Pull Request
   - review at least a ``difficulty/low`` or higher Pull Request
 
+Note: After you have solved a ``difficulty/newcomer`` issue, please don't
+take up any more. Instead, move on to more difficult issues.
+
 Once you've run coala on a project, please fill out our
 `usability survey <http://coala.io/usability>`_. And once you've got your first Pull
 Request merged successfully, fill out our


### PR DESCRIPTION
Tells the newcomer to merge only one difficulty/newcomer issue.

Fixes https://github.com/coala/coala/issues/4771

<!--
Thanks for your contribution!

Please take a quick look at those things down there. They're quite important.
Really! We wrote them for you. Yes you! With utmost care. Read them.
-->

### Checklist

- [x] I read the [commit guidelines](http://coala.io/commit) and I've followed
      them.
- [x] I ran coala over my code locally. (*All commits have to pass
      individually.* It is not sufficient to have "fixup commits" on your PR,
      our bot will still report the issues for the previous commit.) You will
      likely receive a lot of bot comments and build failures if coala does not
      pass on every single commit!