### PR TITLE
BaseTestHelper.py: Improve AssertionError message

### DIFF
--- a/coalib/testing/BaseTestHelper.py
+++ b/coalib/testing/BaseTestHelper.py
@@ -1,44 +1,42 @@
+import unittest
+
 from coala_utils.Comparable import Comparable
 
 
-def _assert_comparable_equal(observed_result, expected_result):
-    """
-    Compares individual fields of the result objects using
-    `__compare_fields__` of `coala_utils.Comparable` class
-    and yields messages in case of an attribute mismatch.
-    """
-
-    if not len(observed_result) == len(expected_result):
-        assert observed_result == expected_result, '%s != %s' % (
-            observed_result, expected_result)
-
-    messages = ''
-    for observed, expected in zip(observed_result, expected_result):
-        if (isinstance(observed, Comparable) and
-            isinstance(expected, Comparable)) and (type(observed) is
-                                                   type(expected)):
-            for attribute in type(observed).__compare_fields__:
-                try:
-                    assert getattr(observed, attribute) == getattr(
-                        expected, attribute), (
-                        '{} mismatch: {}, {} != {}, {}'.format(
-                            attribute,
-                            observed.origin, observed.message,
-                            expected.origin, expected.message))
-                except AssertionError as ex:
-                    messages += (str(ex) + '\n\n')
-        else:
-            assert observed_result == expected_result, '%s != %s' % (
-                observed_result, expected_result)
-
-    if messages:
-        raise AssertionError(messages)
-
-
-class BaseTestHelper:
+class BaseTestHelper(unittest.TestCase):
     """
     This is a base class for all Bears' tests of coala's testing API.
     """
+
+    def _assert_comparable_equal(self,
+                                 observed_result,
+                                 expected_result):
+        """
+        Compares individual fields of the result objects using
+        `__compare_fields__` of `coala_utils.Comparable` class
+        and raises messages in case of an attribute mismatch.
+        """
+
+        if not len(observed_result) == len(expected_result):
+            self.assertEqual(observed_result, expected_result)
+
+        messages = []
+        for observed, expected in zip(observed_result, expected_result):
+            if (isinstance(observed, Comparable) and
+                isinstance(expected, Comparable)) and (
+                    Comparable.__eq__(expected, observed)):
+                for attribute in observed.__compare_fields__:
+                    try:
+                        self.assertEqual(getattr(observed, attribute),
+                                         getattr(expected, attribute),
+                                         msg='{} mismatch.'.format(attribute))
+                    except AssertionError as ex:
+                        messages.append(str(ex))
+            else:
+                self.assertEqual(observed, expected)
+
+        if messages:
+            raise AssertionError('\n\n'.join(message for message in messages))
 
     def assert_result_equal(self,
                             observed_result,
@@ -51,4 +49,4 @@ class BaseTestHelper:
         :param expected_result: The expected result from a bear
         """
 
-        return _assert_comparable_equal(observed_result, expected_result)
+        return self._assert_comparable_equal(observed_result, expected_result)

--- a/tests/testing/BaseTestHelperTest.py
+++ b/tests/testing/BaseTestHelperTest.py
@@ -1,5 +1,3 @@
-import pytest
-
 from coalib.results.Result import Result
 from coalib.testing.BaseTestHelper import BaseTestHelper
 
@@ -9,23 +7,41 @@ class BaseTestHelperTest(BaseTestHelper):
         self.assert_result_equal(['a', 'b'], ['a', 'b'])
 
     def test_inequality_assert_result_equal(self):
-        with pytest.raises(AssertionError) as ex:
+        with self.assertRaises(AssertionError) as ex:
             self.assert_result_equal(['a', 'b'], ['a', 'b', None])
-        assert '[\'a\', \'b\'] != [\'a\', \'b\', None]' in str(ex.value)
+        self.assertEqual("Lists differ: ['a', 'b'] != ['a', 'b', None]\n\n"
+                         'Second list contains 1 additional elements.\n'
+                         'First extra element 2:\n'
+                         'None\n\n'
+                         "- ['a', 'b']\n"
+                         "+ ['a', 'b', None]\n"
+                         '?          ++++++\n', str(ex.exception))
 
     def test_not_comparable_assert_result_equal(self):
-        with pytest.raises(AssertionError) as ex:
+        with self.assertRaises(AssertionError) as ex:
             self.assert_result_equal(['a', 'b'], ['a', 'c'])
-        assert '[\'a\', \'b\'] != [\'a\', \'c\']' in str(ex.value)
+        self.assertEqual("'b' != 'c'\n"
+                         '- b\n'
+                         '+ c\n', str(ex.exception))
 
     def test_comparable_assert_result_equal(self):
         expected = [Result.from_values(origin='AnyBea',
                                        message='This file has 2 lines.',
                                        file='anyfile')]
         observed = [Result.from_values(origin='AnyBear',
-                                       message='This file has 2 lines.',
+                                       message='This file has 3 lines.',
                                        file='anyfile')]
-        with pytest.raises(AssertionError) as ex:
+        with self.assertRaises(AssertionError) as ex:
             self.assert_result_equal(expected, observed)
-        assert ('origin mismatch: AnyBea, This file has 2 lines. != AnyBear, '
-                'This file has 2 lines.\n\n') == str(ex.value)
+        self.assertEqual("'AnyBea' != 'AnyBear'\n"
+                         '- AnyBea\n'
+                         '+ AnyBear\n'
+                         '?       +\n'
+                         ' : origin mismatch.\n\n'
+                         "'This file has 2 lines.' != 'This file "
+                         "has 3 lines.'\n"
+                         '- This file has 2 lines.\n'
+                         '?               ^\n'
+                         '+ This file has 3 lines.\n'
+                         '?               ^\n'
+                         ' : message_base mismatch.', str(ex.exception))


### PR DESCRIPTION
This improves the `AssertionError` message generated from
`assert_result_equal(...)` method by inheriting unittest
in `BaseTestHelper` class.

Closes https://github.com/coala/coala/issues/5533