### PR TITLE
Globbing.py: Return false if globs are absent

### DIFF
--- a/coalib/parsing/Globbing.py
+++ b/coalib/parsing/Globbing.py
@@ -217,7 +217,7 @@ def fnmatch(name, globs):
     globs = (globs,) if isinstance(globs, str) else tuple(globs)
 
     if len(globs) == 0:
-        return True
+        return False
 
     name = os.path.normcase(name)
 

--- a/tests/parsing/GlobbingTest.py
+++ b/tests/parsing/GlobbingTest.py
@@ -211,10 +211,8 @@ class FnmatchTest(unittest.TestCase):
         non_matches = ['aXbX', 'aXcX']
         self._test_fnmatch(pattern, matches, non_matches)
 
-        pattern = []
-        matches = ['anything', 'anything_else']
-        non_matches = []
-        self._test_fnmatch(pattern, matches, non_matches)
+    def test_empty_globs(self):
+        self.assertFalse(fnmatch('something', []))
 
 
 class GlobTest(unittest.TestCase):


### PR DESCRIPTION
Removes the `if` statement from `fnmatch()` that
used to return `True` if no globs were given

Fixes: https://github.com/coala/coala/issues/2302

<!--
Thanks for your contribution!

Please take a quick look at those things down there. They're quite important.
Really! We wrote them for you. Yes you! With utmost care. Read them.
-->

**For short term contributors:** we understand that getting your commits well
defined like we require is a hard task and takes some learning. If you
look to help without wanting to contribute long term there's no need
for you to learn this. Just drop us a message and we'll take care of brushing
up your stuff for merge!

### Checklist

- [ ] I read the [commit guidelines](http://coala.io/commit) and I've followed
      them.
- [ ] I ran coala over my code locally. (*All commits have to pass
      individually.* It is not sufficient to have "fixup commits" on your PR,
      our bot will still report the issues for the previous commit.) You will
      likely receive a lot of bot comments and build failures if coala does not
      pass on every single commit!

After you submit your pull request, **DO NOT click the 'Update Branch' button.**
When asked for a rebase, consult [coala.io/rebase](https://coala.io/rebase)
instead.

Please consider helping us by reviewing other peoples pull requests as well:

- pick up any PR at <https://coala.io/review>
- review it (check <https://coala.io/reviewing> for more info)
- if you are sure that it needs work, use `cobot mark wip <URL>` to get it out
  of the review queue.

The more you review, the more your score will grow at coala.io and we will
review your PRs faster!
