### PR TITLE
FilterHelperTest.py: Add `FilterHelperTest` class

### DIFF
--- a/tests/parsing/FilterHelperTest.py
+++ b/tests/parsing/FilterHelperTest.py
@@ -1,0 +1,46 @@
+import unittest
+
+from coalib.parsing.FilterHelper import (
+    apply_filter,
+    apply_filters,
+    is_valid_filter,
+    _filter_section_bears
+)
+from coalib.parsing.filters import available_filters
+from coalib.parsing.InvalidFilterException import InvalidFilterException
+from coalib.settings.ConfigurationGathering import get_all_bears
+
+
+class FilterHelperTest(unittest.TestCase):
+
+    def test_apply_filter_exception(self):
+        with self.assertRaises(InvalidFilterException) as exp:
+            apply_filter('unknown', ['args'])
+
+        message = str(exp.exception)
+        self.assertEqual("'unknown' is an invalid filter. Available filters: "
+                         + ', '.join(sorted(available_filters)), message)
+
+    def test_is_valid_filter_true(self):
+        filter_result = is_valid_filter('can_detect')
+        self.assertTrue(filter_result)
+
+    def test_is_valid_filter_false(self):
+        filter_result = is_valid_filter('wrong_filter')
+        self.assertFalse(filter_result)
+
+    def test_filter_section_bears(self):
+        local_bears = get_all_bears()[0]
+        filter_args = {'c', 'java'}
+        result_for_filter_section = _filter_section_bears(
+            local_bears, filter_args, 'language')
+        self.assertIsNotNone(result_for_filter_section)
+
+    def test_apply_filter(self):
+        apply_filter_result = apply_filter('language', ['c', 'java'])
+        self.assertIsNotNone(apply_filter_result)
+
+    def test_apply_filters(self):
+        apply_filters_result = apply_filters([('language', 'C', 'Python'),
+                                              ('can_fix', 'syntax')])
+        self.assertIsNotNone(apply_filters_result)


### PR DESCRIPTION
This adds an additional `FilterHelperTest` class and
tests `InvalidFilterException` by raising the exception
using `FilterHelper`.

Closes https://github.com/coala/coala/issues/4864

### Checklist

- [x] I read the [commit guidelines](http://coala.io/commit) and I've followed
      them.
- [x] I ran coala over my code locally. (*All commits have to pass
      individually.* It is not sufficient to have "fixup commits" on your PR,
      our bot will still report the issues for the previous commit.) You will
      likely receive a lot of bot comments and build failures if coala does not
      pass on every single commit!

After you submit your pull request, **DO NOT click the 'Update Branch' button.**
When asked for a rebase, consult [coala.io/rebase](https://coala.io/rebase)
instead.

Please consider helping us by reviewing other peoples pull requests as well:

- pick up any PR at <https://coala.io/review>
- review it (check <https://coala.io/reviewing> for more info)
- if you are sure that it needs work, use `cobot mark wip <URL>` to get it out
  of the review queue.

The more you review, the more your score will grow at coala.io and we will
review your PRs faster!
