### PR TITLE
'.coafile' was not found now occurs only once

### DIFF
--- a/coalib/settings/ConfigurationGathering.py
+++ b/coalib/settings/ConfigurationGathering.py
@@ -105,7 +105,7 @@ def merge_section_dicts(lower, higher):
     return lower
 
 
-def load_config_file(filename, log_printer=None, silent=False):
+def load_config_file(filename, log_printer=None, silent=True):
     """
     Loads sections from a config file. Prints an appropriate warning if
     it doesn't exist and returns a section dict containing an empty
@@ -258,15 +258,7 @@ def load_configuration(arg_list,
         config = os.path.abspath(
             str(cli_sections['cli'].get('config', user_config)))
 
-        try:
-            save = bool(cli_sections['cli'].get('save', 'False'))
-        except ValueError:
-            # A file is deposited for the save parameter, means we want to save
-            # but to a specific file.
-            save = True
-
-        coafile_sections = load_config_file(config,
-                                            silent=save or silent)
+        coafile_sections = load_config_file(config, silent=True)
 
         sections = merge_section_dicts(base_sections, user_sections)
 


### PR DESCRIPTION
coala-quickstart --ci is now emitting warning "The default coafile '.coafile' was not found." only once.

Closes https://github.com/coala/coala-quickstart/issues/62

<!--
Thanks for your contribution!

Please take a quick look at those things down there. They're quite important.
Really! We wrote them for you. Yes you! With utmost care. Read them.
-->

**For short term contributors:** we understand that getting your commits well
defined like we require is a hard task and takes some learning. If you
look to help without wanting to contribute long term there's no need
for you to learn this. Just drop us a message and we'll take care of brushing
up your stuff for merge!

### Checklist

- [x] I read the [commit guidelines](http://coala.io/commit) and I've followed
      them.
- [x] I ran coala over my code locally. (*All commits have to pass
      individually.* It is not sufficient to have "fixup commits" on your PR,
      our bot will still report the issues for the previous commit.) You will
      likely receive a lot of bot comments and build failures if coala does not
      pass on every single commit!

After you submit your pull request, **DO NOT click the 'Update Branch' button.**
When asked for a rebase, consult [coala.io/rebase](https://coala.io/rebase)
instead.

Please consider helping us by reviewing other peoples pull requests as well:

- pick up any PR at <https://coala.io/review>
- review it (check <https://coala.io/reviewing> for more info)
- if you are sure that it needs work, use `cobot mark wip <URL>` to get it out
  of the review queue.

The more you review, the more your score will grow at coala.io and we will
review your PRs faster!
