### PR TITLE
BaseTestHelper.py: Add `BaseTestHelper` class

### DIFF
--- a/coalib/testing/BaseTestHelper.py
+++ b/coalib/testing/BaseTestHelper.py
@@ -1,0 +1,54 @@
+from coala_utils.Comparable import Comparable
+
+
+def _assert_comparable_equal(observed_result, expected_result):
+    """
+    Compares individual fields of the result objects using
+    `__compare_fields__` of `coala_utils.Comparable` class
+    and yields messages in case of an attribute mismatch.
+    """
+
+    if not len(observed_result) == len(expected_result):
+        assert observed_result == expected_result, '%s != %s' % (
+            observed_result, expected_result)
+
+    messages = ''
+    for observed, expected in zip(observed_result, expected_result):
+        if (isinstance(observed, Comparable) and
+            isinstance(expected, Comparable)) and (type(observed) is
+                                                   type(expected)):
+            for attribute in type(observed).__compare_fields__:
+                try:
+                    assert getattr(observed, attribute) == getattr(
+                        expected, attribute), (
+                        '{} mismatch: {}, {} != {}, {}'.format(
+                            attribute,
+                            observed.origin, observed.message,
+                            expected.origin, expected.message))
+                except AssertionError as ex:
+                    messages += (str(ex) + '\n\n')
+        else:
+            assert observed_result == expected_result, '%s != %s' % (
+                observed_result, expected_result)
+
+    if messages:
+        raise AssertionError(messages)
+
+
+class BaseTestHelper:
+    """
+    This is a base class for all Bears' tests of coala's testing API.
+    """
+
+    def assert_result_equal(self,
+                            observed_result,
+                            expected_result):
+        """
+        Asserts that an observed result from a bear is exactly same
+        as the expected result from the bear.
+
+        :param observed_result: The observed result from a bear
+        :param expected_result: The expected result from a bear
+        """
+
+        return _assert_comparable_equal(observed_result, expected_result)

--- a/tests/testing/BaseTestHelperTest.py
+++ b/tests/testing/BaseTestHelperTest.py
@@ -1,0 +1,31 @@
+import pytest
+
+from coalib.results.Result import Result
+from coalib.testing.BaseTestHelper import BaseTestHelper
+
+
+class BaseTestHelperTest(BaseTestHelper):
+    def test_good_assert_result_equal(self):
+        self.assert_result_equal(['a', 'b'], ['a', 'b'])
+
+    def test_inequality_assert_result_equal(self):
+        with pytest.raises(AssertionError) as ex:
+            self.assert_result_equal(['a', 'b'], ['a', 'b', None])
+        assert '[\'a\', \'b\'] != [\'a\', \'b\', None]' in str(ex.value)
+
+    def test_not_comparable_assert_result_equal(self):
+        with pytest.raises(AssertionError) as ex:
+            self.assert_result_equal(['a', 'b'], ['a', 'c'])
+        assert '[\'a\', \'b\'] != [\'a\', \'c\']' in str(ex.value)
+
+    def test_comparable_assert_result_equal(self):
+        expected = [Result.from_values(origin='AnyBea',
+                                       message='This file has 2 lines.',
+                                       file='anyfile')]
+        observed = [Result.from_values(origin='AnyBear',
+                                       message='This file has 2 lines.',
+                                       file='anyfile')]
+        with pytest.raises(AssertionError) as ex:
+            self.assert_result_equal(expected, observed)
+        assert ('origin mismatch: AnyBea, This file has 2 lines. != AnyBear, '
+                'This file has 2 lines.\n\n') == str(ex.value)


### PR DESCRIPTION
`observed_result` is result generated from a bear and `expected_result` is tester's expected result from the bears.

Related to https://gitlab.com/coala/GSoC/GSoC-2018/issues/307
Closes https://github.com/coala/coala/issues/3676