### PR TITLE
Remove line continuation and ban it in .coafile

### DIFF
--- a/.coafile
+++ b/.coafile
@@ -12,9 +12,11 @@ use_spaces = True
 # will be executed sequentially; also we need the LineLengthBear to double
 # check the line length because PEP8Bear sometimes isn't able to correct the
 # linelength.
-bears = SpaceConsistencyBear, QuotesBear
+bears = SpaceConsistencyBear, QuotesBear, KeywordBear
 language = Python
 preferred_quotation = '
+keywords =
+regex_keyword = \\\$
 
 default_actions = **: ApplyPatchAction
 

--- a/coalib/bearlib/languages/Language.py
+++ b/coalib/bearlib/languages/Language.py
@@ -152,9 +152,9 @@ class LanguageMeta(type, metaclass=LanguageUberMeta):
         if cls is Language:
             assert len(args) == 1
             arg = args[0]
-            assert isclass(arg), \
-                'This decorator is made for classes. Did you mean to use ' \
-                '`Language[%s]`?' % (repr(arg[0]),)
+            assert isclass(arg), (
+                'This decorator is made for classes. Did you mean to use '(
+                    '`Language[%s]`?' % (repr(arg[0]),)))
 
             class SubLanguageMeta(type(cls)):
                 # Override __getattr__ of the LanguageMeta to get a dict with
@@ -271,8 +271,8 @@ class Language(metaclass=LanguageMeta):
     the class:
 
     >>> Language.TrumpScript.comment_delimiter
-    OrderedDict([(<Version('2.7')>, '#'), (<Version('3.3')>, '#'), \
-(<Version('3.4')>, '#'), (<Version('3.5')>, '#'), (<Version('3.6')>, '#')])
+    OrderedDict([(<Version('2.7')>, '#'), (<Version('3.3')>, '#'), (
+(<Version('3.4')>, '#'), (<Version('3.5')>, '#'), (<Version('3.6')>, '#')]))
 
     Any nonexistent item will of course not be served:
 

--- a/coalib/bearlib/languages/documentation/DocumentationComment.py
+++ b/coalib/bearlib/languages/documentation/DocumentationComment.py
@@ -257,10 +257,10 @@ class DocumentationComment:
         This function just assembles the documentation comment
         itself, without the markers and indentation.
 
-        >>> from coalib.bearlib.languages.documentation.DocumentationComment \
-        ...     import DocumentationComment
-        >>> from coalib.bearlib.languages.documentation.DocstyleDefinition \
-        ...     import DocstyleDefinition
+        >>> from coalib.bearlib.languages.documentation.DocumentationComment (
+        ...     import DocumentationComment)
+        >>> from coalib.bearlib.languages.documentation.DocstyleDefinition (
+        ...     import DocstyleDefinition)
         >>> from coalib.results.TextPosition import TextPosition
         >>> Description = DocumentationComment.Description
         >>> Parameter = DocumentationComment.Parameter

--- a/coalib/bearlib/languages/documentation/DocumentationExtraction.py
+++ b/coalib/bearlib/languages/documentation/DocumentationExtraction.py
@@ -211,8 +211,8 @@ def _extract_doc_comment_from_line(content, line, column, regex,
         if doc_comment:
             return end_line, end_column, doc
         else:
-            malformed_comment = MalformedComment(dedent("""\
-                Please check the docstring for faulty markers. A starting
+            malformed_comment = MalformedComment(dedent(
+                """Please check the docstring for faulty markers. A starting
                 marker has been found, but no instance of DocComment is
                 returned."""), line)
             return line + 1, 0, malformed_comment

--- a/coalib/coala_main.py
+++ b/coalib/coala_main.py
@@ -15,10 +15,10 @@ from coalib.results.result_actions.ApplyPatchAction import ApplyPatchAction
 from coalib.results.result_actions.IgnoreResultAction import IgnoreResultAction
 from coalib.results.result_actions.OpenEditorAction import OpenEditorAction
 from coalib.results.result_actions.PrintAspectAction import PrintAspectAction
-from coalib.results.result_actions.PrintMoreInfoAction import  \
-    PrintMoreInfoAction
-from coalib.results.result_actions.PrintDebugMessageAction import \
-    PrintDebugMessageAction
+from coalib.results.result_actions.PrintMoreInfoAction import (
+    PrintMoreInfoAction)
+from coalib.results.result_actions.PrintDebugMessageAction import (
+    PrintDebugMessageAction)
 from coalib.misc.Caching import FileCache
 from coalib.misc.CachingUtilities import (
     settings_changed, update_settings_db, get_settings_hash)

--- a/coalib/misc/BuildManPage.py
+++ b/coalib/misc/BuildManPage.py
@@ -26,8 +26,8 @@ class BuildManPage(Command):
 
     You can then use the following setup command to produce a man page::
 
-        $ python setup.py build_manpage --output=coala.1 \
-            --parser=coalib.parsing.DefaultArgParser:default_arg_parser
+        $ python setup.py build_manpage --output=coala.1 (
+            --parser=coalib.parsing.DefaultArgParser:default_arg_parser)
 
     If automatically want to build the man page every time you invoke
     your build, add to your ``setup.cfg`` the following::

--- a/coalib/parsing/CliParsing.py
+++ b/coalib/parsing/CliParsing.py
@@ -116,11 +116,9 @@ def check_conflicts(sections):
         if (
                 section.get('no_config', False) and
                 (section.get('save', False) or
-                 section.get('find_config', False) or
-                 str(section.get('config', 'input')) != 'input')):
+                 section.get('find_config', False))):
             ArgumentParser().error(
-                "'no_config' cannot be set together with 'save', "
-                "'find_config' or 'config'.")
+                "'no_config' cannot be set together 'save' or 'find_config'.")
 
         if (
                 not section.get('json', False) and

--- a/coalib/parsing/CliParsing.py
+++ b/coalib/parsing/CliParsing.py
@@ -116,9 +116,11 @@ def check_conflicts(sections):
         if (
                 section.get('no_config', False) and
                 (section.get('save', False) or
-                 section.get('find_config', False))):
+                 section.get('find_config', False) or
+                 str(section.get('config', 'input')) != 'input')):
             ArgumentParser().error(
-                "'no_config' cannot be set together 'save' or 'find_config'.")
+                "'no_config' cannot be set together with 'save', "
+                "'find_config' or 'config'.")
 
         if (
                 not section.get('json', False) and

--- a/coalib/processes/Processing.py
+++ b/coalib/processes/Processing.py
@@ -18,8 +18,8 @@ from coalib.results.Result import Result
 from coalib.results.result_actions.DoNothingAction import DoNothingAction
 from coalib.results.result_actions.ApplyPatchAction import ApplyPatchAction
 from coalib.results.result_actions.IgnoreResultAction import IgnoreResultAction
-from coalib.results.result_actions.ShowAppliedPatchesAction \
-    import ShowAppliedPatchesAction
+from coalib.results.result_actions.ShowAppliedPatchesAction import (
+    ShowAppliedPatchesAction)
 from coalib.results.result_actions.GeneratePatchesAction import (
     GeneratePatchesAction)
 from coalib.results.result_actions.PrintDebugMessageAction import (

--- a/coalib/results/Result.py
+++ b/coalib/results/Result.py
@@ -37,8 +37,8 @@ class Result:
     Result messages can also have arguments. The message is python
     style formatted with these arguments.
 
-    >>> r = Result('origin','{arg1} and {arg2}', \
-           message_arguments={'arg1': 'foo', 'arg2': 'bar'})
+    >>> r = Result('origin','{arg1} and {arg2}', (
+           message_arguments={'arg1': 'foo', 'arg2': 'bar'}))
     >>> r.message
     'foo and bar'
 

--- a/coalib/settings/Annotations.py
+++ b/coalib/settings/Annotations.py
@@ -17,8 +17,8 @@ def typechain(*args):
     >>> function("str")
     Traceback (most recent call last):
         ...
-    ValueError: Couldn't convert value 'str' to any specified type or find it \
-in specified values.
+    ValueError: Couldn't convert value 'str' to any specified type or find it (
+in specified values.)
 
     :raises TypeError:  Raises when either no functions are specified for
                         checking.

--- a/coalib/testing/LocalBearTestHelper.py
+++ b/coalib/testing/LocalBearTestHelper.py
@@ -58,8 +58,8 @@ def execute_bear(bear, *args, **kwargs):
 
             bear_output_generator = bear.execute(*args, **kwargs)
 
-        assert bear_output_generator is not None, \
-            'Bear returned None on execution\n'
+        assert bear_output_generator is not None, (
+            'Bear returned None on execution\n')
         yield bear_output_generator
     except Exception as err:
         msg = []
@@ -94,10 +94,10 @@ def get_results(local_bear,
     with prepare_file(lines, filename,
                       force_linebreaks=force_linebreaks,
                       create_tempfile=create_tempfile,
-                      tempfile_kwargs=tempfile_kwargs) as (file, fname), \
+                      tempfile_kwargs=tempfile_kwargs) as (file, fname), (
         execute_bear(local_bear, fname, file, dependency_results=deps_results,
                      **local_bear.get_metadata().filter_parameters(settings)
-                     ) as bear_output:
+                     )) as bear_output:
         return bear_output
 
 

--- a/tests/bearlib/aspects/SubTest.py
+++ b/tests/bearlib/aspects/SubTest.py
@@ -31,8 +31,8 @@ class SubAspectTest:
             taste_values = aspect.tastes
             for name, taste in SubAspect_tastes.items():
                 if not taste.languages or language in taste.languages:
-                    assert getattr(aspect, name) == taste_values[name] \
-                        == taste.default
+                    assert getattr(aspect, name) == taste_values[name](
+                        == taste.default)
                 else:
                     with pytest.raises(TasteError) as exc:
                         getattr(aspect, name)
@@ -41,19 +41,19 @@ class SubAspectTest:
 
     def test__eq__(self, RootAspect, SubAspect, SubAspect_taste_values):
         assert SubAspect('py') == SubAspect('py')
-        assert SubAspect('py', **SubAspect_taste_values) \
-            == SubAspect('py', **SubAspect_taste_values)
+        assert SubAspect('py', **SubAspect_taste_values)(
+            == SubAspect('py', **SubAspect_taste_values))
         assert not SubAspect('py') == RootAspect('py')
         assert not SubAspect('py') == Root('py')
-        assert not SubAspect('py') \
-            == SubAspect('py', **SubAspect_taste_values)
-        assert not SubAspect('py', **SubAspect_taste_values) \
-            == SubAspect('py')
+        assert not SubAspect('py')(
+            == SubAspect('py', **SubAspect_taste_values))
+        assert not SubAspect('py', **SubAspect_taste_values)(
+            == SubAspect('py'))
 
     def test__ne__(self, RootAspect, SubAspect, SubAspect_taste_values):
         assert not SubAspect('py') != SubAspect('py')
-        assert not SubAspect('py', **SubAspect_taste_values) \
-            != SubAspect('py', **SubAspect_taste_values)
+        assert not SubAspect('py', **SubAspect_taste_values)(
+            != SubAspect('py', **SubAspect_taste_values))
         assert SubAspect('py') != RootAspect('py')
         assert SubAspect('py') != Root('py')
         assert SubAspect('py') != SubAspect('py', **SubAspect_taste_values)

--- a/tests/bearlib/aspects/TasteTest.py
+++ b/tests/bearlib/aspects/TasteTest.py
@@ -30,5 +30,5 @@ class TasteTest:
         for name, taste in SubAspect_tastes.items():
             assert getattr(SubAspect, name) is taste
             assert getattr(using_default_values, name) == taste.default
-            assert getattr(using_custom_values, name) \
-                == SubAspect_taste_values[name]
+            assert getattr(using_custom_values, name)(
+                == SubAspect_taste_values[name])

--- a/tests/bearlib/languages/documentation/DocBaseClassTest.py
+++ b/tests/bearlib/languages/documentation/DocBaseClassTest.py
@@ -453,8 +453,8 @@ class DocBaseClassTest(unittest.TestCase):
                 '* A doc-comment aborted in the middle of writing\n',
                 '* This won\'t get parsed (hopefully...)\n']
 
-        expected = [dedent("""\
-            Please check the docstring for faulty markers. A starting
+        expected = [dedent(
+            """Please check the docstring for faulty markers. A starting
             marker has been found, but no instance of DocComment is
             returned."""), 0]
 
@@ -467,8 +467,8 @@ class DocBaseClassTest(unittest.TestCase):
         data = ['\n',
                 '/** Aborts...\n']
 
-        expected = [dedent("""\
-            Please check the docstring for faulty markers. A starting
+        expected = [dedent(
+            """Please check the docstring for faulty markers. A starting
             marker has been found, but no instance of DocComment is
             returned."""), 1]
 
@@ -482,8 +482,8 @@ class DocBaseClassTest(unittest.TestCase):
                 '* Markers are faulty\n',
                 '*/']
 
-        expected = [dedent("""\
-            Please check the docstring for faulty markers. A starting
+        expected = [dedent(
+            """Please check the docstring for faulty markers. A starting
             marker has been found, but no instance of DocComment is
             returned."""), 0]
 

--- a/tests/bears/BearTest.py
+++ b/tests/bears/BearTest.py
@@ -536,8 +536,8 @@ class BearDownloadTest(BearTestBase):
         filename = self.filename
         file_location = self.file_location
 
-        with freeze_time('2017-01-01') as frozen_datetime, \
-                requests_mock.Mocker() as reqmock:
+        with freeze_time('2017-01-01') as frozen_datetime, (
+                requests_mock.Mocker()) as reqmock:
 
             reqmock.get(mock_url, text=mock_text)
             self.assertFalse(isfile(file_location))

--- a/tests/coalaCITest.py
+++ b/tests/coalaCITest.py
@@ -53,8 +53,8 @@ class coalaCITest(unittest.TestCase):
         self.test_nonexistent(debug=True)
 
     def test_find_no_issues(self, debug=False):
-        with bear_test_module(), \
-                prepare_file(['#include <a>'], None) as (lines, filename):
+        with bear_test_module(), (
+                prepare_file(['#include <a>'], None)) as (lines, filename):
             retval, stdout, stderr = execute_coala(coala.main, 'coala',
                                                    '--non-interactive',
                                                    '-c', os.devnull,
@@ -75,8 +75,8 @@ class coalaCITest(unittest.TestCase):
                              'coala must return zero when successful')
 
     def test_section_ordering(self, debug=False):
-        with bear_test_module(), \
-                prepare_file(['#include <a>'], None) as (lines, filename):
+        with bear_test_module(), (
+                prepare_file(['#include <a>'], None)) as (lines, filename):
             retval, stdout, stderr = execute_coala(
                     coala.main, 'coala', 'b', 'a',
                     '--non-interactive', '-S',
@@ -111,8 +111,8 @@ class coalaCITest(unittest.TestCase):
         self.test_find_no_issues(debug=True)
 
     def test_find_issues(self, debug=False):
-        with bear_test_module(), \
-                prepare_file(['#fixme'], None) as (lines, filename):
+        with bear_test_module(), (
+                prepare_file(['#fixme'], None)) as (lines, filename):
             retval, stdout, stderr = execute_coala(coala.main, 'coala',
                                                    '--non-interactive',
                                                    '-c', os.devnull,
@@ -130,8 +130,8 @@ class coalaCITest(unittest.TestCase):
         self.test_find_issues(debug=True)
 
     def test_show_patch(self, debug=False):
-        with bear_test_module(), \
-             prepare_file(['\t#include <a>'], None) as (lines, filename):
+        with bear_test_module(), (
+             prepare_file(['\t#include <a>'], None)) as (lines, filename):
             retval, stdout, stderr = execute_coala(
                 coala.main, 'coala', '--non-interactive',
                 '-c', os.devnull,
@@ -161,8 +161,8 @@ class coalaCITest(unittest.TestCase):
                                 'coala was expected to return non-zero')
 
     def test_additional_parameters_settings(self, debug=False):
-        with bear_test_module(), \
-             prepare_file(['\t#include <a>'], None) as (lines, filename):
+        with bear_test_module(), (
+             prepare_file(['\t#include <a>'], None)) as (lines, filename):
             retval, stdout, stderr = execute_coala(
                  coala.main, 'coala',
                  '--non-interactive', '-S',
@@ -187,8 +187,8 @@ class coalaCITest(unittest.TestCase):
 
     def test_limit_files_affirmative(self):
         sample_text = '\t#include <a>'
-        with open('match.cpp', 'w') as match, \
-                open('noMatch.cpp', 'w') as no_match:
+        with open('match.cpp', 'w') as match, (
+                open('noMatch.cpp', 'w')) as no_match:
             match.write(sample_text)
             no_match.write(sample_text)
         with bear_test_module():
@@ -209,8 +209,8 @@ class coalaCITest(unittest.TestCase):
                              'autofixes the code.')
 
     def test_limit_files_negative(self):
-        with bear_test_module(), \
-                prepare_file(['\t#include <a>'], None) as (lines, filename):
+        with bear_test_module(), (
+                prepare_file(['\t#include <a>'], None)) as (lines, filename):
             retval, stdout, stderr = execute_coala(
                 coala.main, 'coala', '--non-interactive',
                 '-c', os.devnull,

--- a/tests/coalaDebugFlagTest.py
+++ b/tests/coalaDebugFlagTest.py
@@ -59,9 +59,9 @@ class coalaDebugFlagTest(unittest.TestCase):
 
     def test_no_ipdb(self, mocked_mode_json):
         mocked_mode_json.side_effect = None
-        with bear_test_module(), \
-                prepare_file(['#fixme  '], None) as (lines, filename), \
-                self.pipReqIsNotInstalledMock():
+        with bear_test_module(), (
+                prepare_file(['#fixme  '], None)) as (lines, filename), (
+                self.pipReqIsNotInstalledMock()):
             # additionally use RaiseTestBear to verify independency from
             # failing bears
             status, stdout, stderr = execute_coala(
@@ -76,14 +76,14 @@ class coalaDebugFlagTest(unittest.TestCase):
     def test_bear__init__raises(self, mocked_mode_json):
         mocked_mode_json.side_effect = None
         mocked_ipdb = self.ipdbMock()
-        with bear_test_module(), \
-                prepare_file(['#fixme  '], None) as (lines, filename), \
-                self.pipReqIsInstalledMock(), \
-                patch.dict('sys.modules', ipdb=mocked_ipdb), \
+        with bear_test_module(), (
+                prepare_file(['#fixme  '], None)) as (lines, filename), (
+                self.pipReqIsInstalledMock()), (
+                patch.dict('sys.modules', ipdb=mocked_ipdb)), (
                 self.assertRaisesRegex(
                     RuntimeError,
                     r'^The bear ErrorTestBear does not fulfill all '
-                    r"requirements\. 'I_do_not_exist' is not installed\.$"):
+                    r"requirements\. 'I_do_not_exist' is not installed\.$")):
             execute_coala(
                 coala.main, 'coala', '--debug',
                 '-c', os.devnull,
@@ -95,12 +95,12 @@ class coalaDebugFlagTest(unittest.TestCase):
     def test_bear_run_raises(self, mocked_mode_json):
         mocked_mode_json.side_effect = None
         mocked_ipdb = self.ipdbMock()
-        with bear_test_module(), \
-                prepare_file(['#fixme  '], None) as (lines, filename), \
-                self.pipReqIsInstalledMock(), \
-                patch.dict('sys.modules', ipdb=mocked_ipdb), \
+        with bear_test_module(), (
+                prepare_file(['#fixme  '], None)) as (lines, filename), (
+                self.pipReqIsInstalledMock()), (
+                patch.dict('sys.modules', ipdb=mocked_ipdb)), (
                 self.assertRaisesRegex(
-                    RuntimeError, r"^That's all the RaiseTestBear can do\.$"):
+                    RuntimeError, r"^That's all the RaiseTestBear can do\.$")):
             execute_coala(
                 coala.main, 'coala', '--debug',
                 '-c', os.devnull,
@@ -112,12 +112,12 @@ class coalaDebugFlagTest(unittest.TestCase):
     def test_coala_main_mode_json_launches_ipdb(self, mocked_mode_json):
         mocked_mode_json.side_effect = RuntimeError('Mocked mode_json fails.')
         mocked_ipdb = self.ipdbMock()
-        with bear_test_module(), \
-                prepare_file(['#fixme  '], None) as (lines, filename), \
-                self.pipReqIsInstalledMock(), \
-                patch.dict('sys.modules', ipdb=mocked_ipdb), \
+        with bear_test_module(), (
+                prepare_file(['#fixme  '], None)) as (lines, filename), (
+                self.pipReqIsInstalledMock()), (
+                patch.dict('sys.modules', ipdb=mocked_ipdb)), (
                 self.assertRaisesRegex(RuntimeError,
-                                       r'^Mocked mode_json fails\.$'):
+                                       r'^Mocked mode_json fails\.$')):
             # additionally use RaiseTestBear to verify independency from
             # failing bears
             execute_coala(

--- a/tests/coalaDebugTest.py
+++ b/tests/coalaDebugTest.py
@@ -23,12 +23,12 @@ class coalaDebugTest(unittest.TestCase):
         sys.argv = self.old_argv
 
     def test_coala_main_bear__init__raises(self):
-        with bear_test_module(), \
-                prepare_file(['#fixme  '], None) as (lines, filename), \
+        with bear_test_module(), (
+                prepare_file(['#fixme  '], None)) as (lines, filename), (
                 self.assertRaisesRegex(
                     RuntimeError,
                     r'^The bear ErrorTestBear does not fulfill all '
-                    r"requirements\. 'I_do_not_exist' is not installed\.$"):
+                    r"requirements\. 'I_do_not_exist' is not installed\.$")):
             execute_coala(
                 coala.main, 'coala',
                 '-c', os.devnull,
@@ -38,12 +38,12 @@ class coalaDebugTest(unittest.TestCase):
 
     def test_run_coala_bear__init__raises(self):
         configure_logging()
-        with bear_test_module(), \
-                prepare_file(['#fixme  '], None) as (lines, filename), \
+        with bear_test_module(), (
+                prepare_file(['#fixme  '], None)) as (lines, filename), (
                 self.assertRaisesRegex(
                     RuntimeError,
                     r'^The bear ErrorTestBear does not fulfill all '
-                    r"requirements. 'I_do_not_exist' is not installed.$"):
+                    r"requirements. 'I_do_not_exist' is not installed.$")):
             run_coala(
                 console_printer=ConsolePrinter(),
                 log_printer=LogPrinter(),
@@ -55,10 +55,10 @@ class coalaDebugTest(unittest.TestCase):
                 debug=True)
 
     def test_coala_main_bear_run_raises(self):
-        with bear_test_module(), \
-                prepare_file(['#fixme  '], None) as (lines, filename), \
+        with bear_test_module(), (
+                prepare_file(['#fixme  '], None)) as (lines, filename), (
                 self.assertRaisesRegex(
-                    RuntimeError, r"^That's all the RaiseTestBear can do\.$"):
+                    RuntimeError, r"^That's all the RaiseTestBear can do\.$")):
             execute_coala(
                 coala.main, 'coala',
                 '-c', os.devnull,
@@ -68,10 +68,10 @@ class coalaDebugTest(unittest.TestCase):
 
     def test_run_coala_bear_run_raises(self):
         configure_logging()
-        with bear_test_module(), \
-                prepare_file(['#fixme  '], None) as (lines, filename), \
+        with bear_test_module(), (
+                prepare_file(['#fixme  '], None)) as (lines, filename), (
                 self.assertRaisesRegex(
-                    RuntimeError, r"^That's all the RaiseTestBear can do\.$"):
+                    RuntimeError, r"^That's all the RaiseTestBear can do\.$")):
             run_coala(
                 console_printer=ConsolePrinter(),
                 log_printer=LogPrinter(),
@@ -86,10 +86,10 @@ class coalaDebugTest(unittest.TestCase):
     def test_coala_main_mode_json_raises(self, mocked_mode_json):
         mocked_mode_json.side_effect = RuntimeError('Mocked mode_json fails.')
 
-        with bear_test_module(), \
-                prepare_file(['#fixme  '], None) as (lines, filename), \
+        with bear_test_module(), (
+                prepare_file(['#fixme  '], None)) as (lines, filename), (
                 self.assertRaisesRegex(RuntimeError,
-                                       r'^Mocked mode_json fails\.$'):
+                                       r'^Mocked mode_json fails\.$')):
             # additionally use RaiseTestBear to verify independency from
             # failing bears
             execute_coala(

--- a/tests/coalaDeleteOrigTest.py
+++ b/tests/coalaDeleteOrigTest.py
@@ -32,8 +32,8 @@ class coalaDeleteOrigTest(unittest.TestCase):
             self.assertIn("Couldn't delete", output)
 
         # Directory instead of file
-        with tempfile.TemporaryDirectory() as filename, \
-                retrieve_stderr() as stderr:
+        with tempfile.TemporaryDirectory() as filename, (
+                retrieve_stderr()) as stderr:
             mock_glob.return_value = [filename]
             retval = coala_delete_orig.main(section=self.section)
             output = stderr.getvalue()

--- a/tests/coalaFormatTest.py
+++ b/tests/coalaFormatTest.py
@@ -22,8 +22,8 @@ class coalaFormatTest(unittest.TestCase):
         self.assertIn('usage: coala', stdout)
 
     def test_line_count(self):
-        with bear_test_module(), \
-                prepare_file(['#fixme'], None) as (lines, filename):
+        with bear_test_module(), (
+                prepare_file(['#fixme'], None)) as (lines, filename):
             retval, stdout, stderr = execute_coala(coala.main, 'coala',
                                                    '--format', '-c',
                                                    os.devnull, '-f', filename,
@@ -37,8 +37,8 @@ class coalaFormatTest(unittest.TestCase):
             self.assertFalse(stderr)
 
     def test_format_ci_combination(self):
-        with bear_test_module(), \
-                prepare_file(['#fixme'], None) as (lines, filename):
+        with bear_test_module(), (
+                prepare_file(['#fixme'], None)) as (lines, filename):
             retval, stdout, stderr = execute_coala(coala.main, 'coala',
                                                    '--format', '--ci', '-c',
                                                    os.devnull, '-f', filename,

--- a/tests/coalaJSONTest.py
+++ b/tests/coalaJSONTest.py
@@ -38,8 +38,8 @@ class coalaJSONTest(unittest.TestCase):
                             'coala must return nonzero when errors occured')
 
     def test_find_issues(self):
-        with bear_test_module(), \
-                prepare_file(['#fixme'], None) as (lines, filename):
+        with bear_test_module(), (
+                prepare_file(['#fixme'], None)) as (lines, filename):
             retval, stdout, stderr = execute_coala(coala.main, 'coala',
                                                    '--json', '-c', os.devnull,
                                                    '-b', 'LineCountTestBear',

--- a/tests/coalaTest.py
+++ b/tests/coalaTest.py
@@ -29,8 +29,8 @@ class coalaTest(unittest.TestCase):
         sys.argv = self.old_argv
 
     def test_coala(self):
-        with bear_test_module(), \
-                prepare_file(['#fixme'], None) as (lines, filename):
+        with bear_test_module(), (
+                prepare_file(['#fixme'], None)) as (lines, filename):
             retval, stdout, stderr = execute_coala(
                              coala.main,
                              'coala', '-c', os.devnull,
@@ -48,10 +48,10 @@ class coalaTest(unittest.TestCase):
                                 'coala must return nonzero when errors occured')
 
     def test_coala2(self):
-        with bear_test_module(), \
-                prepare_file(['#fixme'], None) as (lines, filename):
-            with simulate_console_inputs('a', 'n') as generator, \
-                    retrieve_stdout() as sio:
+        with bear_test_module(), (
+                prepare_file(['#fixme'], None)) as (lines, filename):
+            with simulate_console_inputs('a', 'n') as generator, (
+                    retrieve_stdout()) as sio:
                 retval, stdout, stderr = execute_coala(
                                  coala.main,
                                  'coala', '-c', os.devnull,
@@ -70,10 +70,10 @@ class coalaTest(unittest.TestCase):
                                     'occured')
 
     def test_coala3(self):
-        with bear_test_module(), \
-                prepare_file(['#fixme'], None) as (lines, filename):
-            with simulate_console_inputs('1', 'n') as generator, \
-                    retrieve_stdout() as sio:
+        with bear_test_module(), (
+                prepare_file(['#fixme'], None)) as (lines, filename):
+            with simulate_console_inputs('1', 'n') as generator, (
+                    retrieve_stdout()) as sio:
                 retval, stdout, stderr = execute_coala(
                                  coala.main,
                                  'coala', '-c', os.devnull,
@@ -92,10 +92,10 @@ class coalaTest(unittest.TestCase):
                                     'occured')
 
     def test_coala4(self):
-        with bear_test_module(), \
-                prepare_file(['#fixme'], None) as (lines, filename):
-            with simulate_console_inputs('x', 'n') as generator, \
-                    retrieve_stdout() as sio:
+        with bear_test_module(), (
+                prepare_file(['#fixme'], None)) as (lines, filename):
+            with simulate_console_inputs('x', 'n') as generator, (
+                    retrieve_stdout()) as sio:
                 retval, stdout, stderr = execute_coala(
                                  coala.main,
                                  'coala', '-c', os.devnull,
@@ -114,8 +114,8 @@ class coalaTest(unittest.TestCase):
                                     'occured')
 
     def test_coala_aspect(self):
-        with bear_test_module(), \
-                prepare_file(['#fixme'], None) as (lines, filename):
+        with bear_test_module(), (
+                prepare_file(['#fixme'], None)) as (lines, filename):
             retval, stdout, stderr = execute_coala(
                              coala.main,
                              'coala', '-c', os.devnull,
@@ -241,8 +241,8 @@ class coalaTest(unittest.TestCase):
             self.assertIn('No bears to show.', stdout)
 
     def test_run_coala_no_autoapply(self, debug=False):
-        with bear_test_module(), \
-                prepare_file(['#fixme  '], None) as (lines, filename):
+        with bear_test_module(), (
+                prepare_file(['#fixme  '], None)) as (lines, filename):
             self.assertEqual(
                 1,
                 len(run_coala(
@@ -281,8 +281,8 @@ class coalaTest(unittest.TestCase):
 
     def test_logged_error_causes_non_zero_exitcode(self):
         configure_logging()
-        with bear_test_module(), \
-                prepare_file(['#fixme  '], None) as (lines, filename):
+        with bear_test_module(), (
+                prepare_file(['#fixme  '], None)) as (lines, filename):
             _, exitcode, _ = run_coala(
                 console_printer=ConsolePrinter(),
                 log_printer=LogPrinter(),
@@ -297,8 +297,8 @@ class coalaTest(unittest.TestCase):
             assert exitcode == 1
 
     def test_coala_with_color(self):
-        with bear_test_module(), \
-                prepare_file(['#fixme'], None) as (lines, filename):
+        with bear_test_module(), (
+                prepare_file(['#fixme'], None)) as (lines, filename):
             retval, stdout, stderr = execute_coala(
                 coala.main, 'coala')
             errors = filter(bool, stderr.split('\n'))
@@ -310,8 +310,8 @@ class coalaTest(unittest.TestCase):
                 retval, 0, 'coala must return zero when there are no errors')
 
     def test_coala_without_color(self):
-        with bear_test_module(), \
-                prepare_file(['#fixme'], None) as (lines, filename):
+        with bear_test_module(), (
+                prepare_file(['#fixme'], None)) as (lines, filename):
 
             retval, stdout, stderr = execute_coala(
                              coala.main, 'coala', '-N')
@@ -324,8 +324,8 @@ class coalaTest(unittest.TestCase):
                 retval, 0, 'coala must return zero when there are no errors')
 
     def test_coala_ignore_file(self):
-        with bear_test_module(), \
-                prepare_file(['#fixme'], None) as (lines, filename):
+        with bear_test_module(), (
+                prepare_file(['#fixme'], None)) as (lines, filename):
             retval, stdout, stderr = execute_coala(
                     coala.main, 'coala',
                     '-c', os.devnull,

--- a/tests/core/BearTest.py
+++ b/tests/core/BearTest.py
@@ -197,8 +197,8 @@ class BearTest(unittest.TestCase):
         filename = 'test.html'
         file_location = join(uut.data_dir, filename)
 
-        with freeze_time('2017-01-01') as frozen_datetime, \
-                requests_mock.Mocker() as reqmock:
+        with freeze_time('2017-01-01') as frozen_datetime, (
+                requests_mock.Mocker()) as reqmock:
 
             reqmock.get(mock_url, text=mock_text)
             self.assertFalse(isfile(file_location))

--- a/tests/misc/CachingTest.py
+++ b/tests/misc/CachingTest.py
@@ -100,8 +100,8 @@ class CachingTest(unittest.TestCase):
         A simple integration test to assert that results are not dropped
         when coala is ran multiple times with caching enabled.
         """
-        with bear_test_module(), \
-                prepare_file(['a=(5,6)'], None) as (lines, filename):
+        with bear_test_module(), (
+                prepare_file(['a=(5,6)'], None)) as (lines, filename):
             with simulate_console_inputs('n'):
                 retval, stdout, stderr = execute_coala(
                     coala.main,

--- a/tests/output/ConsoleInteractionTest.py
+++ b/tests/output/ConsoleInteractionTest.py
@@ -30,8 +30,8 @@ from coalib.results.Result import Result
 from coalib.results.result_actions.ApplyPatchAction import ApplyPatchAction
 from coalib.results.result_actions.OpenEditorAction import OpenEditorAction
 from coalib.results.result_actions.DoNothingAction import DoNothingAction
-from coalib.results.result_actions.ShowAppliedPatchesAction \
-    import ShowAppliedPatchesAction
+from coalib.results.result_actions.ShowAppliedPatchesAction import (
+    ShowAppliedPatchesAction)
 from coalib.results.result_actions.GeneratePatchesAction import (
     GeneratePatchesAction)
 from coalib.results.result_actions.ResultAction import ResultAction
@@ -361,8 +361,8 @@ class ConsoleInteractionTest(unittest.TestCase):
             self.assertEqual(generator.last_input, 4)
 
     def test_print_affected_files(self):
-        with retrieve_stdout() as stdout, \
-                make_temp() as some_file:
+        with retrieve_stdout() as stdout, (
+                make_temp()) as some_file:
             file_dict = {some_file: ['1\n', '2\n', '3\n']}
             affected_code = (SourceRange.from_values(some_file),)
             print_affected_files(self.console_printer,
@@ -379,8 +379,8 @@ class ConsoleInteractionTest(unittest.TestCase):
             diff = Diff(file_dict[testfile_path])
             diff.delete_line(2)
             diff.change_line(3, '3\n', '3_changed\n')
-            with simulate_console_inputs('a', 'n') as generator, \
-                    retrieve_stdout() as sio:
+            with simulate_console_inputs('a', 'n') as generator, (
+                    retrieve_stdout()) as sio:
                 ApplyPatchAction.is_applicable = staticmethod(
                     lambda *args: True)
                 acquire_actions_and_apply(self.console_printer,
@@ -404,8 +404,8 @@ class ConsoleInteractionTest(unittest.TestCase):
             ApplyPatchAction.is_applicable = staticmethod(lambda *args: True)
             cli_actions = [ApplyPatchAction(), InvalidateTestAction()]
 
-            with simulate_console_inputs('a', 'o', 'n') as generator, \
-                    retrieve_stdout() as sio:
+            with simulate_console_inputs('a', 'o', 'n') as generator, (
+                    retrieve_stdout()) as sio:
                 acquire_actions_and_apply(self.console_printer,
                                           Section(''),
                                           self.file_diff_dict,
@@ -429,8 +429,8 @@ class ConsoleInteractionTest(unittest.TestCase):
             diff = Diff(file_dict[testfile_path])
             diff.delete_line(2)
             diff.change_line(3, '3\n', '3_changed\n')
-            with simulate_console_inputs('a', 'n') as generator, \
-                    retrieve_stdout() as sio:
+            with simulate_console_inputs('a', 'n') as generator, (
+                    retrieve_stdout()) as sio:
                 ApplyPatchAction.is_applicable = staticmethod(
                     lambda *args: True)
                 acquire_actions_and_apply(self.console_printer,
@@ -454,8 +454,8 @@ class ConsoleInteractionTest(unittest.TestCase):
             ApplyPatchAction.is_applicable = staticmethod(lambda *args: True)
             cli_actions = [ApplyPatchAction(), InvalidateTestAction()]
 
-            with simulate_console_inputs('a') as generator, \
-                    retrieve_stdout() as sio:
+            with simulate_console_inputs('a') as generator, (
+                    retrieve_stdout()) as sio:
                 acquire_actions_and_apply(self.console_printer,
                                           Section(''),
                                           self.file_diff_dict,
@@ -604,8 +604,8 @@ class ConsoleInteractionTest(unittest.TestCase):
             diff = Diff(file_dict[testfile_path])
             diff.delete_line(2)
             diff.change_line(3, '3\n', '3_changed\n')
-            with simulate_console_inputs(1, 2, 3) as generator, \
-                    retrieve_stdout() as stdout:
+            with simulate_console_inputs(1, 2, 3) as generator, (
+                    retrieve_stdout()) as stdout:
                 ApplyPatchAction.is_applicable = staticmethod(
                     lambda *args: True)
                 print_results_no_input(self.log_printer,

--- a/tests/parsing/CliParsingTest.py
+++ b/tests/parsing/CliParsingTest.py
@@ -71,3 +71,8 @@ class CliParserTest(unittest.TestCase):
         with self.assertRaisesRegex(SystemExit, '2') as cm:
             check_conflicts(sections)
             self.assertEqual(cm.exception.code, 2)
+
+        sections = parse_cli(arg_list=['--no-config', '--config', '.coafile'])
+        with self.assertRaisesRegex(SystemExit, '2') as cm:
+            check_conflicts(sections)
+            self.assertEqual(cm.exception.code, 2)

--- a/tests/parsing/CliParsingTest.py
+++ b/tests/parsing/CliParsingTest.py
@@ -71,8 +71,3 @@ class CliParserTest(unittest.TestCase):
         with self.assertRaisesRegex(SystemExit, '2') as cm:
             check_conflicts(sections)
             self.assertEqual(cm.exception.code, 2)
-
-        sections = parse_cli(arg_list=['--no-config', '--config', '.coafile'])
-        with self.assertRaisesRegex(SystemExit, '2') as cm:
-            check_conflicts(sections)
-            self.assertEqual(cm.exception.code, 2)

--- a/tests/results/result_actions/ShowAppliedPatchesActionTest.py
+++ b/tests/results/result_actions/ShowAppliedPatchesActionTest.py
@@ -3,8 +3,8 @@ import unittest
 from coala_utils.ContextManagers import make_temp
 from coalib.results.Diff import Diff
 from coalib.results.Result import Result
-from coalib.results.result_actions.ShowAppliedPatchesAction import \
-    ShowAppliedPatchesAction
+from coalib.results.result_actions.ShowAppliedPatchesAction import (
+    ShowAppliedPatchesAction)
 from coalib.settings.Section import Section
 from coala_utils.ContextManagers import (
     make_temp, retrieve_stdout, simulate_console_inputs)

--- a/tests/settings/ConfigurationGatheringTest.py
+++ b/tests/settings/ConfigurationGatheringTest.py
@@ -317,8 +317,8 @@ class ConfigurationGatheringTest(unittest.TestCase):
         test_dir = os.path.join(current_dir, 'section_manager_test_files')
         logger = logging.getLogger()
 
-        with change_directory(test_dir), \
-                self.assertLogs(logger, 'WARNING') as cm:
+        with change_directory(test_dir), (
+                self.assertLogs(logger, 'WARNING')) as cm:
             sections, _, _, _ = gather_configuration(
                 lambda *args: True,
                 self.log_printer,

--- a/tests/test_bears/internal_folder/DependentBear.py
+++ b/tests/test_bears/internal_folder/DependentBear.py
@@ -1,6 +1,6 @@
 from coalib.bears.LocalBear import LocalBear
-from tests.test_bears.internal_folder.SpaceConsistencyTestBear import \
-    SpaceConsistencyTestBear
+from tests.test_bears.internal_folder.SpaceConsistencyTestBear import (
+    SpaceConsistencyTestBear)
 
 
 class DependentBear(LocalBear):


### PR DESCRIPTION
Removes all use of line continuation in python files and bans it in .coafile, python section, using KeywordBear.
    
Closes https://github.com/coala/coala/issues/4552
<!--
Thanks for your contribution!

Please take a quick look at those things down there. They're quite important.
Really! We wrote them for you. Yes you! With utmost care. Read them.
-->

**For short term contributors:** we understand that getting your commits well
defined like we require is a hard task and takes some learning. If you
look to help without wanting to contribute long term there's no need
for you to learn this. Just drop us a message and we'll take care of brushing
up your stuff for merge!

### Checklist

- [ ] I read the [commit guidelines](http://coala.io/commit) and I've followed
      them.
- [ ] I ran coala over my code locally. (*All commits have to pass
      individually.* It is not sufficient to have "fixup commits" on your PR,
      our bot will still report the issues for the previous commit.) You will
      likely receive a lot of bot comments and build failures if coala does not
      pass on every single commit!

After you submit your pull request, **DO NOT click the 'Update Branch' button.**
When asked for a rebase, consult [coala.io/rebase](https://coala.io/rebase)
instead.

Please consider helping us by reviewing other peoples pull requests as well:

- pick up any PR at <https://coala.io/review>
- review it (check <https://coala.io/reviewing> for more info)
- if you are sure that it needs work, use `corobo mark wip <URL>` to get it out
  of the review queue.

The more you review, the more your score will grow at coala.io and we will
review your PRs faster!
