### PR TITLE
Change instances of re.escape() with PathArg()

### DIFF
--- a/coalib/settings/ConfigurationGathering.py
+++ b/coalib/settings/ConfigurationGathering.py
@@ -1,5 +1,4 @@
 import os
-import re
 import sys
 import logging
 
@@ -11,6 +10,7 @@ from coalib.output.ConfWriter import ConfWriter
 from coalib.output.printers.LOG_LEVEL import LOG_LEVEL
 from coalib.parsing.CliParsing import parse_cli, check_conflicts
 from coalib.parsing.ConfParser import ConfParser
+from coalib.parsing.DefaultArgParser import PathArg
 from coalib.settings.Section import Section, extract_aspects_from_section
 from coalib.settings.SectionFilling import fill_settings
 from coalib.settings.Setting import Setting, path
@@ -237,7 +237,7 @@ def load_configuration(arg_list,
             bool(cli_sections['cli'].get('find_config', 'False')) and
             str(cli_sections['cli'].get('config')) == ''):
         cli_sections['cli'].add_or_create_setting(
-            Setting('config', re.escape(find_user_config(os.getcwd()))))
+            Setting('config', PathArg(find_user_config(os.getcwd()))))
 
     targets = []
     # We don't want to store targets argument back to file, thus remove it

--- a/tests/coalaDeleteOrigTest.py
+++ b/tests/coalaDeleteOrigTest.py
@@ -1,10 +1,10 @@
 import tempfile
 import unittest
 import os
-import re
 
 from coalib import coala_delete_orig
 from coala_utils.ContextManagers import retrieve_stderr
+from coalib.parsing.DefaultArgParser import PathArg
 from coalib.settings.Section import Section
 from coalib.settings.Setting import Setting
 
@@ -45,7 +45,7 @@ class coalaDeleteOrigTest(unittest.TestCase):
             temporary = tempfile.mkstemp(suffix='.orig', dir=directory)
             os.close(temporary[0])
             section = Section('')
-            section.append(Setting('project_dir', re.escape(directory)))
+            section.append(Setting('project_dir', PathArg(directory)))
             retval = coala_delete_orig.main(section=section)
             self.assertEqual(retval, 0)
             self.assertFalse(os.path.isfile(temporary[1]))

--- a/tests/settings/SettingTest.py
+++ b/tests/settings/SettingTest.py
@@ -1,5 +1,4 @@
 import os
-import re
 import unittest
 from collections import OrderedDict
 
@@ -10,6 +9,7 @@ from coalib.settings.Setting import (
     language,
     float_list, bool_list, int_list, str_list,
 )
+from coalib.parsing.DefaultArgParser import PathArg
 from coalib.parsing.Globbing import glob_escape
 
 
@@ -34,8 +34,8 @@ class SettingTest(unittest.TestCase):
         self.assertEqual(path(self.uut),
                          os.path.abspath(os.path.join('.', '22')))
 
-        abspath = os.path.abspath('.')
-        self.uut = Setting('key', re.escape(abspath))
+        abspath = PathArg(os.path.abspath('.'))
+        self.uut = Setting('key', abspath)
         self.assertEqual(path(self.uut), abspath)
 
         self.uut = Setting('key', ' 22', '')


### PR DESCRIPTION
Instances of `re.escape` not changed:

`Globbing.py`: 3 Instances
`DocumentationExtraction.py`: 1 Instance

Reason: Not sure whether to change them or not 
OR
using `re.escape()` in a way that it is intended to use, not operating on file paths, operating on file globs and the paths will ultimately be changed due to the other changes made.

Closes https://github.com/coala/coala/issues/4890

