### PR TITLE
.travis.yml: Skip unsupported except on master

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,16 +5,18 @@ python:
   - 3.5
   - 3.6
 
-matrix:
+jobs:
   include:
     # OSX build removed due to long build startup delays
     # Restore matrix job entry from d2d67fab to test OSX
     - python: 2.7
       env: UNSUPPORTED=true
       script: .misc/check_unsupported.sh
+      if: branch = master
     - python: 3.3
       env: UNSUPPORTED=true
       script: .misc/check_unsupported.sh
+      if: branch = master
 
 env:
   global:


### PR DESCRIPTION
The jobs for unsupported platforms 2.7 & 3.3 do not need to run
so frequently, and any breakages are usually related to upstream
dropping support for 2.7 or 3.3, rather than a local problem.
The master builds will break, and usually we'll need to pin
something to get around the problem.  Ultimately, failure to
verify that these old versions fail in a predictable manner
should not prevent us adding new features or dependencies.

Closes https://github.com/coala/coala/issues/4323

<!--
Thanks for your contribution!

Please take a quick look at those things down there. They're quite important.
Really! We wrote them for you. Yes you! With utmost care. Read them.
-->

**For short term contributors:** we understand that getting your commits well
defined like we require is a hard task and takes some learning. If you
look to help without wanting to contribute long term there's no need
for you to learn this. Just drop us a message and we'll take care of brushing
up your stuff for merge!

### Checklist

- [ ] I read the [commit guidelines](http://coala.io/commit) and I've followed
      them.
- [ ] I ran coala over my code locally. (*All commits have to pass
      individually.* It is not sufficient to have "fixup commits" on your PR,
      our bot will still report the issues for the previous commit.) You will
      likely receive a lot of bot comments and build failures if coala does not
      pass on every single commit!

After you submit your pull request, **DO NOT click the 'Update Branch' button.**
When asked for a rebase, consult [coala.io/rebase](https://coala.io/rebase)
instead.

Please consider helping us by reviewing other peoples pull requests as well:

- pick up any PR at <https://coala.io/review>
- review it (check <https://coala.io/reviewing> for more info)
- if you are sure that it needs work, use `cobot mark wip <URL>` to get it out
  of the review queue.

The more you review, the more your score will grow at coala.io and we will
review your PRs faster!
