### PR TITLE
ConsoleInteractionTest: Remove check_logs usage

### DIFF
--- a/tests/output/ConsoleInteractionTest.py
+++ b/tests/output/ConsoleInteractionTest.py
@@ -14,7 +14,6 @@ from coalib.bears.Bear import Bear
 from coalib import coala
 from coala_utils.ContextManagers import (
     make_temp, retrieve_stdout, simulate_console_inputs)
-from coala_utils.decorators import check_logs
 from coalib.output.ConsoleInteraction import (
     acquire_actions_and_apply, acquire_settings, get_action_info, nothing_done,
     print_affected_files, print_result, print_results,
@@ -869,6 +868,8 @@ class ShowBearsTest(unittest.TestCase):
 
     def setUp(self):
         self.console_printer = ConsolePrinter(print_colored=False)
+        self.logs = LogCapture()
+        self.logs.__enter__()
 
     deprecation_messages = [('root',
                              'WARNING',
@@ -877,14 +878,17 @@ class ShowBearsTest(unittest.TestCase):
                              'WARNING',
                              'show_params parameter is deprecated')]
 
-    @check_logs(*deprecation_messages)
+    def tearDown(self):
+        self.logs.__exit__(None, None, None)
+
     def test_show_bear_minimal(self):
         with retrieve_stdout() as stdout:
             show_bear(
                 SomelocalBear, False, False, self.console_printer)
             self.assertEqual(stdout.getvalue(), 'SomelocalBear\n')
 
-    @check_logs(*deprecation_messages)
+        self.logs.check(*self.deprecation_messages)
+
     def test_show_bear_desc_only(self):
         with retrieve_stdout() as stdout:
             show_bear(
@@ -893,7 +897,8 @@ class ShowBearsTest(unittest.TestCase):
                 stdout.getvalue(),
                 'SomelocalBear\n  Some local-bear Description.\n\n')
 
-    @check_logs(*deprecation_messages)
+        self.logs.check(*self.deprecation_messages)
+
     def test_show_bear_details_only(self):
         with retrieve_stdout() as stdout:
             show_bear(
@@ -911,7 +916,8 @@ class ShowBearsTest(unittest.TestCase):
                              'can fix.\n\n  Path:\n   ' +
                              repr(SomelocalBear.source_location) + '\n\n')
 
-    @check_logs(*deprecation_messages)
+        self.logs.check(*self.deprecation_messages)
+
     def test_show_bear_long_without_content(self):
         with retrieve_stdout() as stdout:
             show_bear(
@@ -930,7 +936,8 @@ class ShowBearsTest(unittest.TestCase):
                              'can fix.\n\n  Path:\n   ' +
                              repr(SomelocalBear.source_location) + '\n\n')
 
-    @check_logs(*deprecation_messages)
+        self.logs.check(*self.deprecation_messages)
+
     def test_show_bear_with_content(self):
         with retrieve_stdout() as stdout:
             show_bear(TestBear, True, True, self.console_printer)
@@ -950,7 +957,8 @@ class ShowBearsTest(unittest.TestCase):
                              '  Can fix:\n   * Formatting\n\n  Path:\n   ' +
                              repr(TestBear.source_location) + '\n\n')
 
-    @check_logs(*deprecation_messages)
+        self.logs.check(*self.deprecation_messages)
+
     def test_show_bear_settings_only(self):
         with retrieve_stdout() as stdout:
             args = default_arg_parser().parse_args(['--show-settings'])
@@ -963,20 +971,23 @@ class ShowBearsTest(unittest.TestCase):
                              '   * setting2: Optional Setting. ('
                              "Optional, defaults to 'None'.)\n\n")
 
-    @check_logs(*deprecation_messages)
+        self.logs.check(*self.deprecation_messages)
+
     def test_show_bears_empty(self):
         with retrieve_stdout() as stdout:
             show_bears({}, {}, True, True, self.console_printer)
             self.assertIn('No bears to show.', stdout.getvalue())
 
-    @check_logs(*deprecation_messages)
+        self.logs.check(*self.deprecation_messages)
+
     def test_show_bears_with_json(self):
         args = default_arg_parser().parse_args(['--json'])
         with retrieve_stdout() as stdout:
             show_bears({}, {}, True, True, self.console_printer, args)
             self.assertEqual('{\n  "bears": []\n}\n', stdout.getvalue())
 
-    @check_logs(*deprecation_messages)
+        self.logs.check(*self.deprecation_messages)
+
     @patch('coalib.output.ConsoleInteraction.show_bear')
     def test_show_bears(self, show_bear):
         local_bears = OrderedDict([('default', [SomelocalBear]),
@@ -988,7 +999,8 @@ class ShowBearsTest(unittest.TestCase):
                                           self.console_printer,
                                           None)
 
-    @check_logs(*(deprecation_messages*5))
+        self.logs.check(*self.deprecation_messages)
+
     def test_show_bears_sorted(self):
         local_bears = OrderedDict([('default', [SomelocalBear]),
                                    ('test', [aSomelocalBear])])
@@ -1003,6 +1015,8 @@ class ShowBearsTest(unittest.TestCase):
                              'BSomeglobalBear\n'
                              'SomeglobalBear\n'
                              'SomelocalBear\n')
+
+        self.logs.check(*(self.deprecation_messages*5))
 
     def test_show_bears_capabilities(self):
         with retrieve_stdout() as stdout:


### PR DESCRIPTION
``coala_utils`` decorator ``check_logs`` relies on
``textfixtures``, a dependency it shoul not have.
Inlining the decorator will allow it to be removed.

Related to https://github.com/coala/coala/issues/5335

<!--
Thanks for your contribution!

Please take a quick look at those things down there. They're quite important.
Really! We wrote them for you. Yes you! With utmost care. Read them.
-->

**For short term contributors:** we understand that getting your commits well
defined like we require is a hard task and takes some learning. If you
look to help without wanting to contribute long term there's no need
for you to learn this. Just drop us a message and we'll take care of brushing
up your stuff for merge!

### Checklist

- [ ] I read the [commit guidelines](http://coala.io/commit) and I've followed
      them.
- [ ] I ran coala over my code locally. (*All commits have to pass
      individually.* It is not sufficient to have "fixup commits" on your PR,
      our bot will still report the issues for the previous commit.) You will
      likely receive a lot of bot comments and build failures if coala does not
      pass on every single commit!

After you submit your pull request, **DO NOT click the 'Update Branch' button.**
When asked for a rebase, consult [coala.io/rebase](https://coala.io/rebase)
instead.

Please consider helping us by reviewing other peoples pull requests as well:

- pick up any PR at <https://coala.io/review>
- review it (check <https://coala.io/reviewing> for more info)
- if you are sure that it needs work, use `corobo mark wip <URL>` to get it out
  of the review queue.

The more you review, the more your score will grow at coala.io and we will
review your PRs faster!
