### PR TITLE
Support unidiff 0.5.5

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,4 +10,4 @@ PyPrint~=0.2.6
 requests~=2.12
 setuptools>=19.0
 testfixtures~=4.14.3
-unidiff>=0.5.2,<=0.5.4
+unidiff~=0.5.2

--- a/tests/bearlib/abstractions/LinterTest.py
+++ b/tests/bearlib/abstractions/LinterTest.py
@@ -369,7 +369,7 @@ class LinterComponentTest(unittest.TestCase):
                 '@@ -1,3 +1,4 @@',
                 '-void main()  {',
                 '-return 09;',
-                '+void main()'
+                '+void main()',
                 '+{',
                 '+       return 9;',
                 ' }']

--- a/tests/results/DiffTest.py
+++ b/tests/results/DiffTest.py
@@ -289,7 +289,7 @@ class DiffTest(unittest.TestCase):
         target = ['A\n', 'Y\n', 'Z\n', 'C']
         diff = ['--- a/testfile',
                 '+++ b/testfile',
-                '@@ -1,3 +1,5 @@',
+                '@@ -1,3 +1,4 @@',
                 ' A',
                 '+Y',
                 '+Z',
@@ -304,7 +304,7 @@ class DiffTest(unittest.TestCase):
         target = ['Y\n', 'Z\n', 'C']
         diff = ['--- a/testfile',
                 '+++ b/testfile',
-                '@@ -1,3 +1,5 @@',
+                '@@ -1,3 +1,3 @@',
                 '-A',
                 '+Y',
                 '+Z',


### PR DESCRIPTION
A recent test breakage forced the requirements to limit the version
of the "unidiff" package below 0.5.5. It was identified on an upstream
issue that coala's tests tested against invalid unified-diffs (context
lines were wrong), but this wasn't accurately catched by "unidiff", it
just processed the actual diff content.

The current tests are now modified to have valid context lines.