### PR TITLE
.coafile: Ignore new pycodestyle's checks

### DIFF
--- a/.coafile
+++ b/.coafile
@@ -30,7 +30,8 @@ remove_all_unused_imports = true
 
 [autopep8]
 bears = PEP8Bear, PycodestyleBear
-pycodestyle_ignore = E303, E121, E123, E126, E133, E226, E241, E242, E704, W503
+pycodestyle_ignore = E303, E121, E123, E126, E133, E226, E241, E242, E252, E704,
+                     W503, W504, W605
 
 default_actions = PEP8Bear: ApplyPatchAction
 


### PR DESCRIPTION
New checks E252, W504 and W605 of pycodestyle 2.4.0
are breaking the builds. This adds those checks to
`pycodestyle_ignore` list.

Closes https://github.com/coala/coala/issues/5372

<!--
Thanks for your contribution!

Please take a quick look at those things down there. They're quite important.
Really! We wrote them for you. Yes you! With utmost care. Read them.
-->

**For short term contributors:** we understand that getting your commits well
defined like we require is a hard task and takes some learning. If you
look to help without wanting to contribute long term there's no need
for you to learn this. Just drop us a message and we'll take care of brushing
up your stuff for merge!

### Checklist

- [x] I read the [commit guidelines](http://coala.io/commit) and I've followed
      them.
- [x] I ran coala over my code locally. (*All commits have to pass
      individually.* It is not sufficient to have "fixup commits" on your PR,
      our bot will still report the issues for the previous commit.) You will
      likely receive a lot of bot comments and build failures if coala does not
      pass on every single commit!

After you submit your pull request, **DO NOT click the 'Update Branch' button.**
When asked for a rebase, consult [coala.io/rebase](https://coala.io/rebase)
instead.

Please consider helping us by reviewing other peoples pull requests as well:

- pick up any PR at <https://coala.io/review>
- review it (check <https://coala.io/reviewing> for more info)
- if you are sure that it needs work, use `corobo mark wip <URL>` to get it out
  of the review queue.

The more you review, the more your score will grow at coala.io and we will
review your PRs faster!
