### PR TITLE
Ignore additional parameters if a section disabled

### DIFF
--- a/coalib/settings/ConfigurationGathering.py
+++ b/coalib/settings/ConfigurationGathering.py
@@ -491,6 +491,7 @@ def gather_configuration(acquire_settings,
     _set_section_language(sections)
     aspectize_sections(sections)
     local_bears, global_bears = fill_settings(sections,
+                                              targets,
                                               acquire_settings)
     save_sections(sections)
     warn_nonexistent_targets(targets, sections)

--- a/coalib/settings/SectionFilling.py
+++ b/coalib/settings/SectionFilling.py
@@ -61,6 +61,7 @@ def fill_section(section, acquire_settings, log_printer, bears):
 
 
 def fill_settings(sections,
+                  targets,
                   acquire_settings,
                   log_printer=None,
                   fill_section_method=fill_section,
@@ -72,6 +73,8 @@ def fill_settings(sections,
     This will retrieve all bears and their dependencies.
 
     :param sections:            The sections to fill up, modified in place.
+    :param targets:             List of section names to be executed which are
+                                passed from cli.
     :param acquire_settings:    The method to use for requesting settings. It
                                 will get a parameter which is a dictionary with
                                 the settings name as key and a list containing
@@ -107,11 +110,12 @@ def fill_settings(sections,
         section_global_bears = Dependencies.resolve(section_global_bears)
         all_bears = copy.deepcopy(section_local_bears)
         all_bears.extend(section_global_bears)
-        fill_section_method(section,
-                            acquire_settings,
-                            None,
-                            all_bears,
-                            **kwargs)
+        if section.is_enabled(targets):
+            fill_section_method(section,
+                                acquire_settings,
+                                None,
+                                all_bears,
+                                **kwargs)
 
         local_bears[section_name] = section_local_bears
         global_bears[section_name] = section_global_bears

--- a/tests/coalaCITest.py
+++ b/tests/coalaCITest.py
@@ -127,6 +127,23 @@ class coalaCITest(unittest.TestCase):
             self.assertNotEqual(retval, 0,
                                 'coala was expected to return non-zero')
 
+    def test_additional_parameters_settings(self, debug=False):
+        with bear_test_module(), \
+             prepare_file(['\t#include <a>'], None) as (lines, filename):
+            retval, stdout, stderr = execute_coala(
+                 coala.main, 'coala',
+                 '--non-interactive', '-S',
+                 'name.bears=SpaceConsistencyTestBear',
+                 'name.files={}'.format(filename),
+                 'name.enabled=False',
+                 '-c', os.devnull,
+                 debug=debug)
+            self.assertEqual('Executing section cli...\n', stdout)
+            self.assertNotIn('During execution, we found that some required '
+                             'settings were not provided.', stderr)
+            self.assertEqual(retval, 0,
+                             'coala was expected to return zero')
+
     def test_fail_acquire_settings_debug(self):
         with self.assertRaisesRegex(
                 AssertionError,

--- a/tests/settings/SectionFillingTest.py
+++ b/tests/settings/SectionFillingTest.py
@@ -45,8 +45,10 @@ class SectionFillingTest(unittest.TestCase):
 
     def test_fill_settings(self):
         sections = {'test': self.section}
+        targets = []
         with simulate_console_inputs() as generator:
             fill_settings(sections,
+                          targets,
                           acquire_settings,
                           self.log_printer)
             self.assertEqual(generator.last_input, -1)
@@ -55,6 +57,7 @@ class SectionFillingTest(unittest.TestCase):
 
         with simulate_console_inputs('True'), bear_test_module():
             local_bears, global_bears = fill_settings(sections,
+                                                      targets,
                                                       acquire_settings,
                                                       self.log_printer)
             self.assertEqual(len(local_bears['test']), 1)
@@ -110,8 +113,9 @@ class SectionFillingTest(unittest.TestCase):
 
     def test_dependency_resolving(self):
         sections = {'test': self.section}
+        targets = []
         self.section['bears'] = 'DependentBear'
         with simulate_console_inputs('True'), bear_test_module():
-            fill_settings(sections, acquire_settings, self.log_printer)
+            fill_settings(sections, targets, acquire_settings, self.log_printer)
 
         self.assertEqual(bool(self.section['use_spaces']), True)


### PR DESCRIPTION
If a section is disabled using `enabled=Flase` or something like
this `TODOS.enabled=False` in `.coafile` where TODOS is section name,
then that section will be disabled and won't ask for any additional
parameters.

Fixes https://github.com/coala/coala/issues/4849
  
  