### PR TITLE
ConfParser.py: Display correct error

### DIFF
--- a/coalib/parsing/ConfParser.py
+++ b/coalib/parsing/ConfParser.py
@@ -32,6 +32,23 @@ class ConfParser:
         self.__rand_helper = None
         self.__init_sections()
 
+    def check_valid_lines(self, lines):
+        """
+        This function checks for some invalid config file commands like
+        ``default_action: *: ShowPatchAction``
+        which show error in the previous line. This function gives the
+        correct error in such cases.
+        """
+        for line in lines:
+            occ = line.find(':')
+            line_substr = line[:occ]
+            occ_equals = line_substr.find('=')
+            occ_comment = line_substr.find('#')
+            if occ != -1 and not ((occ_equals != -1 and occ_equals < occ) or
+                                  (occ_comment != -1 and occ_comment < occ)):
+                logging.error('Invalid command "{}" in config file'.format
+                              (line.strip('\n')))
+
     def parse(self, input_data, overwrite=False):
         """
         Parses the input and adds the new data to the existing.
@@ -50,6 +67,8 @@ class ConfParser:
 
         with open(input_data, 'r', encoding='utf-8') as _file:
             lines = _file.readlines()
+
+        self.check_valid_lines(lines)
 
         if overwrite:
             self.__init_sections()

--- a/tests/parsing/ConfParserTest.py
+++ b/tests/parsing/ConfParserTest.py
@@ -191,3 +191,11 @@ class ConfParserTest(unittest.TestCase):
                                             'already been defined in section '
                                             'name. The previous setting will '
                                             'be overridden.')
+
+    def test_check_valid_lines(self):
+        logger = logging.getLogger()
+        with self.assertLogs(logger, 'ERROR') as self.cm:
+            self.uut.check_valid_lines(['default_action: *: ShowPatchAction'])
+        self.assertEqual(self.cm.output[0], 'ERROR:root:Invalid command '
+                                            '"default_action: *: ShowPatc'
+                                            'hAction" in config file')


### PR DESCRIPTION
Fixes https://github.com/coala/coala/issues/5044

### Basic idea behind my changes:
if I find a `:` before I find a `#` or a `=` I print out the error