### PR TITLE
docs-requirements: Fix CI break

### DIFF
--- a/docs-requirements.txt
+++ b/docs-requirements.txt
@@ -1,5 +1,5 @@
 # all requirements are needed so that autodoc can find them
 -r requirements.txt
 -r test-requirements.txt
-sphinx~=1.6.2
+sphinx>=1.6.2,<1.6.6
 sphinx-argparse~=0.2.1


### PR DESCRIPTION
Change the version of sphinx to less than 1.6.6
to fix the CI break.

Fixes https://github.com/coala/coala/issues/5058