### PR TITLE
Language.py: Fix __contains__ method

### DIFF
--- a/coalib/bearlib/languages/Language.py
+++ b/coalib/bearlib/languages/Language.py
@@ -422,8 +422,11 @@ class Language(metaclass=LanguageMeta):
 
     def __contains__(self, item):
         item = Language[item]
+        item_versions = set(item.versions)
+        versions = set(self.versions)
         return (type(self) is type(item)
-                and set(item.versions).issubset(set(self.versions)))
+                and (item_versions.issubset(versions)
+                     or item_versions.issuperset(versions)))
 
     def __reduce__(self):
         return (Language.__getitem__, (str(self),))

--- a/tests/bearlib/languages/LanguageTest.py
+++ b/tests/bearlib/languages/LanguageTest.py
@@ -17,6 +17,18 @@ class LanguageTest(unittest.TestCase):
         cpp_unpickled = pickle.loads(cpp_str)
         self.assertEqual(str(cpp), str(cpp_unpickled))
 
+    def test_contains_method(self):
+        # Test alias
+        self.assertTrue('py' in Language[Language.Python])
+        # Test version
+        self.assertTrue('python' in Language[Language.Python == 3])
+        # Test string parse
+        self.assertTrue('python' in Language['python 3'])
+        # Test version exclusion
+        self.assertFalse('py 2' in Language['py 3'])
+        # More complex version exclusion test
+        self.assertFalse('py 2.7, 3.4' in Language['py 3'])
+
 
 class LanguageAttributeErrorTest(unittest.TestCase):
 


### PR DESCRIPTION
The __contains__ method in the Language class only checks
if self.versions is a superset of item.versions. This change
adds a subset check so if self.versions is a subset
of item.versions, __contains__ will return True.

Closes https://github.com/coala/coala/issues/4690