### PR TITLE
CliParsing.py: Throw error for conflicting arguments

### DIFF
--- a/coalib/parsing/CliParsing.py
+++ b/coalib/parsing/CliParsing.py
@@ -116,9 +116,11 @@ def check_conflicts(sections):
         if (
                 section.get('no_config', False) and
                 (section.get('save', False) or
-                 section.get('find_config', False))):
+                 section.get('find_config', False) or
+                 str(section.get('config', 'input')) != 'input')):
             ArgumentParser().error(
-                "'no_config' cannot be set together 'save' or 'find_config'.")
+                "'no_config' cannot be set together with 'save', "
+                "'find_config' or 'config'.")
 
         if (
                 not section.get('json', False) and

--- a/tests/parsing/CliParsingTest.py
+++ b/tests/parsing/CliParsingTest.py
@@ -71,3 +71,8 @@ class CliParserTest(unittest.TestCase):
         with self.assertRaisesRegex(SystemExit, '2') as cm:
             check_conflicts(sections)
             self.assertEqual(cm.exception.code, 2)
+
+        sections = parse_cli(arg_list=['--no-config', '--config', '.coafile'])
+        with self.assertRaisesRegex(SystemExit, '2') as cm:
+            check_conflicts(sections)
+            self.assertEqual(cm.exception.code, 2)


### PR DESCRIPTION
Add conflict check for arguments `-config` and `--no-config`

Fixes https://github.com/coala/coala/issues/5115

<!--
Thanks for your contribution!

Please take a quick look at those things down there. They're quite important.
Really! We wrote them for you. Yes you! With utmost care. Read them.
-->

**For short term contributors:** we understand that getting your commits well
defined like we require is a hard task and takes some learning. If you
look to help without wanting to contribute long term there's no need
for you to learn this. Just drop us a message and we'll take care of brushing
up your stuff for merge!

### Checklist

- [x] I read the [commit guidelines](http://coala.io/commit) and I've followed
      them.
- [x] I ran coala over my code locally. (*All commits have to pass
      individually.* It is not sufficient to have "fixup commits" on your PR,
      our bot will still report the issues for the previous commit.) You will
      likely receive a lot of bot comments and build failures if coala does not
      pass on every single commit!

After you submit your pull request, **DO NOT click the 'Update Branch' button.**
When asked for a rebase, consult [coala.io/rebase](https://coala.io/rebase)
instead.

Please consider helping us by reviewing other peoples pull requests as well:

- pick up any PR at <https://coala.io/review>
- review it (check <https://coala.io/reviewing> for more info)
- if you are sure that it needs work, use `corobo mark wip <URL>` to get it out
  of the review queue.

The more you review, the more your score will grow at coala.io and we will
review your PRs faster!
