### PR TITLE
Writing_Linter_Bears.rst: Improve quotes style

### DIFF
--- a/docs/Developers/Writing_Linter_Bears.rst
+++ b/docs/Developers/Writing_Linter_Bears.rst
@@ -412,7 +412,7 @@ gather information by using these values. Our bear now looks like:
       https://pylint.org/
       """
 
-      LANGUAGES = {"Python", "Python 2", "Python 3"}
+      LANGUAGES = {'Python', 'Python 2', 'Python 3'}
       REQUIREMENTS = {PipRequirement('pylint', '1.*')}
       AUTHORS = {'The coala developers'}
       AUTHORS_EMAILS = {'coala-devel@googlegroups.com'}


### PR DESCRIPTION
In line: LANGUAGES = {"Python", "Python 2", "Python 3"} with change " --> '.

Fixes https://github.com/coala/coala/issues/3832


