### PR TITLE
Testing_Bears.rst: add `filename` parameter in `Result.from_values()`

### DIFF
--- a/docs/Developers/Testing_Bears.rst
+++ b/docs/Developers/Testing_Bears.rst
@@ -125,7 +125,8 @@ passed.
                 self.uut,
                 file,
                 [Result.from_values('TooManyLinesBear',
-                                    'Too many lines')],
+                                    'Too many lines',
+                                    'filename')],
                 settings={'max_number_of_lines': 20})
 
 ``check_results`` asserts if your bear results match the actual


### PR DESCRIPTION
Result : The from_values() function of Result class accepts a file as a parameter.
Fixes #5003 