### PR TITLE
ConfigurationGatheringTest.py: Save user_coafile before modify

### DIFF
--- a/tests/settings/ConfigurationGatheringTest.py
+++ b/tests/settings/ConfigurationGatheringTest.py
@@ -46,7 +46,12 @@ class ConfigurationGatheringTest(unittest.TestCase):
         # Needed so coala doesn't error out
         self.min_args = ['-f', '*.java', '-b', 'JavaTestBear']
 
+        self.original_user_coafile = Constants.user_coafile
+        self.original_system_coafile = Constants.system_coafile
+
     def tearDown(self):
+        Constants.user_coafile = self.original_user_coafile
+        Constants.system_coafile = self.original_system_coafile
         close_objects(self.log_printer)
 
     def test_gather_configuration(self):
@@ -101,7 +106,6 @@ class ConfigurationGatheringTest(unittest.TestCase):
         )
 
     def test_system_coafile_parsing(self):
-        tmp = Constants.system_coafile
 
         Constants.system_coafile = os.path.abspath(os.path.join(
             os.path.dirname(os.path.realpath(__file__)),
@@ -116,11 +120,7 @@ class ConfigurationGatheringTest(unittest.TestCase):
         self.assertEqual(str(sections['test']),
                          "test {value : '1', testval : '5'}")
 
-        Constants.system_coafile = tmp
-
     def test_user_coafile_parsing(self):
-        tmp = Constants.user_coafile
-
         Constants.user_coafile = os.path.abspath(os.path.join(
             os.path.dirname(os.path.realpath(__file__)),
             'section_manager_test_files',
@@ -134,8 +134,6 @@ class ConfigurationGatheringTest(unittest.TestCase):
         self.assertEqual(str(sections['test']),
                          "test {value : '1', testval : '5'}")
 
-        Constants.user_coafile = tmp
-
     def test_nonexistent_file(self):
         filename = 'bad.one/test\neven with bad chars in it'
         with self.assertRaises(SystemExit):
@@ -143,7 +141,6 @@ class ConfigurationGatheringTest(unittest.TestCase):
                                  self.log_printer,
                                  arg_list=['-S', 'config=' + filename])
 
-        tmp = Constants.system_coafile
         Constants.system_coafile = filename
 
         with self.assertRaises(SystemExit):
@@ -151,10 +148,7 @@ class ConfigurationGatheringTest(unittest.TestCase):
                                  self.log_printer,
                                  arg_list=[])
 
-        Constants.system_coafile = tmp
-
     def test_merge(self):
-        tmp = Constants.system_coafile
         Constants.system_coafile = os.path.abspath(os.path.join(
             os.path.dirname(os.path.realpath(__file__)),
             'section_manager_test_files',
@@ -196,8 +190,6 @@ class ConfigurationGatheringTest(unittest.TestCase):
                          "test-4 {bears : 'TestBear'}")
         self.assertEqual(str(sections['test-5']),
                          "test-5 {bears : 'TestBear2'}")
-
-        Constants.system_coafile = tmp
 
     def test_merge_defaults(self):
         with make_temp() as temporary:


### PR DESCRIPTION
…onstants.user_coafile state save

Constants.user_coafile is now saved and restored from setUp() and tearDown()
Fixes #5445

<!--
Thanks for your contribution!

Please take a quick look at those things down there. They're quite important.
Really! We wrote them for you. Yes you! With utmost care. Read them.
-->

**For short term contributors:** we understand that getting your commits well
defined like we require is a hard task and takes some learning. If you
look to help without wanting to contribute long term there's no need
for you to learn this. Just drop us a message and we'll take care of brushing
up your stuff for merge!

### Checklist

- [ *] I read the [commit guidelines](http://coala.io/commit) and I've followed
      them.
- [ *] I ran coala over my code locally. (*All commits have to pass
      individually.* It is not sufficient to have "fixup commits" on your PR,
      our bot will still report the issues for the previous commit.) You will
      likely receive a lot of bot comments and build failures if coala does not
      pass on every single commit!

After you submit your pull request, **DO NOT click the 'Update Branch' button.**
When asked for a rebase, consult [coala.io/rebase](https://coala.io/rebase)
instead.

Please consider helping us by reviewing other peoples pull requests as well:

- pick up any PR at <https://coala.io/review>
- review it (check <https://coala.io/reviewing> for more info)
- if you are sure that it needs work, use `corobo mark wip <URL>` to get it out
  of the review queue.

The more you review, the more your score will grow at coala.io and we will
review your PRs faster!
