### PR TITLE
development_setup.rst:fixed docstring typo

### DIFF
--- a/docs/Developers/Development_Setup.rst
+++ b/docs/Developers/Development_Setup.rst
@@ -64,7 +64,7 @@ in your current directory, as coala only works for Python >= 3.4
         (coala-venv)$ deactivate # to exit the environment
 
 - After this, you can start
-  `installing from git <https://coala.io/devsetup#installing-from-git>`_.
+  `installing from git <https://coala.io/devsetup#id1>`_.
 
 Repositories
 ------------


### PR DESCRIPTION
Fixed the 'installing from git' redirection link
associated with development_setup.rst

Closes #5002