### PR TITLE
Linter_Bears_Advanced.rst: Fix typo

### DIFF
--- a/docs/Developers/Linter_Bears_Advanced.rst
+++ b/docs/Developers/Linter_Bears_Advanced.rst
@@ -17,7 +17,7 @@ easily by overriding ``generate_config()``.
         @staticmethod
         def generate_config(filename, file):
             config_file = ("value1 = 1\n"
-                           "value=2 = 2")
+                           "value2 = 2")
             return config_file
 
 The string returned by this method is written into a temporary file before


### PR DESCRIPTION
This changes value=2 -> value2.

Closes https://github.com/coala/coala/issues/5165
