### PR TITLE
tests/: Fix typos "instantation"

### DIFF
--- a/tests/bearlib/languages/documentation/DocstyleDefinitionTest.py
+++ b/tests/bearlib/languages/documentation/DocstyleDefinitionTest.py
@@ -17,7 +17,7 @@ class DocstyleDefinitionTest(unittest.TestCase):
     dummy_docstring_type_regex = DocstringTypeRegex('class', 'def')
     dummy_docstring_position = 'top'
 
-    def test_fail_instantation(self):
+    def test_fail_instantiation(self):
         with self.assertRaises(ValueError):
             DocstyleDefinition('PYTHON', 'doxyGEN',
                                (('##', '#'),), self.dummy_metadata,

--- a/tests/results/TextPositionTest.py
+++ b/tests/results/TextPositionTest.py
@@ -5,7 +5,7 @@ from coalib.results.TextPosition import TextPosition
 
 class TextPositionTest(unittest.TestCase):
 
-    def test_fail_instantation(self):
+    def test_fail_instantiation(self):
         with self.assertRaises(ValueError):
             TextPosition(None, 2)
 

--- a/tests/results/TextRangeTest.py
+++ b/tests/results/TextRangeTest.py
@@ -6,7 +6,7 @@ from coalib.results.TextRange import TextRange
 
 class TextRangeTest(unittest.TestCase):
 
-    def test_fail_instantation(self):
+    def test_fail_instantiation(self):
         with self.assertRaises(ValueError):
             TextRange(TextPosition(3, 4), TextPosition(2, 8))
 


### PR DESCRIPTION
Changing the typo "instantation" --> "instantiation"
in the following files:
tests/results/TextPositionTest.py
tests/results/TextRangeTest.py
tests/bearlib/languages/documentation/DocstyleDefinitionTest.py

Fixes https://github.com/coala/coala/issues/5373

<!--
Thanks for your contribution!

Please take a quick look at those things down there. They're quite important.
Really! We wrote them for you. Yes you! With utmost care. Read them.
-->

**For short term contributors:** we understand that getting your commits well
defined like we require is a hard task and takes some learning. If you
look to help without wanting to contribute long term there's no need
for you to learn this. Just drop us a message and we'll take care of brushing
up your stuff for merge!

### Checklist

- [x] I read the [commit guidelines](http://coala.io/commit) and I've followed
      them.
- [x] I ran coala over my code locally. (*All commits have to pass
      individually.* It is not sufficient to have "fixup commits" on your PR,
      our bot will still report the issues for the previous commit.) You will
      likely receive a lot of bot comments and build failures if coala does not
      pass on every single commit!

After you submit your pull request, **DO NOT click the 'Update Branch' button.**
When asked for a rebase, consult [coala.io/rebase](https://coala.io/rebase)
instead.

Please consider helping us by reviewing other peoples pull requests as well:

- pick up any PR at <https://coala.io/review>
- review it (check <https://coala.io/reviewing> for more info)
- if you are sure that it needs work, use `corobo mark wip <URL>` to get it out
  of the review queue.

The more you review, the more your score will grow at coala.io and we will
review your PRs faster!
