### PR TITLE
Newcomers_Guide.rst: correct grammatical mistake

### DIFF
--- a/docs/Developers/Newcomers_Guide.rst
+++ b/docs/Developers/Newcomers_Guide.rst
@@ -397,7 +397,7 @@ Now there are two possibilities:
 - your ``Pull Request`` gets accepted, and your commits will get merged into
   the master branch
 - your ``Pull Request`` doesn't get accepted, and therefore you will
-  need to to modify it as per the review comments
+  need to modify it as per the review comments
 
 .. note::
 


### PR DESCRIPTION
This corrects the grammatical error and changes it from "to to" --> "to".

Closes https://github.com/coala/coala/issues/5087