### PR TITLE
Git_Basics.rst: Incorporate http://ohshitgit.com/

### DIFF
--- a/docs/Developers/Git_Basics.rst
+++ b/docs/Developers/Git_Basics.rst
@@ -451,6 +451,10 @@ While rebasing, you may come across mid-rebase conflicts. For information
 regarding how to resolve mid-rebase conflicts, please check this
 `tutorial <http://gitforteams.com/resources/rebasing.html>`_.
 
+http://ohshitgit.com/ contains helpful Git snippets for recovering from various
+common Git issues. It is a great resource to check out when something has gone
+wrong.
+
 If at any stage you are confused, or have an issue, do not close your Pull
 Request. Instead, contact us on gitter so that we can help you resolve your
 problem.


### PR DESCRIPTION
http://ohshitgit.com/ contains helpful git snippets when something has
gone wrong.
This commit adds the link to the website as well as some snippets and
paraphrased instructions into Git Basics.

Closes https://github.com/coala/coala/issues/4985

### Checklist

- [x] I read the [commit guidelines](http://coala.io/commit) and I've followed
      them.
- [x] I ran coala over my code locally. (*All commits have to pass
      individually.* It is not sufficient to have "fixup commits" on your PR,
      our bot will still report the issues for the previous commit.) You will
      likely receive a lot of bot comments and build failures if coala does not
      pass on every single commit!