### PR TITLE
aspects: Rename class `docs` to follow CapWords

### DIFF
--- a/coalib/bearlib/aspects/Formatting.py
+++ b/coalib/bearlib/aspects/Formatting.py
@@ -6,7 +6,7 @@ class Formatting:
     """
     The visual appearance of source code.
     """
-    class docs:
+    class Docs:
         example = """
         # Here is an example of Python code with lots of
         # formatting issues including: trailing spaces, missing spaces
@@ -34,7 +34,7 @@ class Length:
     """
     Hold sub-aspects for file and line length.
     """
-    class docs:
+    class Docs:
         example = """
         # We assume that the maximum number of characters per line is 10
         # and that the maximum number of lines per files is 3.
@@ -59,7 +59,7 @@ class LineLength:
     """
     Number of characters found in a line of code.
     """
-    class docs:
+    class Docs:
         example = """
         print('The length of this line is 38')
         """
@@ -82,7 +82,7 @@ class FileLength:
     """
     Number of lines found in a file.
     """
-    class docs:
+    class Docs:
         example = """
         # This file would be a large file if we assume that the max number of
         # lines per file is 10
@@ -114,7 +114,7 @@ class Spacing:
     """
     All whitespace found between non-whitespace characters.
     """
-    class docs:
+    class Docs:
         example = """
         # Here is an example of code with spacing issues including
         # unnecessary blank lines and missing space around operators.
@@ -138,7 +138,7 @@ class Indentation:
     """
     Spaces/tabs used before blocks of code to convey a program's structure.
     """
-    class docs:
+    class Docs:
         example = """
         # If this code was written on an editor that defined a tab as 2
         # spaces, mixing tabs and spaces would look like this on a different
@@ -176,7 +176,7 @@ class TrailingSpace:
     character on the line until the newline. This includes tabs "\\\\t",
     blank lines, blanks etc.
     """
-    class docs:
+    class Docs:
         example = """
         def func( a ):
               pass
@@ -199,7 +199,7 @@ class BlankLine:
     """
     A line with zero characters.
     """
-    class docs:
+    class Docs:
         example = """
         name = input('What is your name?')
 
@@ -224,7 +224,7 @@ class BlankLineAfterDeclaration:
     """
     Those found after declarations.
     """
-    class docs:
+    class Docs:
         example = """
         #include <stdio.h>
 
@@ -258,7 +258,7 @@ class BlankLineAfterProcedure:
     """
     Those found after procedures or functions.
     """
-    class docs:
+    class Docs:
         example = """
         #include <stdio.h>
 
@@ -288,7 +288,7 @@ class BlankLineAfterClass:
     """
     Those found after classes' definitions.
     """
-    class docs:
+    class Docs:
         example = """
         class SomeClass:
             def __init__(self):
@@ -315,7 +315,7 @@ class NewlineAtEOF:
     """
     Newline character (usually '\\\\n', aka CR) found at the end of file.
     """
-    class docs:
+    class Docs:
         example = """
         def do_nothing():
             pass
@@ -344,7 +344,7 @@ class SpacesAroundOperator:
     """
     Spacing around operators.
     """
-    class docs:
+    class Docs:
         example = """
         def f(a, x):
             return 37+a[42 -  x]
@@ -374,7 +374,7 @@ class Quotation:
     """
     Quotation mark used for strings and docstrings.
     """
-    class docs:
+    class Docs:
         example = """
         # Here is an example of code where both '' and "" quotation mark
         # Are used.

--- a/coalib/bearlib/aspects/Metadata.py
+++ b/coalib/bearlib/aspects/Metadata.py
@@ -7,7 +7,7 @@ class Metadata:
     This describes any aspect that is related to metadata that is not
     inside your source code.
     """
-    class docs:
+    class Docs:
         example = """
         Commit message, commit message shortlog, commit message body, etc...
         """
@@ -28,7 +28,7 @@ class CommitMessage:
     """
     Your commit message the documentation associated with your source code.
     """
-    class docs:
+    class Docs:
         example = 'YapfBear: Add `YapfBear`'
         example_language = 'English'
         importance_reason = """
@@ -50,7 +50,7 @@ class Emptiness:
     Your commit message serves as important documentation for your source
     code.
     """
-    class docs:
+    class Docs:
         example = '(no text at all)'
         example_language = 'English'
         importance_reason = """
@@ -65,7 +65,7 @@ class Shortlog:
     """
     Your commit shortlog is the first line of your commit message.
     """
-    class docs:
+    class Docs:
         example = """
         FIX: Describe change further
         """
@@ -85,7 +85,7 @@ class ColonExistence:
     Some projects force to use colons in the commit message shortlog
     (first line).
     """
-    class docs:
+    class Docs:
         example = """
         FIX: Describe change further
         context: Describe change further
@@ -112,7 +112,7 @@ class TrailingPeriod:
     Some projects force not to use trailing periods in the commit
     message shortlog (first line).
     """
-    class docs:
+    class Docs:
         example = """
         Describe change.
         Describe change
@@ -138,7 +138,7 @@ class Tense:
     Most projects have a convention on which tense to use in the commit
     shortlog (the first line of the commit message).
     """
-    class docs:
+    class Docs:
         example = """
         Add file
         Adding file
@@ -163,7 +163,7 @@ class Length:
     """
     The length of your commit message shortlog (first line).
     """
-    class docs:
+    class Docs:
         example = """
         Some people just write very long commit messages. Too long. "
         Even full sentences. And more of them, too!
@@ -197,7 +197,7 @@ class FirstCharacter:
     If the commit message contains a colon, only the first character after
     the colon will be checked.
     """
-    class docs:
+    class Docs:
         example = """
         Add coverage pragma
         Compatability: Add coverage pragma
@@ -225,7 +225,7 @@ class Body:
     """
     Your commit body may contain an elaborate description of your commit.
     """
-    class docs:
+    class Docs:
         example = """
         CI: Revert requests breakage workaround
 
@@ -254,7 +254,7 @@ class Existence:
     """
     Forces the commit message body to exist (nonempty).
     """
-    class docs:
+    class Docs:
         example = """
         aspects: Add CommitMessage.Body
         """
@@ -273,7 +273,7 @@ class Length:
     """
     The length of your commit message body lines.
     """
-    class docs:
+    class Docs:
         example = """
         Some people just write very long commit messages. Too long.
         Way too much actually. If they would just break their lines!

--- a/coalib/bearlib/aspects/Redundancy.py
+++ b/coalib/bearlib/aspects/Redundancy.py
@@ -7,7 +7,7 @@ class Redundancy:
     """
     This aspect describes redundancy in your source code.
     """
-    class docs:
+    class Docs:
         example = """
         int foo(int iX)
         {
@@ -31,7 +31,7 @@ class Clone:
     Code clones are multiple pieces of source code in your
     codebase that are very similar.
     """
-    class docs:
+    class Docs:
         example = """
         extern int array_a[];
         extern int array_b[];
@@ -87,7 +87,7 @@ class UnusedImport:
     >>> UnusedImport.remove_non_standard_import.default
     True
     """
-    class docs:
+    class Docs:
         example = """
         import sys
         import os
@@ -118,7 +118,7 @@ class UnreachableCode:
     Unreachable code, sometimes called dead code, is source code that
     can never be executed during the program execution.
     """
-    class docs:
+    class Docs:
         example = """
         def func():
             return True
@@ -145,7 +145,7 @@ class UnusedFunction:
     An unused function is a function that is never called during
     code execution.
     """
-    class docs:
+    class Docs:
         example = """
         def func():
             pass
@@ -171,7 +171,7 @@ class UnreachableStatement:
     An unreachable statement is a statement that is never executed
     during code execution.
     """
-    class docs:
+    class Docs:
         example = """
         def func():
             return True
@@ -197,7 +197,7 @@ class UnusedVariable:
     """
     Unused variables are declared but never used.
     """
-    class docs:
+    class Docs:
         example = """
         a = {}
         print ('coala')
@@ -217,7 +217,7 @@ class UnusedParameter:
     """
     Unused parameters are functions arguments which are never used.
     """
-    class docs:
+    class Docs:
         example = """
         def func(a):
             pass
@@ -237,7 +237,7 @@ class UnusedLocalVariable:
     """
     These are variable which are defined locally but never used.
     """
-    class docs:
+    class Docs:
         example = """
         def func():
             for i in range (5):
@@ -258,7 +258,7 @@ class UnusedGlobalVariable:
     """
     These are variable which have a global scope but are never used.
     """
-    class docs:
+    class Docs:
         example = """
         a = 0
         for i in range (5):

--- a/coalib/bearlib/aspects/Security.py
+++ b/coalib/bearlib/aspects/Security.py
@@ -7,7 +7,7 @@ class Security:
     This aspects checks for code with flaws (or security weaknesses) in your
     codebase.
     """
-    class docs:
+    class Docs:
         example = """
         char buf[1024];
         ssizet_t len;

--- a/coalib/bearlib/aspects/Smell.py
+++ b/coalib/bearlib/aspects/Smell.py
@@ -11,7 +11,7 @@ class Smell:
     technically incorrect and do not currently prevent the program from
     functioning.
     """
-    class docs:
+    class Docs:
         example = """
         =begin
         Example of Ruby code with data clumps and methods with too many
@@ -53,7 +53,7 @@ class ClassSmell:
     large classes or God object, data clump feature envy etc...) in your
     source code.
     """
-    class docs:
+    class Docs:
         example = """
         class Warehouse
             def sale_price(item)
@@ -87,7 +87,7 @@ class MethodSmell:
     functions (too long method or functions, or functions with too many
     parameters) in your source code.
     """
-    class docs:
+    class Docs:
         example = """
         def do_nothing(var1, var2, var3, var4, var5, var6, var7):
             pass
@@ -117,7 +117,7 @@ class MethodLength:
     defines a default value of 100 lines per method, `checkstlye`` 150 and
     60 (when comments are not considered), ``rubocop`` 10.
     """
-    class docs:
+    class Docs:
         example = """
         def _is_positive(num):
             if num > 0:
@@ -164,7 +164,7 @@ class ParameterListLength:
     maximum number of parameter per function or method is 7; ``rubocop``
     suggests 5.
     """
-    class docs:
+    class Docs:
         example = """
         def func(a, b, c, d, e, f, g, h, i, j, k):
             pass
@@ -192,7 +192,7 @@ class DataClump:
     """
     Identical groups of variables found in many different part of a program.
     """
-    class docs:
+    class Docs:
         example = """
         public static void main(String args[]) {
 
@@ -237,7 +237,7 @@ class ClassSize:
         * the number of methods,
         * and the number of lines of code.
     """
-    class docs:
+    class Docs:
         example = """
         // This is large class given that the `max_class_length` is 20
 
@@ -290,7 +290,7 @@ class ClassLength:
     """
     Number of lines of code in class' definition.
     """
-    class docs:
+    class Docs:
         example = """
         # Here is an example of a large class (in terms of number of lines) if
         # we assume that the maximum number of lines per class defintion is 10
@@ -328,7 +328,7 @@ class ClassConstants:
     """
     Number of constants in a class.
     """
-    class docs:
+    class Docs:
         example = """
         // Here is an example of class with too many constants if we assume
         // that the maximum number of constants per class is 4
@@ -361,7 +361,7 @@ class ClassInstanceVariables:
     """
     Number of instance variables in a class.
     """
-    class docs:
+    class Docs:
         example = """
         # Here is an example of a class with a large number of instance
         # variables if we assume that the maximun nubmer of instance variables
@@ -400,7 +400,7 @@ class ClassMethods:
     """
     Number of class methods a class has.
     """
-    class docs:
+    class Docs:
         example = """
         # Here is an example of a class with too many methods
         # Assuming that the maximum per class is 5.
@@ -432,7 +432,7 @@ class FeatureEnvy:
     """
     Classes that excessively use methods of other classes.
     """
-    class docs:
+    class Docs:
         example = """
         public class Phone {
             private final String unformattedNumber;
@@ -475,7 +475,7 @@ class Naming:
     """
     `Naming` refers to the naming conventions to use for identifiers.
     """
-    class docs:
+    class Docs:
         example = """
         dummyVar = None  # lowerCamelCase naming convention
         DummyVar = None  # UpperCamelCase naming convention
@@ -512,7 +512,7 @@ class Complexity:
     """
     Complexity of a code based on different complexity metrics.
     """
-    class docs:
+    class Docs:
         example = """
         * McCabe's complexity
         * Halstead complexity
@@ -544,7 +544,7 @@ class CylomaticComplexity:
     Thomas J. McCabe in 1976 and it is based on a control flow representation
     of the program.
     """
-    class docs:
+    class Docs:
         example = """
         // The cyclomatic complexity of this program is 4.
 
@@ -584,7 +584,7 @@ class MaintainabilityIndex:
     * A `MI` in the range 10-19 maps to a maintainable code.
     * A `MI` in the range 20-100 maps to a code highly maintainable.
     """
-    class docs:
+    class Docs:
         example = """
         '''
         The maintainability index for the following piece of code is 100.

--- a/coalib/bearlib/aspects/Spelling.py
+++ b/coalib/bearlib/aspects/Spelling.py
@@ -6,7 +6,7 @@ class Spelling:
     """
     How words should be written.
     """
-    class docs:
+    class Docs:
         example = """
         'Tihs si surly som incoreclt speling.
         `Coala` is always written with a lowercase `c`.
@@ -26,7 +26,7 @@ class DictionarySpelling:
     """
     Valid language's words spelling.
     """
-    class docs:
+    class Docs:
         example = """
         This is toatly wonrg.
         """
@@ -48,7 +48,7 @@ class OrgSpecificWordSpelling:
     """
     Organisations like coala specified words' spelling.
     """
-    class docs:
+    class Docs:
         example = """
         `Coala` is always written with a lower case c, also at the beginning
         of the sentence.

--- a/coalib/bearlib/aspects/meta.py
+++ b/coalib/bearlib/aspects/meta.py
@@ -43,7 +43,7 @@ class aspectclass(type):
         aspectname = subcls.__name__
         sub_qualname = '%s.%s' % (cls.__qualname__, aspectname)
 
-        docs = getattr(subcls, 'docs', None)
+        docs = getattr(subcls, 'Docs', None)
         aspectdocs = Documentation(subcls.__doc__, **{
             attr: getattr(docs, attr, '') for attr in
             list(signature(Documentation).parameters.keys())[1:]})

--- a/coalib/bearlib/aspects/root.py
+++ b/coalib/bearlib/aspects/root.py
@@ -8,7 +8,7 @@ class Root(aspectbase, metaclass=aspectclass):
 
     Define sub-aspectclasses with class-bound ``.subaspect`` decorator.
     Definition string is taken from doc-string of decorated class.
-    Remaining docs are taken from a nested ``docs`` class.
+    Remaining docs are taken from a nested ``Docs`` class.
     Tastes are defined as class attributes that are instances of
     :class:`coalib.bearlib.aspects.Taste`.
 
@@ -19,7 +19,7 @@ class Root(aspectbase, metaclass=aspectclass):
     ...     \"""
     ...     A parent aspect for code formatting aspects...
     ...     \"""
-    ...     class docs:
+    ...     class Docs:
     ...        example = "..."
     ...        example_language = "..."
     ...        importance_reason = "..."
@@ -32,7 +32,7 @@ class Root(aspectbase, metaclass=aspectclass):
     ...     \"""
     ...     This aspect controls the length of a line...
     ...     \"""
-    ...     class docs:
+    ...     class Docs:
     ...        example = "..."
     ...        example_language = "..."
     ...        importance_reason = "..."
@@ -79,7 +79,7 @@ class Root(aspectbase, metaclass=aspectclass):
     ...     \"""
     ...     This aspect controls the greatness of a file...
     ...     \"""
-    ...     class docs:
+    ...     class Docs:
     ...        example = "..."
     ...        example_language = "..."
     ...        importance_reason = "..."

--- a/coalib/results/Result.py
+++ b/coalib/results/Result.py
@@ -128,7 +128,7 @@ class Result:
         self.aspect = aspect
         if self.aspect and not self.additional_info:
             self.additional_info = '{} {}'.format(
-                aspect.docs.importance_reason, aspect.docs.fix_suggestions)
+                aspect.Docs.importance_reason, aspect.Docs.fix_suggestions)
 
     @property
     def message(self):

--- a/tests/bearlib/aspects/ClassTest.py
+++ b/tests/bearlib/aspects/ClassTest.py
@@ -30,7 +30,7 @@ class AspectClassTest:
             Description
             """
 
-            class docs:
+            class Docs:
                 example = 'Example'
 
         assert not SubAspect.docs.check_consistency()

--- a/tests/bearlib/aspects/conftest.py
+++ b/tests/bearlib/aspects/conftest.py
@@ -50,13 +50,13 @@ def SubAspect_docs():
     """
     Docs definitions for an exclusive SubAspect class for unit tests.
     """
-    class docs:
+    class Docs:
         example = 'An example'
         example_language = 'The example language'
         importance_reason = 'The reason of importance'
         fix_suggestions = 'Suggestions for fixing'
 
-    return docs
+    return Docs
 
 
 @pytest.fixture
@@ -111,13 +111,13 @@ def SubSubAspect_docs():
     """
     Docs definitions for an exclusive SubSubAspect class for unit tests.
     """
-    class docs:
+    class Docs:
         example = 'An example'
         example_language = 'The example language'
         importance_reason = 'The reason of importance'
         fix_suggestions = 'Suggestions for fixing'
 
-    return docs
+    return Docs
 
 
 @pytest.fixture

--- a/tests/results/result_actions/PrintAspectActionTest.py
+++ b/tests/results/result_actions/PrintAspectActionTest.py
@@ -17,7 +17,7 @@ class PrintAspectActionTest(unittest.TestCase):
             """
             This is a test aspect
             """
-            class docs:
+            class Docs:
                 example = 'test'
                 example_language = 'test'
                 importance_reason = 'test'


### PR DESCRIPTION
This renames class name `docs` to `Docs` so that
it follows CapWords convention.

Closes https://github.com/coala/coala/issues/5626

<!--
Thanks for your contribution!

Please take a quick look at those things down there. They're quite important.
Really! We wrote them for you. Yes you! With utmost care. Read them.
-->

**For short term contributors:** we understand that getting your commits well
defined like we require is a hard task and takes some learning. If you
look to help without wanting to contribute long term there's no need
for you to learn this. Just drop us a message and we'll take care of brushing
up your stuff for merge!

### Checklist

- [x] I read the [commit guidelines](http://coala.io/commit) and I've followed
      them.
- [x] I ran coala over my code locally. (*All commits have to pass
      individually.* It is not sufficient to have "fixup commits" on your PR,
      our bot will still report the issues for the previous commit.) You will
      likely receive a lot of bot comments and build failures if coala does not
      pass on every single commit!

After you submit your pull request, **DO NOT click the 'Update Branch' button.**
When asked for a rebase, consult [coala.io/rebase](https://coala.io/rebase)
instead.

Please consider helping us by reviewing other peoples pull requests as well:

- pick up any PR at <https://coala.io/review>
- review it (check <https://coala.io/reviewing> for more info)
- if you are sure that it needs work, use `corobo mark wip <URL>` to get it out
  of the review queue.

The more you review, the more your score will grow at coala.io and we will
review your PRs faster!
