### PR TITLE
Core.py: Removes section from docstring

### DIFF
--- a/coalib/core/Core.py
+++ b/coalib/core/Core.py
@@ -184,9 +184,9 @@ class Session:
             be used.
 
             The cache stores the results that were returned last time from the
-            parameters passed to ``execute_task`` in bears. If the section and
-            parameters to ``execute_task`` are the same from a previous run,
-            the cache will be queried instead of executing ``execute_task``.
+            parameters passed to ``execute_task`` in bears. If the parameters
+            to ``execute_task`` are the same from a previous run, the cache
+            will be queried instead of executing ``execute_task``.
 
             The cache has to be a dictionary-like object, that maps bear types
             to respective cache-tables. The cache-tables itself are
@@ -430,9 +430,9 @@ def run(bears, result_callback, cache=None, executor=None):
         used.
 
         The cache stores the results that were returned last time from the
-        parameters passed to ``execute_task`` in bears. If the section and
-        parameters to ``execute_task`` are the same from a previous run,
-        the cache will be queried instead of executing ``execute_task``.
+        parameters passed to ``execute_task`` in bears. If the parameters
+        to ``execute_task`` are the same from a previous run, the cache
+        will be queried instead of executing ``execute_task``.
 
         The cache has to be a dictionary-like object, that maps bear types
         to respective cache-tables. The cache-tables itself are dictionary-like


### PR DESCRIPTION
The cache look-up only looks for the parameters
of ``execute_task`` and not the section to get
the cached result of a bear.

Fixes https://github.com/coala/coala/issues/5270

<!--
Thanks for your contribution!

Please take a quick look at those things down there. They're quite important.
Really! We wrote them for you. Yes you! With utmost care. Read them.
-->

**For short term contributors:** we understand that getting your commits well
defined like we require is a hard task and takes some learning. If you
look to help without wanting to contribute long term there's no need
for you to learn this. Just drop us a message and we'll take care of brushing
up your stuff for merge!

### Checklist

- [ ] I read the [commit guidelines](http://coala.io/commit) and I've followed
      them.
- [ ] I ran coala over my code locally. (*All commits have to pass
      individually.* It is not sufficient to have "fixup commits" on your PR,
      our bot will still report the issues for the previous commit.) You will
      likely receive a lot of bot comments and build failures if coala does not
      pass on every single commit!

After you submit your pull request, **DO NOT click the 'Update Branch' button.**
When asked for a rebase, consult [coala.io/rebase](https://coala.io/rebase)
instead.

Please consider helping us by reviewing other peoples pull requests as well:

- pick up any PR at <https://coala.io/review>
- review it (check <https://coala.io/reviewing> for more info)
- if you are sure that it needs work, use `cobot mark wip <URL>` to get it out
  of the review queue.

The more you review, the more your score will grow at coala.io and we will
review your PRs faster!
