### PR TITLE
Linter.py: Support colorised output from linters

### DIFF
--- a/.moban.yaml
+++ b/.moban.yaml
@@ -22,6 +22,7 @@ entry_points:
 
 dependencies:
   - appdirs~=1.4
+  - cli_helpers~=1.0.2
   - coala_utils~=0.7.0
   - colorlog>=2.7,<4.0
   - dependency_management~=0.4.0

--- a/coalib/bearlib/abstractions/Linter.py
+++ b/coalib/bearlib/abstractions/Linter.py
@@ -8,6 +8,7 @@ import shutil
 from subprocess import check_call, CalledProcessError, DEVNULL
 from types import MappingProxyType
 
+from cli_helpers.utils import strip_ansi
 from coalib.bearlib.abstractions.LinterClass import LinterClass
 from coalib.bears.LocalBear import LocalBear
 from coalib.bears.GlobalBear import GlobalBear
@@ -38,7 +39,8 @@ def _prepare_options(options, bear_class):
                        'config_suffix',
                        'executable_check_fail_info',
                        'prerequisite_check_command',
-                       'global_bear'}
+                       'global_bear',
+                       'strip_ansi'}
 
     if not options['use_stdout'] and not options['use_stderr']:
         raise ValueError('No output streams provided at all.')
@@ -668,7 +670,8 @@ def _create_linter(klass, options):
                     (options['use_stdout'], options['use_stderr'])))
                 if len(output) == 1:
                     output = output[0]
-
+                if options['strip_ansi']:
+                    output = strip_ansi(output)
                 process_output_kwargs = FunctionMetadata.filter_parameters(
                     self._get_process_output_metadata(), kwargs)
                 return self.process_output(output, filename, file,
@@ -752,6 +755,7 @@ def linter(executable: str,
            executable_check_fail_info: str='',
            prerequisite_check_command: tuple=(),
            output_format: (str, None)=None,
+           strip_ansi: bool=False,
            **options):
     """
     Decorator that creates a ``Bear`` that is able to process results from
@@ -949,6 +953,9 @@ def linter(executable: str,
         output-format is given. If a negative distance is given, every change
         will be yielded as an own diff, even if they are right beneath each
         other. By default this value is ``1``.
+    :param strip_ansi:
+        Supresses colored output from linters when enabled by stripping the
+        ascii characters around the text.
     :raises ValueError:
         Raised when invalid options are supplied.
     :raises TypeError:
@@ -966,5 +973,6 @@ def linter(executable: str,
     options['executable_check_fail_info'] = executable_check_fail_info
     options['prerequisite_check_command'] = prerequisite_check_command
     options['global_bear'] = global_bear
+    options['strip_ansi'] = strip_ansi
 
     return partial(_create_linter, options=options)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 appdirs~=1.4
+cli_helpers~=1.0.2
 coala_utils~=0.7.0
 colorlog>=2.7,<4.0
 dependency_management~=0.4.0

--- a/tests/bearlib/abstractions/LinterTest.py
+++ b/tests/bearlib/abstractions/LinterTest.py
@@ -314,6 +314,38 @@ class LinterComponentTest(unittest.TestCase):
         process_output_mock.assert_called_once_with(('hello stdout\n',
                                                      'hello stderr\n'), '', [])
 
+    def test_strip_ansi(self):
+        process_output_mock = Mock()
+
+        class TestLinter:
+
+            @staticmethod
+            def process_output(output, filename, file):
+                process_output_mock(output, filename, file)
+
+            @staticmethod
+            def create_arguments(filename, file, config_file):
+                code = '\n'.join(['import sys',
+                                  "blue = '\033[94m'",
+                                  "print(blue + 'Hello blue')"])
+                return '-c', code
+
+        uut = (linter(sys.executable, use_stdout=True, strip_ansi=True)
+               (TestLinter)
+               (self.section, None))
+        uut.run('', [])
+
+        process_output_mock.assert_called_once_with('Hello blue\n', '', [])
+        process_output_mock.reset_mock()
+
+        uut = (linter(sys.executable, use_stdout=True, strip_ansi=False)
+               (TestLinter)
+               (self.section, None))
+        uut.run('', [])
+
+        process_output_mock.assert_called_once_with(
+            '\033[94mHello blue\n', '', [])
+
     def test_process_output_corrected(self):
         uut = (linter(sys.executable, output_format='corrected')
                (self.EmptyTestLinter)


### PR DESCRIPTION
New option `strip_ansi` implemented that strips ansi characters that
lead to colored output of linters.

Closes https://github.com/coala/coala/issues/5281

<!--
Thanks for your contribution!

Please take a quick look at those things down there. They're quite important.
Really! We wrote them for you. Yes you! With utmost care. Read them.
-->

**For short term contributors:** we understand that getting your commits well
defined like we require is a hard task and takes some learning. If you
look to help without wanting to contribute long term there's no need
for you to learn this. Just drop us a message and we'll take care of brushing
up your stuff for merge!

### Checklist

- [ ] I read the [commit guidelines](http://coala.io/commit) and I've followed
      them.
- [ ] I ran coala over my code locally. (*All commits have to pass
      individually.* It is not sufficient to have "fixup commits" on your PR,
      our bot will still report the issues for the previous commit.) You will
      likely receive a lot of bot comments and build failures if coala does not
      pass on every single commit!

After you submit your pull request, **DO NOT click the 'Update Branch' button.**
When asked for a rebase, consult [coala.io/rebase](https://coala.io/rebase)
instead.

Please consider helping us by reviewing other peoples pull requests as well:

- pick up any PR at <https://coala.io/review>
- review it (check <https://coala.io/reviewing> for more info)
- if you are sure that it needs work, use `corobo mark wip <URL>` to get it out
  of the review queue.

The more you review, the more your score will grow at coala.io and we will
review your PRs faster!
