### PR TITLE
Related clang stuff removed

### DIFF
--- a/tests/misc/ExceptionsTest.py
+++ b/tests/misc/ExceptionsTest.py
@@ -11,6 +11,6 @@ class ExceptionsTest(unittest.TestCase):
         self.assertEqual(get_exitcode(AssertionError()), 255)
         self.assertEqual(get_exitcode(SystemExit(999)), 999)
         self.assertEqual(get_exitcode(VersionConflict(
-            'libclang-py3 0.3', 'libclang-py3==0.2')), 13)
+            'version 1.0', 'version 2.0')), 13)
         self.assertEqual(get_exitcode(EOFError()), 0)
         self.assertEqual(get_exitcode(None), 0)

--- a/tests/output/ConsoleInteractionTest.py
+++ b/tests/output/ConsoleInteractionTest.py
@@ -755,7 +755,7 @@ file
             print_results(
                 self.log_printer,
                 Section(''),
-                [Result('ClangCloneDetectionBear',
+                [Result('Bear_for_detecting_clone',
                         'Clone Found',
                         affected_code)],
                 {abspath('some_file'): ['line ' + str(i + 1) + '\n'
@@ -775,7 +775,7 @@ some_file
 [   5] li{0}{3}
 [   6] li{0}{4}
 [   7] li{0}{5}
-**** ClangCloneDetectionBear [Section:  | Severity: NORMAL] ****
+**** Bear_for_detecting_clone [Section:  | Severity: NORMAL] ****
 !    ! {6}\n""".format(highlight_text(self.no_color, 'ne',
                                       BackgroundSourceRangeStyle, self.lexer),
                        highlight_text(self.no_color, ' 1', NoColorStyle,


### PR DESCRIPTION
This removes the clang related code from ExceptionsTest.py and
ConsoleInteractionTest.py. clanglib-py3 is changed to version_1 and
version_2 and ClangCloneDetectionBear is changed to CloneDetectionBear.

Closes https://github.com/coala/coala/issues/5250

<!--
Thanks for your contribution!

Please take a quick look at those things down there. They're quite important.
Really! We wrote them for you. Yes you! With utmost care. Read them.
-->

**For short term contributors:** we understand that getting your commits well
defined like we require is a hard task and takes some learning. If you
look to help without wanting to contribute long term there's no need
for you to learn this. Just drop us a message and we'll take care of brushing
up your stuff for merge!

### Checklist

- [x] I read the [commit guidelines](http://coala.io/commit) and I've followed
      them.
- [x] I ran coala over my code locally. (*All commits have to pass
      individually.* It is not sufficient to have "fixup commits" on your PR,
      our bot will still report the issues for the previous commit.) You will
      likely receive a lot of bot comments and build failures if coala does not
      pass on every single commit!

After you submit your pull request, **DO NOT click the 'Update Branch' button.**
When asked for a rebase, consult [coala.io/rebase](https://coala.io/rebase)
instead.

Please consider helping us by reviewing other peoples pull requests as well:

- pick up any PR at <https://coala.io/review>
- review it (check <https://coala.io/reviewing> for more info)
- if you are sure that it needs work, use `cobot mark wip <URL>` to get it out
  of the review queue.

The more you review, the more your score will grow at coala.io and we will
review your PRs faster!
