### PR TITLE
Shell: Use sys.executable in doctest

### DIFF
--- a/coalib/misc/Shell.py
+++ b/coalib/misc/Shell.py
@@ -15,7 +15,8 @@ class ShellCommandResult(tuple):
 
     It additionally stores the return ``.code``:
 
-    >>> process = Popen(['python', '-c',
+    >>> import sys
+    >>> process = Popen([sys.executable, '-c',
     ...                  'import sys; print(sys.stdin.readline().strip() +'
     ...                  '                  " processed")'],
     ...                 stdin=PIPE, stdout=PIPE, stderr=PIPE,


### PR DESCRIPTION
... instead of python which is not availabe on Linux systems without
having Python 2 installed (Python 3 is called python3 on command
line). Now Python 2 is not necessary for the modified doctest
to execute.