### PR TITLE
appveyor.yml: Run pip install as Python module

### DIFF
--- a/.misc/appveyor.yml
+++ b/.misc/appveyor.yml
@@ -31,8 +31,8 @@ install:
   - "python --version"
   - "python -c \"import struct; print(struct.calcsize('P') * 8)\""
 
-  - "%CMD_IN_ENV% pip install --cache-dir=C:\\pip_cache -r requirements.txt \
-     -r test-requirements.txt"
+  - "%CMD_IN_ENV% python -m pip install --cache-dir=C:\\pip_cache \
+     -r requirements.txt -r test-requirements.txt"
 
 build: false  # Not a C# project, build stuff at the test step instead.
 


### PR DESCRIPTION
pip now complains about being downgraded when being
executed via the `pip` command on Windows.

Closes https://github.com/coala/coala/issues/5466
