### PR TITLE
Bears.py: Add Debugger Setting toolset

### DIFF
--- a/tests/bears/DebugBearsTest.py
+++ b/tests/bears/DebugBearsTest.py
@@ -2,8 +2,12 @@ import unittest
 import sys
 
 from io import StringIO
+from queue import Queue
 
-from coalib.bears.Bear import Debugger, debug_run
+from coalib.bears.Bear import Bear, Debugger, debug_run
+from coalib.bears.LocalBear import LocalBear
+from coalib.settings.Section import Section
+from coalib.settings.Setting import Setting
 
 
 def func1(*args, **kwargs):
@@ -20,10 +24,20 @@ def func3(*args, **kwargs):
     return func1(*args, **kwargs)
 
 
-def execute_debugger(debugger_commands, func, *args, **kwargs):
+class TestOneBear(LocalBear):
+    def __init__(self, section, queue):
+        Bear.__init__(self, section, queue)
+
+    def run(self, x: int, y: str, z: int = 79, w: str = 'kbc'):
+        args = ()
+        kwargs = {}
+        return func1(*args, **kwargs)
+
+
+def execute_debugger(debugger_commands, func, bear, *args, **kwargs):
     input = StringIO('\n'.join(debugger_commands))
     output = StringIO()
-    dbg = Debugger(stdin=input, stdout=output)
+    dbg = Debugger(bear, stdin=input, stdout=output)
     return debug_run(func, dbg, *args, **kwargs), output.getvalue()
 
 
@@ -35,12 +49,15 @@ class DebugBearsTest(unittest.TestCase):
         # BearTest file.
         # https://goo.gl/sKaJfh
         self.trace = sys.gettrace()
+        self.section = Section('name')
+        self.queue = Queue()
 
     def tearDown(self):
         sys.settrace(self.trace)
 
     def test_run_return_yield_with_debugger(self):
-        result, output = execute_debugger('qcqc', func1)
+        result, output = execute_debugger('qcqc', func1, bear=Bear(self.section,
+                                                                   self.queue))
         self.assertEqual(result, [1, 2, 3])
         lines = output.splitlines()
         self.assertEqual(lines[1], '-> yield 1')
@@ -48,15 +65,36 @@ class DebugBearsTest(unittest.TestCase):
         self.assertEqual(lines[5], '-> yield 3')
 
     def test_run_return_list_with_debugger(self):
-        result, output = execute_debugger('q', func2)
+        result, output = execute_debugger('q', func2, bear=Bear(self.section,
+                                                                self.queue))
         self.assertEqual(result, [1, 2])
         lines = output.splitlines()
         self.assertEqual(lines[1], '-> return [1, 2]')
 
     def test_run_return_generator_with_debugger(self):
-        result, output = execute_debugger('qcqcq', func3)
+        result, output = execute_debugger('qcqcq', func3, bear=Bear(
+            self.section, self.queue))
         self.assertEqual(result, [1, 2, 3])
         lines = output.splitlines()
         self.assertEqual(lines[3], '-> yield 1')
         self.assertEqual(lines[5], '-> yield 2')
         self.assertEqual(lines[7], '-> yield 3')
+
+    def test_do_settings_with_bear_object(self):
+        self.section.append(Setting('x', '85'))
+        self.section.append(Setting('y', 'kbc3'))
+        self.section.append(Setting('z', '75'))
+        bear = TestOneBear(self.section, self.queue)
+        kwargs = {'x': 2, 'y': 'abc'}
+        result, output = execute_debugger(['q', 'c', 'settings', 'c', 'q', 'c'],
+                                          bear.run, bear=bear, **kwargs)
+        self.assertEqual(result, [1, 2, 3])
+        lines = output.splitlines()
+        self.assertEqual(lines[6], '(Pdb) x = 85')
+        self.assertEqual(lines[7], "y = 'kbc3'")
+        self.assertEqual(lines[8], 'z = 75')
+        self.assertEqual(lines[9], "w = 'kbc'")
+
+    def test_debugger_without_bear_object(self):
+        with self.assertRaises(ValueError):
+            execute_debugger([], func2, bear=None)


### PR DESCRIPTION
Add the code of Settings inspection
toolset so that user can access the
settings of a Bear in Debug environment
and add initial test.

Related to https://github.com/coala/coala/issues/5545
