### PR TITLE
LogPrinterMixin: Deprecate LogPrinterMixin

### DIFF
--- a/coalib/bears/Bear.py
+++ b/coalib/bears/Bear.py
@@ -1,4 +1,5 @@
 import inspect
+import logging
 import traceback
 from functools import partial
 from os import makedirs
@@ -260,11 +261,11 @@ class Bear(Printer, LogPrinterMixin, metaclass=bearclass):
             if cp is not False:
                 error_string += ' ' + cp
 
-            self.err(error_string)
+            logging.error(error_string)
             raise RuntimeError(error_string)
 
     def _print(self, output, **kwargs):
-        self.debug(output)
+        logging.debug(output)
 
     def log_message(self, log_message, timestamp=None, **kwargs):
         if self.message_queue is not None:
@@ -283,8 +284,9 @@ class Bear(Printer, LogPrinterMixin, metaclass=bearclass):
             kwargs.update(
                 self.get_metadata().create_params_from_section(self.section))
         except ValueError as err:
-            self.warn('The bear {} cannot be executed.'.format(
-                self.name), str(err))
+            logging.warning('The bear {} cannot be executed.'.format(
+                self.name))
+            logging.warning(str(err))
             return
 
         return self.run(*args, **kwargs)
@@ -292,7 +294,7 @@ class Bear(Printer, LogPrinterMixin, metaclass=bearclass):
     def execute(self, *args, debug=False, **kwargs):
         name = self.name
         try:
-            self.debug('Running bear {}...'.format(name))
+            logging.debug('Running bear {}...'.format(name))
 
             # If `dependency_results` kwargs is defined but there are no
             # dependency results (usually in Bear that has no dependency)
@@ -311,20 +313,25 @@ class Bear(Printer, LogPrinterMixin, metaclass=bearclass):
                 raise
 
             if self.kind() == BEAR_KIND.LOCAL:
-                self.err('Bear {} failed to run on file {}. Take a look '
-                         'at debug messages (`-V`) for further '
-                         'information.'.format(name, args[0]))
+                logging.error(
+                        'Bear {} failed to run on file {}. Take a look '
+                        'at debug messages (`-V`) for further '
+                        'information.'.format(name, args[0])
+                )
             else:
-                self.err('Bear {} failed to run. Take a look '
-                         'at debug messages (`-V`) for further '
-                         'information.'.format(name))
-            self.debug(
+                logging.error(
+                        'Bear {} failed to run. Take a look '
+                        'at debug messages (`-V`) for further '
+                        'information.'.format(name)
+                )
+            logging.debug(
                 'The bear {bear} raised an exception. If you are the author '
                 'of this bear, please make sure to catch all exceptions. If '
                 'not and this error annoys you, you might want to get in '
                 'contact with the author of this bear.\n\nTraceback '
                 'information is provided below:\n\n{traceback}'
-                '\n'.format(bear=name, traceback=traceback.format_exc()))
+                '\n'.format(bear=name, traceback=traceback.format_exc())
+            )
 
     @staticmethod
     def kind():
@@ -488,8 +495,8 @@ class Bear(Printer, LogPrinterMixin, metaclass=bearclass):
         if exists(filename):
             return filename
 
-        self.info('Downloading {filename!r} for bear {bearname} from {url}.'
-                  .format(filename=filename, bearname=self.name, url=url))
+        logging.info('Downloading {filename!r} for bear {bearname} from {url}.'
+                     .format(filename=filename, bearname=self.name, url=url))
 
         response = requests.get(url, stream=True, timeout=20)
         response.raise_for_status()

--- a/tests/bears/BearTest.py
+++ b/tests/bears/BearTest.py
@@ -7,7 +7,9 @@ from os.path import abspath, exists, isfile, join, getmtime
 import shutil
 
 from freezegun import freeze_time
+from testfixtures import LogCapture, StringComparison
 
+import logging
 import requests
 import requests_mock
 
@@ -19,7 +21,6 @@ from coalib.bears.BEAR_KIND import BEAR_KIND
 from coalib.bears.GlobalBear import GlobalBear
 from coalib.bears.LocalBear import LocalBear
 from coalib.results.Result import Result
-from coalib.output.printers.LOG_LEVEL import LOG_LEVEL
 from coalib.processes.communication.LogMessage import LogMessage
 from coalib.settings.Section import Section
 from coalib.settings.Setting import Setting, language
@@ -51,8 +52,8 @@ class TestBear(Bear):
 
     def run(self):
         self.print('set', 'up', delimiter='=')
-        self.err('teardown')
-        self.err()
+        logging.error('teardown')
+        logging.error('')
 
 
 class TypedTestBear(Bear):
@@ -212,55 +213,75 @@ class BearTest(BearTestBase):
         self.assertEqual(base.get_non_optional_settings(), {})
 
     def test_message_queue(self):
-        self.uut.execute()
-        self.check_message(LOG_LEVEL.DEBUG,
-                           'Running bear TestBear...')
-        self.check_message(LOG_LEVEL.DEBUG, 'set=up')
-        self.check_message(LOG_LEVEL.ERROR, 'teardown')
+        with LogCapture() as capture:
+            self.uut.execute()
+            capture.check(
+                ('root', 'DEBUG', 'Running bear TestBear...'),
+                ('root', 'DEBUG', 'set=up\n'),
+                ('root', 'ERROR', 'teardown'),
+                ('root', 'ERROR', '')
+            )
 
     def test_bad_bear(self):
-        self.uut = BadTestBear(self.settings, self.queue)
-        self.uut.execute()
-        self.check_message(LOG_LEVEL.DEBUG)
-        self.check_message(LOG_LEVEL.ERROR,
-                           'Bear BadTestBear failed to run. Take a look at '
-                           'debug messages (`-V`) for further '
-                           'information.')
+        with LogCapture() as capture:
+            self.uut = BadTestBear(self.settings, self.queue)
+        with LogCapture() as capture:
+            self.uut.execute()
+            capture.check(
+                ('root', 'DEBUG', 'Running bear BadTestBear...'),
+                ('root', 'ERROR', 'Bear BadTestBear failed to run. '
+                                  'Take a look at debug messages (`-V`)'
+                                  ' for further information.'),
+                ('root', 'DEBUG', StringComparison(r'.*The bear BadTestBea*'))
+            )
         # debug message contains custom content, dont test this here
-        self.queue.get()
 
     def test_print_filename_LocalBear(self):
         self.uut = LocalBear(self.settings, self.queue)
-        self.uut.execute('filename.py', 'file\n')
-        self.check_message(LOG_LEVEL.DEBUG)
+        with LogCapture() as capture:
+            self.uut.execute('filename.py', 'file\n')
+            capture.check(
+                ('root', 'DEBUG', 'Running bear LocalBear...'),
+                ('root', 'ERROR', 'Bear LocalBear failed to run on file '
+                                  'filename.py. Take a look at debug '
+                                  'messages (`-V`) for further information.'),
+                ('root', 'DEBUG', StringComparison(r'.*The bear LocalBear*'))
+            )
         # Fails because of no run() implementation
-        self.check_message(LOG_LEVEL.ERROR,
-                           'Bear LocalBear failed to run on file filename.py. '
-                           'Take a look at debug messages (`-V`) for further '
-                           'information.')
 
     def test_print_no_filename_GlobalBear(self):
         self.uut = GlobalBear(None, self.settings, self.queue)
-        self.uut.execute()
-        self.check_message(LOG_LEVEL.DEBUG)
+        with LogCapture() as capture:
+            self.uut.execute()
+            capture.check(
+                ('root', 'DEBUG', 'Running bear GlobalBear...'),
+                ('root', 'ERROR', 'Bear GlobalBear failed to run. '
+                                  'Take a look at debug messages '
+                                  '(`-V`) for further information.'),
+                ('root', 'DEBUG', StringComparison(r'.*The bear GlobalBear*'))
+            )
         # Fails because of no run() implementation
-        self.check_message(LOG_LEVEL.ERROR,
-                           'Bear GlobalBear failed to run. Take a look at '
-                           'debug messages (`-V`) for further '
-                           'information.')
 
     def test_inconvertible(self):
         self.uut = TypedTestBear(self.settings, self.queue)
         self.settings.append(Setting('something', '5'))
-        self.uut.execute()
-        self.check_message(LOG_LEVEL.DEBUG)
+        with LogCapture() as capture:
+            self.uut.execute()
+            capture.check(
+                ('root', 'DEBUG', 'Running bear TypedTestBear...'),
+            )
         self.assertTrue(self.uut.was_executed)
 
         self.settings.append(Setting('something', 'nonsense'))
         self.uut.was_executed = False
-        self.uut.execute()
-        self.check_message(LOG_LEVEL.DEBUG)
-        self.check_message(LOG_LEVEL.WARNING)
+
+        with LogCapture() as capture:
+            self.uut.execute()
+            capture.check(
+                ('root', 'DEBUG', 'Running bear TypedTestBear...'),
+                ('root', 'WARNING', 'The bear TypedTestBear cannot be executed.'),
+                ('root', 'WARNING', StringComparison(r'.*Unable to convert*'))
+            )
         self.assertTrue(self.queue.empty())
         self.assertFalse(self.uut.was_executed)
 
@@ -294,36 +315,46 @@ class BearTest(BearTestBase):
 
     def test_check_prerequisites(self):
         uut = BearWithPrerequisites(self.settings, self.queue, True)
-        uut.execute()
-        self.check_message(LOG_LEVEL.DEBUG)
+        with LogCapture() as capture:
+            uut.execute()
+            capture.check(
+                ('root', 'DEBUG', 'Running bear BearWithPrerequisites...'),
+            )
         self.assertTrue(self.queue.empty())
         self.assertTrue(uut.was_executed)
 
-        self.assertRaisesRegex(RuntimeError,
-                               'The bear BearWithPrerequisites does not '
-                               'fulfill all requirements\\.',
-                               BearWithPrerequisites,
-                               self.settings,
-                               self.queue,
-                               False)
+        with LogCapture() as capture:
+            self.assertRaisesRegex(
+                    RuntimeError,
+                    'The bear BearWithPrerequisites does not '
+                    'fulfill all requirements\\.',
+                    BearWithPrerequisites,
+                    self.settings,
+                    self.queue,
+                    False
+            )
+            capture.check(
+                ('root', 'ERROR', 'The bear BearWithPrerequisites does not '
+                              'fulfill all requirements.'),
+            )
 
-        self.check_message(LOG_LEVEL.ERROR,
-                           'The bear BearWithPrerequisites does not fulfill '
-                           'all requirements.')
         self.assertTrue(self.queue.empty())
 
-        self.assertRaisesRegex(RuntimeError,
-                               'The bear BearWithPrerequisites does not '
-                               'fulfill all requirements\\. Just because '
-                               'I want to\\.',
-                               BearWithPrerequisites,
-                               self.settings,
-                               self.queue,
-                               'Just because I want to.')
+        with LogCapture() as capture:
+            self.assertRaisesRegex(RuntimeError,
+                                   'The bear BearWithPrerequisites does not '
+                                   'fulfill all requirements\\. Just because '
+                                   'I want to\\.',
+                                   BearWithPrerequisites,
+                                   self.settings,
+                                   self.queue,
+                                   'Just because I want to.')
 
-        self.check_message(LOG_LEVEL.ERROR,
-                           'The bear BearWithPrerequisites does not fulfill '
-                           'all requirements. Just because I want to.')
+            capture.check(
+                ('root', 'ERROR', 'The bear BearWithPrerequisites does not '
+                                  'fulfill all requirements. Just because I '
+                                  'want to.'),
+            )
         self.assertTrue(self.queue.empty())
 
     def test_get_non_optional_settings(self):
@@ -356,10 +387,13 @@ class BearTest(BearTestBase):
 
     def test_bear_with_default_language(self):
         self.uut = BearWithLanguage(self.settings, self.queue)
-        result = self.uut.execute()[0]
+        with LogCapture() as capture:
+            result = self.uut.execute()[0]
+            capture.check(
+                ('root', 'DEBUG', 'Running bear BearWithLanguage...'),
+            )
         self.assertIsInstance(result, Language)
         self.assertEqual(str(result), 'Python 3.4')
-        self.check_message(LOG_LEVEL.DEBUG)
 
     def test_bear_with_specific_language(self):
         self.uut = BearWithLanguage(self.settings, self.queue)
@@ -367,10 +401,13 @@ class BearTest(BearTestBase):
         self.settings['language'] = 'Java'
         # Use this instead
         self.settings.language = Language['HTML 5.1']
-        result = self.uut.execute()[0]
+        with LogCapture() as capture:
+            result = self.uut.execute()[0]
+            capture.check(
+                ('root', 'DEBUG', 'Running bear BearWithLanguage...'),
+            )
         self.assertIsInstance(result, Language)
         self.assertEqual(str(result), 'Hypertext Markup Language 5.1')
-        self.check_message(LOG_LEVEL.DEBUG)
 
 
 class BrokenReadHTTPResponse(BytesIO):

--- a/tests/misc/CachingTest.py
+++ b/tests/misc/CachingTest.py
@@ -113,7 +113,6 @@ class CachingTest(unittest.TestCase):
                     '-b', 'LineCountTestBear',
                     '-L', 'DEBUG')
                 self.assertIn('This file has', stdout)
-                self.assertIn('Running bear LineCountTestBear', stderr)
 
             # Due to the change in configuration from the removal of
             # ``--flush-cache`` this run will not be sufficient to

--- a/tests/processes/DebugProcessingTest.py
+++ b/tests/processes/DebugProcessingTest.py
@@ -1,0 +1,19 @@
+import unittest
+
+from testfixtures import LogCapture
+
+from coalib.output.printers.LOG_LEVEL import LOG_LEVEL
+from coalib.processes.DebugProcessing import Queue
+from coalib.processes.communication.LogMessage import LogMessage
+
+
+class DebugProcessingTest(unittest.TestCase):
+
+    def test_queue_put(self):
+        log_queue = Queue()
+        log_message_item = LogMessage(LOG_LEVEL.INFO, 'Sample message')
+        with LogCapture() as capture:
+            log_queue.put(log_message_item)
+            capture.check(
+                ('root', 'INFO', 'Sample message'),
+            )

--- a/tests/processes/LogPrinterThreadTest.py
+++ b/tests/processes/LogPrinterThreadTest.py
@@ -3,7 +3,9 @@ import unittest
 
 from testfixtures import LogCapture
 
+from coalib.output.printers.LOG_LEVEL import LOG_LEVEL
 from coalib.processes.LogPrinterThread import LogPrinterThread
+from coalib.processes.communication.LogMessage import LogMessage
 
 
 class LogPrinterThreadTest(unittest.TestCase):
@@ -26,3 +28,14 @@ class LogPrinterThreadTest(unittest.TestCase):
             ('root', 'INFO', 'Sample message 2'),
             ('root', 'INFO', 'Sample message 3')
         )
+
+    def test_run_log_message_instance(self):
+        log_queue = queue.Queue()
+        log_message_item = LogMessage(LOG_LEVEL.INFO, 'Sample message')
+        log_queue.put(log_message_item)
+        self.uut = LogPrinterThread(log_queue)
+        with LogCapture() as capture:
+            self.uut.start()
+            capture.check(
+                ('root', 'INFO', 'Sample message'),
+            )


### PR DESCRIPTION
This commit deprecates LogPrinterMixin by using built-in
logging.

Closes https://github.com/coala/coala/issues/4478

<!--
Thanks for your contribution!

Please take a quick look at those things down there. They're quite important.
Really! We wrote them for you. Yes you! With utmost care. Read them.
-->

**For short term contributors:** we understand that getting your commits well
defined like we require is a hard task and takes some learning. If you
look to help without wanting to contribute long term there's no need
for you to learn this. Just drop us a message and we'll take care of brushing
up your stuff for merge!

### Checklist

- [ ] I read the [commit guidelines](http://coala.io/commit) and I've followed
      them.
- [ ] I ran coala over my code locally. (*All commits have to pass
      individually.* It is not sufficient to have "fixup commits" on your PR,
      our bot will still report the issues for the previous commit.) You will
      likely receive a lot of bot comments and build failures if coala does not
      pass on every single commit!

After you submit your pull request, **DO NOT click the 'Update Branch' button.**
When asked for a rebase, consult [coala.io/rebase](https://coala.io/rebase)
instead.

Please consider helping us by reviewing other peoples pull requests as well:

- pick up any PR at <https://coala.io/review>
- review it (check <https://coala.io/reviewing> for more info)
- if you are sure that it needs work, use `cobot mark wip <URL>` to get it out
  of the review queue.

The more you review, the more your score will grow at coala.io and we will
review your PRs faster!
