### PR TITLE
Collectors.py: Use bear names without suffix

### DIFF
--- a/coalib/collecting/Collectors.py
+++ b/coalib/collecting/Collectors.py
@@ -177,6 +177,23 @@ def collect_bears(bear_dirs, bear_globs, kinds, log_printer=None,
         bears_found[index].append(bear)
         bear_globs_with_bears.add(glob)
 
+    unused_globs = set(bear_globs) - set(bear_globs_with_bears)
+    suffix_globs = {}
+
+    for glob in unused_globs:
+        if glob is not '**' and glob is not '*':
+            if glob.endswith('bear'):  # pragma nt: no cover
+                new_glob = glob[:-4] + 'B' + glob[-3:]
+                suffix_globs[new_glob] = glob
+            elif not glob.endswith('Bear'):
+                suffix_globs[glob + 'Bear'] = glob
+
+    for bear, glob in icollect_bears(bear_dirs,
+                                     set(suffix_globs.keys()), kinds):
+        index = kinds.index(_get_kind(bear))
+        bears_found[index].append(bear)
+        bear_globs_with_bears.add(suffix_globs[glob])
+
     if warn_if_unused_glob:
         _warn_if_unused_glob(bear_globs, bear_globs_with_bears,
                              'No bears matching \'{}\' were found. Make sure '

--- a/tests/collecting/CollectorsTest.py
+++ b/tests/collecting/CollectorsTest.py
@@ -271,6 +271,16 @@ class CollectBearsTest(unittest.TestCase):
             ['other_kind'],
             self.log_printer)[0]), 0)
 
+    def test_bear_suffix(self):
+        self.assertEqual(
+            len(collect_bears(os.path.join(self.collectors_test_dir, 'bears'),
+                              ['namebear'], ['kind'],
+                              self.log_printer)[0]), 1)
+        self.assertEqual(
+            len(collect_bears(os.path.join(self.collectors_test_dir, 'bears'),
+                              ['name'], ['kind'],
+                              self.log_printer)[0]), 1)
+
     def test_all_bears_from_sections(self):
         test_section = Section('test_section')
         test_section.bear_dirs = lambda: os.path.join(self.collectors_test_dir,

--- a/tests/collecting/collectors_test_dir/bears/nameBear.py
+++ b/tests/collecting/collectors_test_dir/bears/nameBear.py
@@ -1,0 +1,3 @@
+from bear1 import TestBear as ImportedTestBear
+
+__additional_bears__ = [ImportedTestBear]


### PR DESCRIPTION
Allow bear names to be used without the "Bear"
suffix at the end.

Closes https://github.com/coala/coala/issues/2290