### PR TITLE
tests: Replace httpbin with Google teapot

### DIFF
--- a/tests/bears/BearTest.py
+++ b/tests/bears/BearTest.py
@@ -489,6 +489,9 @@ class BearDownloadTest(BearTestBase):
         super().setUp()
         self.mock_url = 'https://test.com'
         self.filename = 'test.html'
+        self.teapot_url = 'https://httpstat.us/418'
+        # https://www.google.com/teapot and
+        # http://httpbin.org/status/418 also work
         self.file_location = join(self.uut.data_dir, self.filename)
 
     def test_connection_timeout_mocked(self):
@@ -521,9 +524,9 @@ class BearDownloadTest(BearTestBase):
 
     def test_status_code_error(self):
         exc = requests.exceptions.HTTPError
-        with self.assertRaisesRegex(exc, '418 Client Error'):
+        with self.assertRaisesRegex(exc, '^418 '):
             self.uut.download_cached_file(
-                'http://httpbin.org/status/418', self.filename)
+                self.teapot_url, self.filename)
 
     def test_download_cached_file(self):
         mock_url = 'https://test.com'

--- a/tests/core/BearTest.py
+++ b/tests/core/BearTest.py
@@ -74,6 +74,10 @@ class BearWithPrerequisitesOverride(Bear):
 
 class BearTest(unittest.TestCase):
 
+    def setUp(self):
+        super().setUp()
+        self.teapot_url = 'https://httpstat.us/418'
+
     def tearDown(self):
         defined_bears = [
             value
@@ -221,9 +225,9 @@ class BearTest(unittest.TestCase):
 
     def test_download_cached_file_status_code_error(self):
         exc = requests.exceptions.HTTPError
-        with self.assertRaisesRegex(exc, '418 Client Error'):
+        with self.assertRaisesRegex(exc, '^418 '):
             Bear.download_cached_file(
-                'http://httpbin.org/status/418', 'test.html')
+                self.teapot_url, 'test.html')
 
     def test_json(self):
         result = BearWithAnalysis.__json__()


### PR DESCRIPTION
Replaces http://httpbin.org/status/418 with
https://www.google.com/teapot as a more reliable
end-point for testing.

Closes https://github.com/coala/coala/issues/5433

<!--
Thanks for your contribution!

Please take a quick look at those things down there. They're quite important.
Really! We wrote them for you. Yes you! With utmost care. Read them.
-->

**For short term contributors:** we understand that getting your commits well
defined like we require is a hard task and takes some learning. If you
look to help without wanting to contribute long term there's no need
for you to learn this. Just drop us a message and we'll take care of brushing
up your stuff for merge!

### Checklist

- [ ] I read the [commit guidelines](http://coala.io/commit) and I've followed
      them.
- [ ] I ran coala over my code locally. (*All commits have to pass
      individually.* It is not sufficient to have "fixup commits" on your PR,
      our bot will still report the issues for the previous commit.) You will
      likely receive a lot of bot comments and build failures if coala does not
      pass on every single commit!

After you submit your pull request, **DO NOT click the 'Update Branch' button.**
When asked for a rebase, consult [coala.io/rebase](https://coala.io/rebase)
instead.

Please consider helping us by reviewing other peoples pull requests as well:

- pick up any PR at <https://coala.io/review>
- review it (check <https://coala.io/reviewing> for more info)
- if you are sure that it needs work, use `corobo mark wip <URL>` to get it out
  of the review queue.

The more you review, the more your score will grow at coala.io and we will
review your PRs faster!
