### PR TITLE
remove redundant setuptools version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,6 +8,6 @@ packaging~=16.8
 Pygments~=2.1
 PyPrint~=0.2.6
 requests~=2.12
-setuptools>=21.0.0
+setuptools>=21
 testfixtures~=5.3.1
 unidiff~=0.5.2


### PR DESCRIPTION
requirements.txt: redundant setuptools version amended. 

An unnecessary version number for the setuptools package 
has been shortened.

Fixes https://github.com/coala/coala/issues/5176