### PR TITLE
aspects: Create `map_ambiguous_setting_to_aspect`

### DIFF
--- a/coalib/bearlib/aspects/__init__.py
+++ b/coalib/bearlib/aspects/__init__.py
@@ -6,7 +6,10 @@ from pkgutil import iter_modules
 from types import ModuleType
 
 from .base import aspectbase
-from .decorators import map_setting_to_aspect
+from .decorators import (
+    map_setting_to_aspect,
+    map_ambiguous_setting_to_aspect,
+)
 from .exceptions import (AspectTypeError, AspectNotFoundError,
                          MultipleAspectFoundError)
 from .meta import aspectclass
@@ -23,6 +26,7 @@ __all__ = ['Root', 'Taste', 'TasteError',
            'aspectclass', 'aspectbase', 'AspectTypeError',
            'AspectNotFoundError', 'MultipleAspectFoundError',
            'AspectList', 'map_setting_to_aspect',
+           'map_ambiguous_setting_to_aspect',
            ]
 
 

--- a/coalib/bearlib/aspects/decorators.py
+++ b/coalib/bearlib/aspects/decorators.py
@@ -49,3 +49,56 @@ def map_setting_to_aspect(**aspectable_setting):
         return _new_func
 
     return _func_decorator
+
+
+def map_ambiguous_setting_to_aspect(**aspectable_settings):
+    """
+    Convert bear settings to use aspects in which there is some ambiguity.
+
+    The ambiguity is because of differing values (maybe either name or even
+    data-types) in bear settings and their corresponding aspect tastes.
+
+    This decorator is used by ``Bear.run()`` to automatically map and
+    override the value in the bear setting with their equivalent taste
+    as provided in the parameter.
+
+    The order of setting override from the highest to lowest is:
+    - Explicit setting
+    - Explicit aspect/taste default (if aspect is activated in Section)
+    - Aspect/taste default (if aspect is activated in Section)
+    - Setting default (in bear's run argument)
+
+    :param aspectable_settings:
+        A dictionary in which keys are the bear settings and the corresponding
+        value for each key is a tuple containing an equivalent taste as first
+        value and a list of tuples with matching bear settings' and aspects'
+        value as the second value.
+    """
+    def _func_decorator(func):
+        @wraps(func)
+        def _new_func(self, *args, **kwargs):
+            if not self.section.aspects:
+                return func(self, *args, **kwargs)
+
+            aspects = self.section.aspects
+            for arg, aspect_value in aspectable_settings.items():
+                # Explicit bear setting takes priority over aspects
+                if arg in self.section:
+                    continue
+
+                taste, aspect_settings = aspect_value
+                aspect_instance = aspects.get(taste.aspect_name)
+                if aspect_instance:
+                    value = aspect_instance.tastes[taste.name]
+                    for value_pair in aspect_value[1]:
+                        if value_pair[0] == value:
+                            kwargs[arg] = value_pair[1]
+
+            return func(self, *args, **kwargs)
+
+        # Keep metadata
+        _new_func.__metadata__ = FunctionMetadata.from_function(func)
+
+        return _new_func
+
+    return _func_decorator

--- a/tests/bearlib/aspects/DecoratorsTest.py
+++ b/tests/bearlib/aspects/DecoratorsTest.py
@@ -4,6 +4,7 @@ from coalib.bearlib.aspects import (
     AspectList,
     get as get_aspect,
     map_setting_to_aspect,
+    map_ambiguous_setting_to_aspect,
 )
 from coalib.bears.LocalBear import LocalBear
 from coalib.settings.Section import Section
@@ -16,14 +17,27 @@ class RunDecoratedBear(LocalBear):
         remove_unreachable_code=get_aspect('UnreachableCode'),
         minimum_clone_tokens=get_aspect('Clone').min_clone_tokens,
     )
+    @map_ambiguous_setting_to_aspect(
+        use_spaces=(get_aspect('Indentation').indent_type,
+                    [('space', True), ('tab', False)]),
+    )
     def run(self,
             remove_unreachable_code: bool = False,
             minimum_clone_tokens: int = 10,
+            use_spaces: bool = True,
             ):
-        return [remove_unreachable_code, minimum_clone_tokens]
+        return [('remove_unreachable_code', remove_unreachable_code),
+                ('minimum_clone_tokens', minimum_clone_tokens),
+                ('use_spaces', use_spaces),
+                ]
 
 
 class MapSettingToAspectTest(unittest.TestCase):
+
+    EXPECTED = {'remove_unreachable_code': False,
+                'minimum_clone_tokens': 10,
+                'use_spaces': True,
+                }
 
     def setUp(self):
         self.section = Section('aspect section')
@@ -35,7 +49,10 @@ class MapSettingToAspectTest(unittest.TestCase):
             get_aspect('Clone')('py', min_clone_tokens=30),
         ])
         result = self.bear.execute()
-        self.assertEqual([True, 30], result)
+        expected = self.EXPECTED.copy()
+        expected['remove_unreachable_code'] = True
+        expected['minimum_clone_tokens'] = 30
+        self.assertEqual(expected, dict(result))
 
     def test_setting_priority(self):
         self.section.aspects = AspectList([
@@ -47,21 +64,57 @@ class MapSettingToAspectTest(unittest.TestCase):
         self.section.append(
             Setting('minimum_clone_tokens', 40))
         result = self.bear.execute()
-        self.assertEqual([False, 40], result)
+        expected = self.EXPECTED.copy()
+        expected['minimum_clone_tokens'] = 40
+        self.assertEqual(expected, dict(result))
 
     def test_partial_mapping(self):
         self.section.aspects = AspectList([
             get_aspect('UnreachableCode')('py'),
         ])
         result = self.bear.execute()
-        self.assertEqual([True, 10], result)
+        expected = self.EXPECTED.copy()
+        expected['remove_unreachable_code'] = True
+        self.assertEqual(expected, dict(result))
 
     def test_no_mapping(self):
         self.section.aspects = AspectList([])
         result = self.bear.execute()
-        self.assertEqual([False, 10], result)
+        expected = self.EXPECTED.copy()
+        self.assertEqual(expected, dict(result))
 
     def test_skip_mapping(self):
         self.section.aspects = None
         result = self.bear.execute()
-        self.assertEqual([False, 10], result)
+        expected = self.EXPECTED.copy()
+        self.assertEqual(expected, dict(result))
+
+
+class MapAmbiguousSettingToAspectTest(unittest.TestCase):
+
+    EXPECTED = {'remove_unreachable_code': False,
+                'minimum_clone_tokens': 10,
+                'use_spaces': True,
+                }
+
+    def setUp(self):
+        self.section = Section('aspect section')
+        self.bear = RunDecoratedBear(self.section, None)
+
+    def test_mapping(self):
+        self.section.aspects = AspectList([
+            get_aspect('Indentation')('py', indent_type='tab'),
+        ])
+        result = self.bear.execute()
+        expected = self.EXPECTED.copy()
+        expected['use_spaces'] = False
+        self.assertEqual(expected, dict(result))
+
+    def test_setting_priority(self):
+        self.section.aspects = AspectList([
+            get_aspect('Indentation')('py', indent_type='tab'),
+        ])
+        self.section.append(Setting('use_spaces', True))
+        result = self.bear.execute()
+        expected = self.EXPECTED.copy()
+        self.assertEqual(expected, dict(result))


### PR DESCRIPTION
Create decorator `map_ambiguous_setting_to_aspect` for
mapping bear settings to aspects in cases where data_types
and values are different in bear settings and aspects.
A typical example is `use_spaces` (bear setting) and
`indent_type` (taste of `Indentation` aspect).

This is part of `Convert Bear To Aspects` GSoC 2018 project.

<!--
Thanks for your contribution!

Please take a quick look at those things down there. They're quite important.
Really! We wrote them for you. Yes you! With utmost care. Read them.
-->

**For short term contributors:** we understand that getting your commits well
defined like we require is a hard task and takes some learning. If you
look to help without wanting to contribute long term there's no need
for you to learn this. Just drop us a message and we'll take care of brushing
up your stuff for merge!

### Checklist

- [x] I read the [commit guidelines](http://coala.io/commit) and I've followed
      them.
- [x] I ran coala over my code locally. (*All commits have to pass
      individually.* It is not sufficient to have "fixup commits" on your PR,
      our bot will still report the issues for the previous commit.) You will
      likely receive a lot of bot comments and build failures if coala does not
      pass on every single commit!

After you submit your pull request, **DO NOT click the 'Update Branch' button.**
When asked for a rebase, consult [coala.io/rebase](https://coala.io/rebase)
instead.

Please consider helping us by reviewing other peoples pull requests as well:

- pick up any PR at <https://coala.io/review>
- review it (check <https://coala.io/reviewing> for more info)
- if you are sure that it needs work, use `corobo mark wip <URL>` to get it out
  of the review queue.

The more you review, the more your score will grow at coala.io and we will
review your PRs faster!
