### PR TITLE
BearTest: Replace httpstat with Google teapot

### DIFF
--- a/tests/bears/BearTest.py
+++ b/tests/bears/BearTest.py
@@ -515,8 +515,8 @@ class BearDownloadTest(BearTestBase):
         super().setUp()
         self.mock_url = 'https://test.com'
         self.filename = 'test.html'
-        self.teapot_url = 'https://httpstat.us/418'
-        # https://www.google.com/teapot and
+        self.teapot_url = 'https://www.google.com/teapot'
+        # 'https://httpstat.us/418' and
         # http://httpbin.org/status/418 also work
         self.file_location = join(self.uut.data_dir, self.filename)
 

--- a/tests/core/BearTest.py
+++ b/tests/core/BearTest.py
@@ -76,7 +76,7 @@ class BearTest(unittest.TestCase):
 
     def setUp(self):
         super().setUp()
-        self.teapot_url = 'https://httpstat.us/418'
+        self.teapot_url = 'https://www.google.com/teapot'
 
     def tearDown(self):
         defined_bears = [


### PR DESCRIPTION
Use httpbin instead of httpbin because
of SSL certification error.

Closes https://github.com/coala/coala/issues/5628
