### PR TITLE
Linter: Add option to remove 0 number

### DIFF
--- a/coalib/bearlib/abstractions/Linter.py
+++ b/coalib/bearlib/abstractions/Linter.py
@@ -38,6 +38,7 @@ def _prepare_options(options, bear_class):
                        'use_stderr',
                        'normalize_line_numbers',
                        'normalize_column_numbers',
+                       'remove_zero_numbers',
                        'config_suffix',
                        'executable_check_fail_info',
                        'prerequisite_check_command',
@@ -323,6 +324,11 @@ def _create_linter(klass, options):
             # still give one through the regex
             if filename is None:
                 filename = groups.get('filename', None)
+
+            if options['remove_zero_numbers']:
+                for variable in ('line', 'column', 'end_line', 'end_column'):
+                    if groups[variable] == 0:
+                        groups[variable] = None
 
             # Construct the result. If we have a filename, we
             # use Result.from_values otherwise generate a project
@@ -763,6 +769,7 @@ def linter(executable: str,
            use_stderr: bool = False,
            normalize_line_numbers: bool = False,
            normalize_column_numbers: bool = False,
+           remove_zero_numbers: bool = False,
            config_suffix: str = '',
            executable_check_fail_info: str = '',
            prerequisite_check_command: tuple = (),
@@ -884,6 +891,8 @@ def linter(executable: str,
     :param normalize_column_numbers:
         Whether to normalize column numbers (increase by one) to fit
         coala's one-based convention.
+    :param remove_zero_numbers:
+        Whether to remove 0 line or column number and use None instead.
     :param config_suffix:
         The suffix-string to append to the filename of the configuration file
         created when ``generate_config`` is supplied. Useful if your executable
@@ -989,6 +998,7 @@ def linter(executable: str,
     options['use_stderr'] = use_stderr
     options['normalize_line_numbers'] = normalize_line_numbers
     options['normalize_column_numbers'] = normalize_column_numbers
+    options['remove_zero_numbers'] = remove_zero_numbers
     options['config_suffix'] = config_suffix
     options['executable_check_fail_info'] = executable_check_fail_info
     options['prerequisite_check_command'] = prerequisite_check_command


### PR DESCRIPTION
Add linter option to remove an error message,
if line/column number is 0.

Closes https://github.com/coala/coala/issues/5600

<!--
Thanks for your contribution!

Please take a quick look at those things down there. They're quite important.
Really! We wrote them for you. Yes you! With utmost care. Read them.
-->

**For short term contributors:** we understand that getting your commits well
defined like we require is a hard task and takes some learning. If you
look to help without wanting to contribute long term there's no need
for you to learn this. Just drop us a message and we'll take care of brushing
up your stuff for merge!

### Checklist

- [ ] I read the [commit guidelines](http://coala.io/commit) and I've followed
      them.
- [ ] I ran coala over my code locally. (*All commits have to pass
      individually.* It is not sufficient to have "fixup commits" on your PR,
      our bot will still report the issues for the previous commit.) You will
      likely receive a lot of bot comments and build failures if coala does not
      pass on every single commit!

After you submit your pull request, **DO NOT click the 'Update Branch' button.**
When asked for a rebase, consult [coala.io/rebase](https://coala.io/rebase)
instead.

Please consider helping us by reviewing other peoples pull requests as well:

- pick up any PR at <https://coala.io/review>
- review it (check <https://coala.io/reviewing> for more info)
- if you are sure that it needs work, use `corobo mark wip <URL>` to get it out
  of the review queue.

The more you review, the more your score will grow at coala.io and we will
review your PRs faster!
