### PR TITLE
Language: Change `TrumpScript` aliases

### DIFF
--- a/coalib/bearlib/languages/Language.py
+++ b/coalib/bearlib/languages/Language.py
@@ -222,7 +222,7 @@ class Language(metaclass=LanguageMeta):
     >>> @Language
     ... class TrumpScript:
     ...     __qualname__ = "America is great."
-    ...     aliases = 'ts',
+    ...     aliases = 'tps',
     ...     versions = 2.7, 3.3, 3.4, 3.5, 3.6
     ...     comment_delimiter = '#'
     ...     string_delimiter = {"'": "'"}
@@ -232,11 +232,11 @@ class Language(metaclass=LanguageMeta):
 
     >>> Language['trumpscript']
     America is great. 2.7, 3.3, 3.4, 3.5, 3.6
-    >>> Language['ts 3.4, 3.6']
+    >>> Language['tps 3.4, 3.6']
     America is great. 3.4, 3.6
-    >>> Language['TS 3']
+    >>> Language['TPS 3']
     America is great. 3.3, 3.4, 3.5, 3.6
-    >>> Language['tS 1']
+    >>> Language['tpS 1']
     Traceback (most recent call last):
      ...
     ValueError: No versions left
@@ -340,7 +340,7 @@ class Language(metaclass=LanguageMeta):
 
     >>> Language.TrumpScript(3.6) in Language.TrumpScript
     True
-    >>> 'ts 3.6, 3.5' in Language.TrumpScript
+    >>> 'tps 3.6, 3.5' in Language.TrumpScript
     True
     >>> 'TrumpScript 2.6' in Language.TrumpScript
     False
@@ -349,9 +349,9 @@ class Language(metaclass=LanguageMeta):
 
     This also works on instances:
 
-    >>> 'ts 3.6, 3.5' in (Language.TrumpScript == 3)
+    >>> 'tps 3.6, 3.5' in (Language.TrumpScript == 3)
     True
-    >>> 'ts 3.6,3.5' in ((Language.TrumpScript == 2)
+    >>> 'tps 3.6,3.5' in ((Language.TrumpScript == 2)
     ...                  | Language.TrumpScript(3.5))
     False
     >>> Language.TrumpScript(2.7, 3.5) in (Language.TrumpScript == 3)


### PR DESCRIPTION
This changes aliases of `TrumpScript` in the
doctests so that `TypeScript` and `TrumpScript`
have different aliases and so do not collide.

Fixes https://github.com/coala/coala/issues/5541

<!--
Thanks for your contribution!

Please take a quick look at those things down there. They're quite important.
Really! We wrote them for you. Yes you! With utmost care. Read them.
-->

**For short term contributors:** we understand that getting your commits well
defined like we require is a hard task and takes some learning. If you
look to help without wanting to contribute long term there's no need
for you to learn this. Just drop us a message and we'll take care of brushing
up your stuff for merge!

### Checklist

- [x] I read the [commit guidelines](http://coala.io/commit) and I've followed
      them.
- [x] I ran coala over my code locally. (*All commits have to pass
      individually.* It is not sufficient to have "fixup commits" on your PR,
      our bot will still report the issues for the previous commit.) You will
      likely receive a lot of bot comments and build failures if coala does not
      pass on every single commit!

After you submit your pull request, **DO NOT click the 'Update Branch' button.**
When asked for a rebase, consult [coala.io/rebase](https://coala.io/rebase)
instead.

Please consider helping us by reviewing other peoples pull requests as well:

- pick up any PR at <https://coala.io/review>
- review it (check <https://coala.io/reviewing> for more info)
- if you are sure that it needs work, use `corobo mark wip <URL>` to get it out
  of the review queue.

The more you review, the more your score will grow at coala.io and we will
review your PRs faster!
