### PR TITLE
TypeScript.py: Changes aliases variable to tuple

### DIFF
--- a/coalib/bearlib/languages/definitions/TypeScript.py
+++ b/coalib/bearlib/languages/definitions/TypeScript.py
@@ -3,7 +3,7 @@ from coalib.bearlib.languages.Language import Language
 
 @Language
 class TypeScript:
-    aliases = 'ts'
+    aliases = ('ts',)
     extensions = '.ts', '.tsx'
     comment_delimiter = '//'
     multiline_comment_delimiters = {'/*': '*/'}


### PR DESCRIPTION
This change changes alias to a tuple

Closes #5389.