### PR TITLE
language: Add `string_delimiter_escape` to language definitions

### DIFF
--- a/coalib/bearlib/languages/definitions/C.py
+++ b/coalib/bearlib/languages/definitions/C.py
@@ -19,3 +19,4 @@ class C:
         '#undef', '#ifdef', '#ifndef', '#if', '#endif', '#else', '#elif',
         '#line', '#pragma']
     special_chars = list(r'+-*/.;\,()[]{}\=<>|&^~?%!')
+    string_delimiter_escape = {'"': '\\"'}

--- a/coalib/bearlib/languages/definitions/CPP.py
+++ b/coalib/bearlib/languages/definitions/CPP.py
@@ -29,3 +29,4 @@ class CPP:
         'while', 'xor', 'xor_eq', '#include', '#define', '#undef', '#ifdef',
         '#ifndef', '#if', '#endif', '#else', '#elif', '#line', '#pragma']
     special_chars = list(r'+-*/.;\,()[]{}\=<>|&^~?%!')
+    string_delimiter_escape = {'"': '\\"'}

--- a/coalib/bearlib/languages/definitions/CSS.py
+++ b/coalib/bearlib/languages/definitions/CSS.py
@@ -9,3 +9,4 @@ class CSS:
     multiline_string_delimiters = {}
     indent_types = {'{': '}'}
     encapsulators = {'(': ')', '[': ']'}
+    string_delimiter_escape = {'"': '\\"', "'": "\\'"}

--- a/coalib/bearlib/languages/definitions/CSharp.py
+++ b/coalib/bearlib/languages/definitions/CSharp.py
@@ -9,3 +9,4 @@ class CSharp:
     comment_delimiters = '//',
     multiline_comment_delimiters = {'/*': '*/'}
     string_delimiters = {'"': '"'}
+    string_delimiter_escape = {'"': '\\"'}

--- a/coalib/bearlib/languages/definitions/Fortran.py
+++ b/coalib/bearlib/languages/definitions/Fortran.py
@@ -5,3 +5,4 @@ from coalib.bearlib.languages.Language import Language
 class Fortran:
     extensions = '.f90', '.f95', '.f03', '.f', '.for'
     comment_delimiters = '!',
+    string_delimiter_escape = {'"': '""', "'": "''"}

--- a/coalib/bearlib/languages/definitions/Golang.py
+++ b/coalib/bearlib/languages/definitions/Golang.py
@@ -11,3 +11,4 @@ class Golang:
     multiline_string_delimiters = {'`': '`'}
     indent_types = {'{': '}'}
     encapsulators = {'(': ')', '[': ']'}
+    string_delimiter_escape = {'"': '\\"'}

--- a/coalib/bearlib/languages/definitions/Java.py
+++ b/coalib/bearlib/languages/definitions/Java.py
@@ -10,3 +10,4 @@ class Java:
     multiline_string_delimiters = {}
     indent_types = {'{': '}'}
     encapsulators = {'(': ')', '[': ']'}
+    string_delimiter_escape = {'"': '\\"'}

--- a/coalib/bearlib/languages/definitions/JavaScript.py
+++ b/coalib/bearlib/languages/definitions/JavaScript.py
@@ -11,3 +11,4 @@ class JavaScript:
     multiline_string_delimiters = {}
     indent_types = {'{': '}'}
     encapsulators = {'(': ')', '[': ']'}
+    string_delimiter_escape = {'"': '\\"', "'": "\\'"}

--- a/coalib/bearlib/languages/definitions/Python.py
+++ b/coalib/bearlib/languages/definitions/Python.py
@@ -13,3 +13,4 @@ class Python:
     multiline_string_delimiters = {'"""': '"""', "'''": "'''"}
     indent_types = ':',
     encapsulators = {'(': ')', '[': ']', '{': '}'}
+    string_delimiter_escape = {'"': '\\"', "'": "\\'"}

--- a/coalib/bearlib/languages/definitions/Tcl.py
+++ b/coalib/bearlib/languages/definitions/Tcl.py
@@ -8,3 +8,4 @@ class Tcl:
     string_delimiters = {'"': '"'}
     multiline_string_delimiters = {'"': '"'}
     encapsulators = {'(': ')', '[': ']', '{': '}'}
+    string_delimiter_escape = {'"': '\\"'}

--- a/coalib/bearlib/languages/definitions/VisualBasic.py
+++ b/coalib/bearlib/languages/definitions/VisualBasic.py
@@ -11,3 +11,4 @@ class VisualBasic:
     multiline_string_delimiters = string_delimiters
     encapsulators = {'(': ')', '{': '}'}
     max_line_length = 65535
+    string_delimiter_escape = {'"': '""'}

--- a/coalib/bearlib/languages/definitions/__init__.py
+++ b/coalib/bearlib/languages/definitions/__init__.py
@@ -14,5 +14,23 @@ Currently defined keys are:
   multiline_string_delimiters
   keywords
   special_chars
+  string_delimiter_escape
   max_line_length
+
+When using quoting, if one wishes to represent the delimiter itself
+in a string literal, one runs into the problem of `delimiter collision`.
+
+For example, one cannot simply represent a statement like
+`"This is "in quotes", but invalid."`.
+In some languages, you can use `escape sequences` like
+`"This is \"in quotes\" and properly escaped."` and in some others,
+`doubling up` like `"This is ""in quotes"" and properly escaped."`
+is used but there are many other solutions, depending mainly
+on the language preference. All these result in the same thing
+that is escaping of the quotation marks or the delimiters,
+so these are collectively known as `string_delimiter_escape`.
+
+More information regarding delimiter collision and
+escaping delimiter solutions can be found here at
+https://en.wikipedia.org/wiki/String_literal#Delimiter_collision.
 """


### PR DESCRIPTION
This adds characters used to escape delimiters/quotes
for each language in their respective language
definitions.

This is part of `Convert Bear To Aspects` GSoC project.

<!--
Thanks for your contribution!

Please take a quick look at those things down there. They're quite important.
Really! We wrote them for you. Yes you! With utmost care. Read them.
-->

**For short term contributors:** we understand that getting your commits well
defined like we require is a hard task and takes some learning. If you
look to help without wanting to contribute long term there's no need
for you to learn this. Just drop us a message and we'll take care of brushing
up your stuff for merge!

### Checklist

- [x] I read the [commit guidelines](http://coala.io/commit) and I've followed
      them.
- [x] I ran coala over my code locally. (*All commits have to pass
      individually.* It is not sufficient to have "fixup commits" on your PR,
      our bot will still report the issues for the previous commit.) You will
      likely receive a lot of bot comments and build failures if coala does not
      pass on every single commit!

After you submit your pull request, **DO NOT click the 'Update Branch' button.**
When asked for a rebase, consult [coala.io/rebase](https://coala.io/rebase)
instead.

Please consider helping us by reviewing other peoples pull requests as well:

- pick up any PR at <https://coala.io/review>
- review it (check <https://coala.io/reviewing> for more info)
- if you are sure that it needs work, use `corobo mark wip <URL>` to get it out
  of the review queue.

The more you review, the more your score will grow at coala.io and we will
review your PRs faster!
