### PR TITLE
Add decorator add_value_checks

### DIFF
--- a/coalib/bearlib/type_annotations/Annotations.py
+++ b/coalib/bearlib/type_annotations/Annotations.py
@@ -1,0 +1,42 @@
+import inspect
+from functools import wraps
+
+from coalib.settings.FunctionMetadata import FunctionMetadata
+# The following ignore is added since the source code of some
+# bears use type_list as type annotations to arguments.
+# ignore PyUnusedCodeBear
+from coalib.settings.Setting import typed_list
+
+
+def add_value_checks(*settings):
+    """
+    Decorator for bears that checks a bear setting against a list
+    of acceptable values.
+
+    :param settings:
+        A list of tuples containing bear setting as a string, and
+        a list of acceptable values as the second value to the tuple.
+    """
+    def wrapping_function(func):
+        @wraps(func)
+        def wrapper(*args, **kwargs):
+            args[0].ACCEPTABLE_VALUES_FOR_SETTINGS = settings[0]
+            if hasattr(args[0], 'CALL_TO_POPULATE') and (
+                    args[0].CALL_TO_POPULATE is True):
+                return
+            code = inspect.getsource(func)
+            hoax_code = code[code.find('def'):code.find('):')+3].strip()
+            hoax_code += '\n\treturn inspect.currentframe()\n'
+            hoax_code = hoax_code.replace(func.__name__, 'hoax_method', 1)
+            exec(hoax_code, globals(), globals())
+            frame = hoax_method(*args, **kwargs)
+            arguments, _, _, values = inspect.getargvalues(frame)
+            for setting_name, acceptable_values in settings[0]:
+                if values[setting_name] not in acceptable_values:
+                    raise ValueError('Invalid value "%s" given to the bear'
+                                     ' setting "%s"' % (values[setting_name],
+                                                        setting_name))
+        new_metadata = FunctionMetadata.from_function(func)
+        wrapper.__metadata__ = new_metadata
+        return wrapper
+    return wrapping_function

--- a/tests/TestUtilities.py
+++ b/tests/TestUtilities.py
@@ -5,10 +5,11 @@ import unittest.mock
 
 from coala_utils.ContextManagers import retrieve_stdout, retrieve_stderr
 
-TEST_BEARS_COUNT = 14
+TEST_BEARS_COUNT = 15
 
 # This list is sorted by filename of the bears, then name within the modules
 TEST_BEAR_NAMES = [
+    "<class 'AnnotationsTestBear.AnnotationsTestBear'>",
     "<class 'AspectTestBear.AspectTestBear'>",
     "<ErrorTestBear linter class (wrapping 'I_do_not_exist')>",
     "<class 'JavaTestBear.JavaTestBear'>",

--- a/tests/bearlib/type_annotations/AnnotationsTest.py
+++ b/tests/bearlib/type_annotations/AnnotationsTest.py
@@ -1,0 +1,56 @@
+import unittest
+from coalib.settings.Section import Section
+from tests.test_bears.AnnotationsTestBear import (
+    AnnotationsTestBear)
+
+
+class AnnotationsTest(unittest.TestCase):
+    def setUp(self):
+        self.section = Section('new_section')
+        self.bear = AnnotationsTestBear(self.section, None)
+        self.acceptable_values = [
+            ('number', [3, 4]), ('fruit', ['mango', 'banana']),
+            ('d', [5, 6, 'pineapple'])]
+
+    def test_add_value_checks_1(self):
+        with self.assertRaises(ValueError,
+                               msg='Invalid value "pineapple"'
+                                   'given to the bear setting "fruit"'):
+            self.bear.run(3, 'pineapple')
+        self.assertEqual(self.bear.ACCEPTABLE_VALUES_FOR_SETTINGS,
+                         self.acceptable_values)
+
+    def test_add_value_checks_2(self):
+        with self.assertRaises(ValueError,
+                               msg='Invalid value "5" given to'
+                                   'the bear setting "number"'):
+            self.bear.run(5, 'mango')
+        self.assertEqual(self.bear.ACCEPTABLE_VALUES_FOR_SETTINGS,
+                         self.acceptable_values)
+
+    def test_add_value_checks_3(self):
+        with self.assertRaises(ValueError,
+                               msg='Invalid value "5" given to'
+                                   'the bear setting "number"'):
+            self.bear.run(5, 'pineapple')
+        self.assertEqual(self.bear.ACCEPTABLE_VALUES_FOR_SETTINGS,
+                         self.acceptable_values)
+
+    def test_add_value_checks_4(self):
+        with self.assertRaises(ValueError,
+                               msg='Invalid value "4" given to the'
+                                   'bear setting "d"'):
+            self.bear.run(3, 'mango', 'anything', 4)
+        self.assertEqual(self.bear.ACCEPTABLE_VALUES_FOR_SETTINGS,
+                         self.acceptable_values)
+
+    def test_Add_value_checks_5(self):
+        self.bear.run(3, 'mango')
+        self.assertEqual(self.bear.ACCEPTABLE_VALUES_FOR_SETTINGS,
+                         self.acceptable_values)
+
+    def test_CALL_FROM_QUICKSTART(self):
+        self.bear.CALL_TO_POPULATE = True
+        self.bear.run(3, 'pineapple')  # invalid value to bear setting
+        self.assertEqual(self.bear.ACCEPTABLE_VALUES_FOR_SETTINGS,
+                         self.acceptable_values)

--- a/tests/coalaJSONTest.py
+++ b/tests/coalaJSONTest.py
@@ -77,7 +77,8 @@ class coalaJSONTest(unittest.TestCase):
             self.assertEqual(len(output['bears']), TEST_BEARS_COUNT)
             self.assertFalse(stderr)
             self.assertEqual(output,
-                             {'bears': ['AspectTestBear',
+                             {'bears': ['AnnotationsTestBear',
+                                        'AspectTestBear',
                                         'DependentBear',
                                         'EchoBear',
                                         'ErrorTestBear',

--- a/tests/collecting/CollectorsTest.py
+++ b/tests/collecting/CollectorsTest.py
@@ -400,7 +400,8 @@ class CollectorsTests(unittest.TestCase):
                  'TestDepBearCDependsB',
                  'TestDepBearAA',
                  'AspectTestBear',
-                 'TestDepBearDependsAAndAA'})
+                 'TestDepBearDependsAAndAA',
+                 'AnnotationsTestBear'})
 
     def test_get_all_bears_names(self):
         with bear_test_module():
@@ -421,4 +422,5 @@ class CollectorsTests(unittest.TestCase):
                  'TestDepBearCDependsB',
                  'TestDepBearAA',
                  'AspectTestBear',
-                 'TestDepBearDependsAAndAA'})
+                 'TestDepBearDependsAAndAA',
+                 'AnnotationsTestBear'})

--- a/tests/test_bears/AnnotationsTestBear.py
+++ b/tests/test_bears/AnnotationsTestBear.py
@@ -1,0 +1,12 @@
+from coalib.bearlib.type_annotations.Annotations import (
+    add_value_checks)
+from coalib.bears.LocalBear import LocalBear
+
+
+class AnnotationsTestBear(LocalBear):
+    @add_value_checks(
+        [('number', [3, 4]),
+         ('fruit', ['mango', 'banana']),
+         ('d', [5, 6, 'pineapple'])])
+    def run(self, number, fruit, c=True, d=5):
+        pass


### PR DESCRIPTION
The decorator may work on any function but made for the
specific use of the bears' `run()` methods or the
`create_arguments()` methods. This decorator compares the value
given to the bear setting against a list of acceptable values
provided by the bear writer. The decorator accepts a list of
tuples with each tuple containing two values, the bear setting
name as a string and a list of acceptable values.
