### PR TITLE
coalib/parsing : Changed "comment_seperators" to "comment_separators"

### DIFF
--- a/coalib/parsing/CliParsing.py
+++ b/coalib/parsing/CliParsing.py
@@ -6,13 +6,18 @@ from coalib.parsing.DefaultArgParser import default_arg_parser
 from coalib.parsing.LineParser import LineParser
 from coalib.settings.Section import Section, append_to_sections
 
-
+def deprecate_settings(**depr_args):
+    """
+     >>> @deprecate_settings(comment_separators='comment_seperators')
+     :param depr_args: A dictionary of settings as keys and their deprecated
+                       names as values.
+    """
 def parse_cli(arg_list=None,
               origin=os.getcwd(),
               arg_parser=None,
               args=None,
               key_value_delimiters=('=', ':'),
-              comment_seperators=(),
+              comment_separators=(),
               key_delimiters=(',',),
               section_override_delimiters=('.',),
               key_value_append_delimiters=('+=',)):
@@ -28,7 +33,7 @@ def parse_cli(arg_list=None,
     :param key_value_delimiters:        Delimiters to separate key and value
                                         in setting arguments where settings are
                                         being defined.
-    :param comment_seperators:          Allowed prefixes for comments.
+    :param comment_separators:          Allowed prefixes for comments.
     :param key_delimiters:              Delimiter to separate multiple keys of
                                         a setting argument.
     :param section_override_delimiters: The delimiter to delimit the section
@@ -52,7 +57,7 @@ def parse_cli(arg_list=None,
     origin += os.path.sep
     sections = OrderedDict(cli=Section('cli'))
     line_parser = LineParser(key_value_delimiters,
-                             comment_seperators,
+                             comment_separators,
                              key_delimiters,
                              {},
                              section_override_delimiters,

--- a/coalib/parsing/ConfParser.py
+++ b/coalib/parsing/ConfParser.py
@@ -8,19 +8,24 @@ from coalib.parsing.LineParser import LineParser
 from coalib.settings.Section import Section
 from coalib.settings.Setting import Setting
 
-
+def deprecate_settings(**depr_args):
+    """
+     >>> @deprecate_settings(comment_separators='comment_seperators')
+     :param depr_args: A dictionary of settings as keys and their deprecated
+                       names as values.
+    """
 class ConfParser:
 
     def __init__(self,
                  key_value_delimiters=('=',),
-                 comment_seperators=('#',),
+                 comment_separators=('#',),
                  key_delimiters=(',', ' '),
                  section_name_surroundings=MappingProxyType({'[': ']'}),
                  remove_empty_iter_elements=True,
                  key_value_append_delimiters=('+=',)):
         self.line_parser = LineParser(
             key_value_delimiters,
-            comment_seperators,
+            comment_separators,
             key_delimiters,
             section_name_surroundings,
             key_value_append_delimiters=key_value_append_delimiters)


### PR DESCRIPTION
This changes the variable name "comment_seperators" to "comment_separators" in files CliParsing.py and ConfParser.py.
Old name is added as a deprecated argument in the corresponding files.

Fixes https://github.com/coala/coala/issues/5510

<!--
Thanks for your contribution!

Please take a quick look at those things down there. They're quite important.
Really! We wrote them for you. Yes you! With utmost care. Read them.
-->

**For short term contributors:** we understand that getting your commits well
defined like we require is a hard task and takes some learning. If you
look to help without wanting to contribute long term there's no need
for you to learn this. Just drop us a message and we'll take care of brushing
up your stuff for merge!

### Checklist

- [x] I read the [commit guidelines](http://coala.io/commit) and I've followed
      them.
- [x] I ran coala over my code locally. (*All commits have to pass
      individually.* It is not sufficient to have "fixup commits" on your PR,
      our bot will still report the issues for the previous commit.) You will
      likely receive a lot of bot comments and build failures if coala does not
      pass on every single commit!

After you submit your pull request, **DO NOT click the 'Update Branch' button.**
When asked for a rebase, consult [coala.io/rebase](https://coala.io/rebase)
instead.

Please consider helping us by reviewing other peoples pull requests as well:

- pick up any PR at <https://coala.io/review>
- review it (check <https://coala.io/reviewing> for more info)
- if you are sure that it needs work, use `corobo mark wip <URL>` to get it out
  of the review queue.

The more you review, the more your score will grow at coala.io and we will
review your PRs faster!
