### PR TITLE
Replace range variable with different name

### DIFF
--- a/coalib/bearlib/abstractions/Linter.py
+++ b/coalib/bearlib/abstractions/Linter.py
@@ -336,12 +336,12 @@ def _create_linter(klass, options):
             }
 
             if filename:
-                range = SourceRange.from_values(filename,
-                                                groups['line'],
-                                                groups['column'],
-                                                groups['end_line'],
-                                                groups['end_column'])
-                result_params['affected_code'] = (range,)
+                source_range = SourceRange.from_values(filename,
+                                                       groups['line'],
+                                                       groups['column'],
+                                                       groups['end_line'],
+                                                       groups['end_column'])
+                result_params['affected_code'] = (source_range,)
             return Result(**result_params)
 
         def process_diff(self,

--- a/coalib/results/Result.py
+++ b/coalib/results/Result.py
@@ -204,15 +204,15 @@ class Result:
             some time figuring out which of the leafs exactly your result
             belongs to.)
         """
-        range = SourceRange.from_values(file,
-                                        line,
-                                        column,
-                                        end_line,
-                                        end_column)
+        source_range = SourceRange.from_values(file,
+                                               line,
+                                               column,
+                                               end_line,
+                                               end_column)
 
         return cls(origin=origin,
                    message=message,
-                   affected_code=(range,),
+                   affected_code=(source_range,),
                    severity=severity,
                    additional_info=additional_info,
                    debug_msg=debug_msg,


### PR DESCRIPTION
Linter.py: replace range variable with different name
Result.py: replace range variable with different name

This fixes the issue of using range as a variable name

Fixes https://github.com/coala/coala/issues/3398

<!--
Thanks for your contribution!

Please take a quick look at those things down there. They're quite important.
Really! We wrote them for you. Yes you! With utmost care. Read them.
-->

**For short term contributors:** we understand that getting your commits well
defined like we require is a hard task and takes some learning. If you
look to help without wanting to contribute long term there's no need
for you to learn this. Just drop us a message and we'll take care of brushing
up your stuff for merge!

### Checklist

- [x] I read the [commit guidelines](http://coala.io/commit) and I've followed
      them.
- [x] I ran coala over my code locally. (*All commits have to pass
      individually.* It is not sufficient to have "fixup commits" on your PR,
      our bot will still report the issues for the previous commit.) You will
      likely receive a lot of bot comments and build failures if coala does not
      pass on every single commit!

After you submit your pull request, **DO NOT click the 'Update Branch' button.**
When asked for a rebase, consult [coala.io/rebase](https://coala.io/rebase)
instead.

Please consider helping us by reviewing other peoples pull requests as well:

- pick up any PR at <https://coala.io/review>
- review it (check <https://coala.io/reviewing> for more info)
- if you are sure that it needs work, use `corobo mark wip <URL>` to get it out
  of the review queue.

The more you review, the more your score will grow at coala.io and we will
review your PRs faster!
