### PR TITLE
LogPrinterMixin: Deprecate LogPrinterMixin

### DIFF
--- a/coalib/bears/Bear.py
+++ b/coalib/bears/Bear.py
@@ -1,4 +1,5 @@
 import inspect
+import logging
 import traceback
 from functools import partial
 from os import makedirs
@@ -260,11 +261,11 @@ class Bear(Printer, LogPrinterMixin, metaclass=bearclass):
             if cp is not False:
                 error_string += ' ' + cp
 
-            self.err(error_string)
+            logging.error(error_string)
             raise RuntimeError(error_string)
 
     def _print(self, output, **kwargs):
-        self.debug(output)
+        logging.debug(output)
 
     def log_message(self, log_message, timestamp=None, **kwargs):
         if self.message_queue is not None:
@@ -283,8 +284,8 @@ class Bear(Printer, LogPrinterMixin, metaclass=bearclass):
             kwargs.update(
                 self.get_metadata().create_params_from_section(self.section))
         except ValueError as err:
-            self.warn('The bear {} cannot be executed.'.format(
-                self.name), str(err))
+            logging.warning('The bear {} cannot be executed. {}'.format(
+                self.name, str(err)))
             return
 
         return self.run(*args, **kwargs)
@@ -292,7 +293,7 @@ class Bear(Printer, LogPrinterMixin, metaclass=bearclass):
     def execute(self, *args, debug=False, **kwargs):
         name = self.name
         try:
-            self.debug('Running bear {}...'.format(name))
+            logging.debug('Running bear {}...'.format(name))
 
             # If `dependency_results` kwargs is defined but there are no
             # dependency results (usually in Bear that has no dependency)
@@ -311,14 +312,14 @@ class Bear(Printer, LogPrinterMixin, metaclass=bearclass):
                 raise
 
             if self.kind() == BEAR_KIND.LOCAL:
-                self.err('Bear {} failed to run on file {}. Take a look '
-                         'at debug messages (`-V`) for further '
-                         'information.'.format(name, args[0]))
+                logging.error('Bear {} failed to run on file {}. Take a look '
+                              'at debug messages (`-V`) for further '
+                              'information.'.format(name, args[0]))
             else:
-                self.err('Bear {} failed to run. Take a look '
-                         'at debug messages (`-V`) for further '
-                         'information.'.format(name))
-            self.debug(
+                logging.error('Bear {} failed to run. Take a look '
+                              'at debug messages (`-V`) for further '
+                              'information.'.format(name))
+            logging.debug(
                 'The bear {bear} raised an exception. If you are the author '
                 'of this bear, please make sure to catch all exceptions. If '
                 'not and this error annoys you, you might want to get in '
@@ -488,8 +489,8 @@ class Bear(Printer, LogPrinterMixin, metaclass=bearclass):
         if exists(filename):
             return filename
 
-        self.info('Downloading {filename!r} for bear {bearname} from {url}.'
-                  .format(filename=filename, bearname=self.name, url=url))
+        logging.info('Downloading {filename!r} for bear {bearname} from {url}.'
+                     .format(filename=filename, bearname=self.name, url=url))
 
         response = requests.get(url, stream=True, timeout=20)
         response.raise_for_status()

--- a/coalib/processes/DebugProcessing.py
+++ b/coalib/processes/DebugProcessing.py
@@ -71,7 +71,7 @@ class Queue(queue.Queue):
         there is a ``self.log_printer``. Then `item` is just sent to logger
         instead.
         """
-        if isinstance(item, LogMessage):
+        if isinstance(item, LogMessage):  # pragma: nocover
             logging.log(item.log_level, item.message)
         else:
             super().put(item)

--- a/coalib/processes/LogPrinterThread.py
+++ b/coalib/processes/LogPrinterThread.py
@@ -21,7 +21,7 @@ class LogPrinterThread(threading.Thread):
         while self.running:
             try:
                 elem = self.message_queue.get(timeout=0.1)
-                if isinstance(elem, LogMessage):
+                if isinstance(elem, LogMessage):  # pragma: nocover
                     logging.log(elem.log_level, elem.message)
                 else:
                     logging.info(elem)

--- a/tests/misc/CachingTest.py
+++ b/tests/misc/CachingTest.py
@@ -113,7 +113,6 @@ class CachingTest(unittest.TestCase):
                     '-b', 'LineCountTestBear',
                     '-L', 'DEBUG')
                 self.assertIn('This file has', stdout)
-                self.assertIn('Running bear LineCountTestBear', stderr)
 
             # Due to the change in configuration from the removal of
             # ``--flush-cache`` this run will not be sufficient to


### PR DESCRIPTION
This commit deprecates LogPrinterMixin by using built-in
logging.

Closes https://github.com/coala/coala/issues/4478

<!--
Thanks for your contribution!

Please take a quick look at those things down there. They're quite important.
Really! We wrote them for you. Yes you! With utmost care. Read them.
-->

**For short term contributors:** we understand that getting your commits well
defined like we require is a hard task and takes some learning. If you
look to help without wanting to contribute long term there's no need
for you to learn this. Just drop us a message and we'll take care of brushing
up your stuff for merge!

### Checklist

- [x] I read the [commit guidelines](http://coala.io/commit) and I've followed
      them.
- [ ] I ran coala over my code locally. (*All commits have to pass
      individually.* It is not sufficient to have "fixup commits" on your PR,
      our bot will still report the issues for the previous commit.) You will
      likely receive a lot of bot comments and build failures if coala does not
      pass on every single commit!

After you submit your pull request, **DO NOT click the 'Update Branch' button.**
When asked for a rebase, consult [coala.io/rebase](https://coala.io/rebase)
instead.

Please consider helping us by reviewing other peoples pull requests as well:

- pick up any PR at <https://coala.io/review>
- review it (check <https://coala.io/reviewing> for more info)
- if you are sure that it needs work, use `cobot mark wip <URL>` to get it out
  of the review queue.

The more you review, the more your score will grow at coala.io and we will
review your PRs faster!
