### PR TITLE
languages: Allow more than one comment delimiter

### DIFF
--- a/coalib/bearlib/languages/LanguageDefinition.py
+++ b/coalib/bearlib/languages/LanguageDefinition.py
@@ -25,7 +25,7 @@ class LanguageDefinition(SectionCreatable):
     For some languages aliases exist, the name is case insensitive; they will
     behave just like before and return settings:
 
-    >>> dict(LanguageDefinition('C++')['comment_delimiter'])
+    >>> dict(LanguageDefinition('C++')['comment_delimiters'])
     {'//': ''}
     >>> dict(LanguageDefinition('C++')['string_delimiters'])
     {'"': '"'}

--- a/coalib/bearlib/languages/definitions/C.py
+++ b/coalib/bearlib/languages/definitions/C.py
@@ -4,7 +4,7 @@ from coalib.bearlib.languages.Language import Language
 @Language
 class C:
     extensions = '.c', '.h'
-    comment_delimiter = '//'
+    comment_delimiters = '//',
     multiline_comment_delimiters = {'/*': '*/'}
     string_delimiters = {'"': '"'}
     multiline_string_delimiters = {}

--- a/coalib/bearlib/languages/definitions/CPP.py
+++ b/coalib/bearlib/languages/definitions/CPP.py
@@ -6,7 +6,7 @@ class CPP:
     aliases = 'C++', 'C Plus Plus', 'CPlusPlus', 'CXX'
 
     extensions = '.c', '.cpp', '.h', '.hpp'
-    comment_delimiter = '//'
+    comment_delimiters = '//',
     multiline_comment_delimiters = {'/*': '*/'}
     string_delimiters = {'"': '"'}
     multiline_string_delimiters = {'R("': ')"'}

--- a/coalib/bearlib/languages/definitions/CSharp.py
+++ b/coalib/bearlib/languages/definitions/CSharp.py
@@ -6,6 +6,6 @@ class CSharp:
     __qualname__ = 'C#'
     aliases = 'CS',
     extensions = '.cs',
-    comment_delimiter = '//'
+    comment_delimiters = '//',
     multiline_comment_delimiters = {'/*': '*/'}
     string_delimiters = {'"': '"'}

--- a/coalib/bearlib/languages/definitions/Fortran.py
+++ b/coalib/bearlib/languages/definitions/Fortran.py
@@ -4,4 +4,4 @@ from coalib.bearlib.languages.Language import Language
 @Language
 class Fortran:
     extensions = '.f90', '.f95', '.f03', '.f', '.for'
-    comment_delimiter = '!'
+    comment_delimiters = '!',

--- a/coalib/bearlib/languages/definitions/Golang.py
+++ b/coalib/bearlib/languages/definitions/Golang.py
@@ -5,7 +5,7 @@ from coalib.bearlib.languages.Language import Language
 class Golang:
     aliases = 'go',
     extensions = '.go',
-    comment_delimiter = '//'
+    comment_delimiters = '//',
     multiline_comment_delimiters = {'/*': '*/'}
     string_delimiters = {'"': '"'}
     multiline_string_delimiters = {'`': '`'}

--- a/coalib/bearlib/languages/definitions/Java.py
+++ b/coalib/bearlib/languages/definitions/Java.py
@@ -4,7 +4,7 @@ from coalib.bearlib.languages.Language import Language
 @Language
 class Java:
     extensions = '.java',
-    comment_delimiter = '//'
+    comment_delimiters = '//',
     multiline_comment_delimiters = {'/*': '*/'}
     string_delimiters = {'"': '"'}
     multiline_string_delimiters = {}

--- a/coalib/bearlib/languages/definitions/JavaScript.py
+++ b/coalib/bearlib/languages/definitions/JavaScript.py
@@ -5,7 +5,7 @@ from coalib.bearlib.languages.Language import Language
 class JavaScript:
     aliases = 'js', 'ecmascript'
     extensions = '.js',
-    comment_delimiter = '//'
+    comment_delimiters = '//',
     multiline_comment_delimiters = {'/*': '*/'}
     string_delimiters = {'"': '"', "'": "'"}
     multiline_string_delimiters = {}

--- a/coalib/bearlib/languages/definitions/Matlab.py
+++ b/coalib/bearlib/languages/definitions/Matlab.py
@@ -5,4 +5,4 @@ from coalib.bearlib.languages.Language import Language
 class Matlab:
     aliases = 'Octave',
     extensions = '.m'
-    comment_delimiter = '%'
+    comment_delimiters = '%',

--- a/coalib/bearlib/languages/definitions/PHP.py
+++ b/coalib/bearlib/languages/definitions/PHP.py
@@ -5,7 +5,7 @@ from coalib.bearlib.languages.Language import Language
 class PHP:
     aliases = 'php',
     extensions = '.php',
-    comment_delimiter = '//'
+    comment_delimiters = '//',
     multiline_comment_delimiters = {'/*': '*/'}
     string_delimiters = {'"': '"', "'": "'"}
     keywords = [

--- a/coalib/bearlib/languages/definitions/PowerShell.py
+++ b/coalib/bearlib/languages/definitions/PowerShell.py
@@ -4,7 +4,7 @@ from coalib.bearlib.languages.Language import Language
 @Language
 class PowerShell:
     extensions = '.ps1',
-    comment_delimiter = '#'
+    comment_delimiters = '#',
     multiline_comment_delimiters = {'<#': '#>'}
     string_delimiters = {'"': '"', "'": "'"}
     multiline_string_delimiters = string_delimiters

--- a/coalib/bearlib/languages/definitions/Python.py
+++ b/coalib/bearlib/languages/definitions/Python.py
@@ -7,7 +7,7 @@ class Python:
     versions = 2.7, 3.3, 3.4, 3.5, 3.6
 
     extensions = '.py',
-    comment_delimiter = '#'
+    comment_delimiters = '#',
     multiline_comment_delimiters = {}
     string_delimiters = {'"': '"', "'": "'"}
     multiline_string_delimiters = {'"""': '"""', "'''": "'''"}

--- a/coalib/bearlib/languages/definitions/Shell.py
+++ b/coalib/bearlib/languages/definitions/Shell.py
@@ -6,7 +6,7 @@ class Shell:
     aliases = 'bash', 'sh'
 
     extensions = '.sh', '.bash', '.zsh'
-    comment_delimiter = '#'
+    comment_delimiters = '#',
     multiline_comment_delimiters = {": '": "'"}
     string_delimiters = {'"': '"', "'": "'", '`': '`'}
     multiline_string_delimiters = string_delimiters

--- a/coalib/bearlib/languages/definitions/TypeScript.py
+++ b/coalib/bearlib/languages/definitions/TypeScript.py
@@ -5,7 +5,7 @@ from coalib.bearlib.languages.Language import Language
 class TypeScript:
     aliases = 'ts',
     extensions = '.ts', '.tsx'
-    comment_delimiter = '//'
+    comment_delimiters = '//',
     multiline_comment_delimiters = {'/*': '*/'}
     string_delimiters = {'"': '"', "'": "'"}
     multiline_string_delimiters = {'`': '`'}

--- a/coalib/bearlib/languages/definitions/Vala.py
+++ b/coalib/bearlib/languages/definitions/Vala.py
@@ -4,7 +4,7 @@ from coalib.bearlib.languages.Language import Language
 @Language
 class Vala:
     extensions = '.vala', '.vapi'
-    comment_delimiter = '//'
+    comment_delimiters = '//',
     multiline_comment_delimiters = {'/*': '*/'}
     string_delimiters = {'"': '"'}
     multiline_string_delimiters = {'"""': '"""'}

--- a/coalib/bearlib/languages/definitions/__init__.py
+++ b/coalib/bearlib/languages/definitions/__init__.py
@@ -8,7 +8,7 @@ Currently defined keys are:
 
   names
   extensions
-  comment_delimiter
+  comment_delimiters
   multiline_comment_delimiters
   string_delimiters
   multiline_string_delimiters

--- a/coalib/bearlib/languages/definitions/m4.py
+++ b/coalib/bearlib/languages/definitions/m4.py
@@ -4,5 +4,5 @@ from coalib.bearlib.languages.Language import Language
 @Language
 class m4:
     extensions = '.m4',
-    comment_delimiter = '#'
+    comment_delimiters = '#',
     encapsulators = {'(': ')', '{': '}'}

--- a/coalib/results/result_actions/IgnoreResultAction.py
+++ b/coalib/results/result_actions/IgnoreResultAction.py
@@ -93,7 +93,7 @@ class IgnoreResultAction(ResultAction):
         """
         try:
             comment_delimiter = Language[
-                language].get_default_version().comment_delimiter
+                language].get_default_version().comment_delimiters[0]
             ignore_comment = (str(comment_delimiter) + ' Ignore ' +
                               origin + '\n')
         except AttributeError:


### PR DESCRIPTION
This changes `comment_delimiter` to `comment_delimiters`
and uses tuple for it, in order to support languages having
multiple comment delimiters.

Closes https://github.com/coala/coala/issues/5591

<!--
Thanks for your contribution!

Please take a quick look at those things down there. They're quite important.
Really! We wrote them for you. Yes you! With utmost care. Read them.
-->

**For short term contributors:** we understand that getting your commits well
defined like we require is a hard task and takes some learning. If you
look to help without wanting to contribute long term there's no need
for you to learn this. Just drop us a message and we'll take care of brushing
up your stuff for merge!

### Checklist

- [x] I read the [commit guidelines](http://coala.io/commit) and I've followed
      them.
- [x] I ran coala over my code locally. (*All commits have to pass
      individually.* It is not sufficient to have "fixup commits" on your PR,
      our bot will still report the issues for the previous commit.) You will
      likely receive a lot of bot comments and build failures if coala does not
      pass on every single commit!

After you submit your pull request, **DO NOT click the 'Update Branch' button.**
When asked for a rebase, consult [coala.io/rebase](https://coala.io/rebase)
instead.

Please consider helping us by reviewing other peoples pull requests as well:

- pick up any PR at <https://coala.io/review>
- review it (check <https://coala.io/reviewing> for more info)
- if you are sure that it needs work, use `corobo mark wip <URL>` to get it out
  of the review queue.

The more you review, the more your score will grow at coala.io and we will
review your PRs faster!
