### PR TITLE
CI: Check man page without altering $MANPATH

### DIFF
--- a/.ci/check_man.sh
+++ b/.ci/check_man.sh
@@ -4,7 +4,6 @@ set -e
 
 if [ $CIRCLECI ]; then
   sudo apt install man
-  export MANPATH=$MANPATH:~/.local/man
 elif [ $TRAVIS ]; then
   export MANPATH=$MANPATH:$VIRTUAL_ENV/man
 fi

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,7 +47,8 @@ jobs:
           when: always
           command: |
             [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
-            pip install --user .
+            python setup.py bdist_wheel
+            sudo pip install ./dist/coala-*.whl
             pip install --user coala-bears[alldeps] --pre -U
             pip install --user "packaging~=16.8"
             ./coala --non-interactive


### PR DESCRIPTION
This removes unneeded addition to $MANPATH for CircleCI.
Also, wheel is built and installed with root privileges, so man
page gets placed under the proper path.

Closes https://github.com/coala/coala/issues/5321

<!--
Thanks for your contribution!

Please take a quick look at those things down there. They're quite important.
Really! We wrote them for you. Yes you! With utmost care. Read them.
-->

**For short term contributors:** we understand that getting your commits well
defined like we require is a hard task and takes some learning. If you
look to help without wanting to contribute long term there's no need
for you to learn this. Just drop us a message and we'll take care of brushing
up your stuff for merge!

### Checklist

- [x] I read the [commit guidelines](http://coala.io/commit) and I've followed
      them.
- [x] I ran coala over my code locally. (*All commits have to pass
      individually.* It is not sufficient to have "fixup commits" on your PR,
      our bot will still report the issues for the previous commit.) You will
      likely receive a lot of bot comments and build failures if coala does not
      pass on every single commit!

After you submit your pull request, **DO NOT click the 'Update Branch' button.**
When asked for a rebase, consult [coala.io/rebase](https://coala.io/rebase)
instead.

Please consider helping us by reviewing other peoples pull requests as well:

- pick up any PR at <https://coala.io/review>
- review it (check <https://coala.io/reviewing> for more info)
- if you are sure that it needs work, use `corobo mark wip <URL>` to get it out
  of the review queue.

The more you review, the more your score will grow at coala.io and we will
review your PRs faster!
