### PR TITLE
check_unsupported.sh: Use template

### DIFF
--- a/.misc/check_unsupported.sh
+++ b/.misc/check_unsupported.sh
@@ -1,17 +1,23 @@
 #!/usr/bin/env bash
 
+# Non-zero exit code is what we want to check
 set +e
 
-# Enable capturing the non-zero exit status of coverage instead of tee
+# Enable capturing the non-zero exit status of setup.py instead of tee
 set -o pipefail
 
-coverage run setup.py install | tee setup.log
+set -x
+
+python setup.py install 2>&1 | tee setup.log
 
 retval=$?
 
+set +x
+
 # coalib.__init__.py should exit with 4 on unsupported versions of Python
+# But bears setup.py sees retval 1.
 if [[ $retval != 4 ]]; then
-  echo "Unexpected error code $?"
+  echo "Unexpected error code $retval"
 
   # When the exit code is 0, use a non-zero exit code instead
   if [[ $retval == 0 ]]; then
@@ -23,6 +29,7 @@ fi
 # error when no lines selected by grep
 set -e
 
+# The following is emitted on stdout
 grep -q 'coala supports only python 3.4.4 or later' setup.log
 
 echo "Unsupported check completed successfully"


### PR DESCRIPTION
Small improvements by sharing the logic with bears repository.
The use of `coverage run` has been discontinued as coverage of
`setup.py` is not needed for assert_supported_version
as bears repo now has mock tests for that function.

Related to https://gitlab.com/coala/mobans/issues/65

<!--
Thanks for your contribution!

Please take a quick look at those things down there. They're quite important.
Really! We wrote them for you. Yes you! With utmost care. Read them.
-->

**For short term contributors:** we understand that getting your commits well
defined like we require is a hard task and takes some learning. If you
look to help without wanting to contribute long term there's no need
for you to learn this. Just drop us a message and we'll take care of brushing
up your stuff for merge!

### Checklist

- [ ] I read the [commit guidelines](http://coala.io/commit) and I've followed
      them.
- [ ] I ran coala over my code locally. (*All commits have to pass
      individually.* It is not sufficient to have "fixup commits" on your PR,
      our bot will still report the issues for the previous commit.) You will
      likely receive a lot of bot comments and build failures if coala does not
      pass on every single commit!

After you submit your pull request, **DO NOT click the 'Update Branch' button.**
When asked for a rebase, consult [coala.io/rebase](https://coala.io/rebase)
instead.

Please consider helping us by reviewing other peoples pull requests as well:

- pick up any PR at <https://coala.io/review>
- review it (check <https://coala.io/reviewing> for more info)
- if you are sure that it needs work, use `corobo mark wip <URL>` to get it out
  of the review queue.

The more you review, the more your score will grow at coala.io and we will
review your PRs faster!
