### PR TITLE
Remove redundant instances of re.escape()

### DIFF
--- a/tests/processes/ProcessingTest.py
+++ b/tests/processes/ProcessingTest.py
@@ -4,7 +4,6 @@ import multiprocessing
 import os
 import platform
 import queue
-import re
 import subprocess
 import sys
 import unittest
@@ -93,7 +92,7 @@ class ProcessingTest(unittest.TestCase):
          targets) = gather_configuration(lambda *args: True,
                                          log_printer,
                                          arg_list=['--config',
-                                                   re.escape(config_path)])
+                                                   config_path])
         self.assertEqual(len(self.local_bears['cli']), 1)
         self.assertEqual(len(self.global_bears['cli']), 1)
         self.assertEqual(targets, [])

--- a/tests/settings/ConfigurationGatheringTest.py
+++ b/tests/settings/ConfigurationGatheringTest.py
@@ -1,5 +1,4 @@
 import os
-import re
 import tempfile
 import unittest
 import logging
@@ -152,7 +151,7 @@ class ConfigurationGatheringTest(unittest.TestCase):
         sections, local_bears, global_bears, targets = gather_configuration(
             lambda *args: True,
             self.log_printer,
-            arg_list=['-c', re.escape(config)])
+            arg_list=['-c', config])
 
         self.assertEqual(str(sections['test']),
                          "test {value : '2'}")
@@ -164,7 +163,7 @@ class ConfigurationGatheringTest(unittest.TestCase):
             lambda *args: True,
             self.log_printer,
             arg_list=['-c',
-                      re.escape(config),
+                      config,
                       '-S',
                       'test.value=3',
                       'test-2.bears=',


### PR DESCRIPTION
Closes https://github.com/coala/coala/issues/5020
