### PR TITLE
CachingUtilities.py: Removes unnecessary imports

### DIFF
--- a/coalib/misc/CachingUtilities.py
+++ b/coalib/misc/CachingUtilities.py
@@ -63,8 +63,6 @@ def pickle_load(log_printer, identifier, fallback=None):
     Get the data stored in ``filename`` present in the user
     config directory. Example usage:
 
-    >>> from pyprint.NullPrinter import NullPrinter
-    >>> from coalib.output.printers.LogPrinter import LogPrinter
     >>> test_data = {'answer': 42}
     >>> pickle_dump(None, 'test_project', test_data)
     True


### PR DESCRIPTION
Removes unnecessary imports on CachingUtilities.pickle_load docstring.

Closes https://github.com/coala/coala/issues/5441

<!--
Thanks for your contribution!

Please take a quick look at those things down there. They're quite important.
Really! We wrote them for you. Yes you! With utmost care. Read them.
-->

**For short term contributors:** we understand that getting your commits well
defined like we require is a hard task and takes some learning. If you
look to help without wanting to contribute long term there's no need
for you to learn this. Just drop us a message and we'll take care of brushing
up your stuff for merge!

### Checklist

- [x] I read the [commit guidelines](http://coala.io/commit) and I've followed
      them.
- [x] I ran coala over my code locally. (*All commits have to pass
      individually.* It is not sufficient to have "fixup commits" on your PR,
      our bot will still report the issues for the previous commit.) You will
      likely receive a lot of bot comments and build failures if coala does not
      pass on every single commit!

After you submit your pull request, **DO NOT click the 'Update Branch' button.**
When asked for a rebase, consult [coala.io/rebase](https://coala.io/rebase)
instead.

Please consider helping us by reviewing other peoples pull requests as well:

- pick up any PR at <https://coala.io/review>
- review it (check <https://coala.io/reviewing> for more info)
- if you are sure that it needs work, use `corobo mark wip <URL>` to get it out
  of the review queue.

The more you review, the more your score will grow at coala.io and we will
review your PRs faster!
