### PR TITLE
Bear: Remove debugger from init

### DIFF
--- a/coalib/bears/Bear.py
+++ b/coalib/bears/Bear.py
@@ -24,6 +24,27 @@ from coalib.settings.ConfigurationGathering import get_config_directory
 from .meta import bearclass
 
 
+def _is_debugged(bear):
+    """
+    Check whether the bear is in debug mode according to its section-settings.
+
+    :param bear: Bear object.
+    :return:     True if ``debug_bears`` is ``True`` or if bear name specified
+                 in ``debug_bears`` setting match with the bear parameter.
+    """
+    if not isinstance(bear, Bear):
+        raise ValueError('Positional argument bear is not an instance of '
+                         'Bear class.')
+    if 'debug_bears' not in bear.section:
+        return False
+    try:
+        return bool(bear.section['debug_bears'])
+    except ValueError:
+        pass
+    return bear.name.lower() in (
+            map(str.lower, bear.section['debug_bears']))
+
+
 class Debugger(pdb.Pdb):
 
     def __init__(self, bear, *args, **kwargs):
@@ -280,8 +301,7 @@ class Bear(Printer, LogPrinterMixin, metaclass=bearclass):
     def __init__(self,
                  section: Section,
                  message_queue,
-                 timeout=0,
-                 debugger=False):
+                 timeout=0):
         """
         Constructs a new bear.
 
@@ -301,7 +321,7 @@ class Bear(Printer, LogPrinterMixin, metaclass=bearclass):
         self.section = section
         self.message_queue = message_queue
         self.timeout = timeout
-        self.debugger = debugger
+        self.debugger = _is_debugged(bear=self)
 
         self.setup_dependencies()
         cp = type(self).check_prerequisites()

--- a/coalib/bears/GlobalBear.py
+++ b/coalib/bears/GlobalBear.py
@@ -18,8 +18,7 @@ class GlobalBear(Bear):
                  file_dict,
                  section,
                  message_queue,
-                 timeout=0,
-                 debugger=False):
+                 timeout=0):
         """
         Constructs a new GlobalBear.
 
@@ -27,7 +26,7 @@ class GlobalBear(Bear):
 
         See :class:`coalib.bears.Bear` for other parameters.
         """
-        Bear.__init__(self, section, message_queue, timeout, debugger)
+        Bear.__init__(self, section, message_queue, timeout)
         self.file_dict = file_dict
 
     @staticmethod

--- a/coalib/processes/Processing.py
+++ b/coalib/processes/Processing.py
@@ -297,8 +297,7 @@ def instantiate_bears(section,
                       file_dict,
                       message_queue,
                       console_printer,
-                      debug=False,
-                      debug_bears=False):
+                      debug=False):
     """
     Instantiates each bear with the arguments it needs.
 
@@ -312,26 +311,13 @@ def instantiate_bears(section,
     :param console_printer:  Object to print messages on the console.
     :return:                 The local and global bear instance lists.
     """
-    debug_bears = (False if debug_bears is False else
-                   [x.lower() for x in debug_bears])
-    for bear in local_bear_list + global_bear_list:
-        for deps_bear in bear.BEAR_DEPS:
-            if debug_bears is not False and (
-                bear.__name__.lower() in debug_bears and (
-                    deps_bear.__name__.lower() not in debug_bears)):
-                debug_bears.append(deps_bear.__name__.lower())
-
     instantiated_local_bear_list = []
     instantiated_global_bear_list = []
     for bear in local_bear_list:
         try:
-            debugger = True if debug_bears is not False and (
-                    debug_bears[0] == 'true' or (
-                        bear.__name__.lower() in debug_bears)) else False
             instantiated_local_bear_list.append(bear(section,
                                                      message_queue,
-                                                     timeout=0.1,
-                                                     debugger=debugger))
+                                                     timeout=0.1))
         # RuntimeError it will be raised only when debug will be set to True.
         except RuntimeError:
             if debug:
@@ -339,14 +325,10 @@ def instantiate_bears(section,
 
     for bear in global_bear_list:
         try:
-            debugger = True if debug_bears is not False and (
-                    debug_bears[0] == 'true' or (
-                        bear.__name__.lower() in debug_bears)) else False
             instantiated_global_bear_list.append(bear(file_dict,
                                                       section,
                                                       message_queue,
-                                                      timeout=0.1,
-                                                      debugger=debugger))
+                                                      timeout=0.1))
         # RuntimeError it will be raised only when debug will be set to True
         except RuntimeError:
             if debug:
@@ -418,8 +400,7 @@ def instantiate_processes(section,
         complete_file_dict,
         message_queue,
         console_printer=console_printer,
-        debug=debug,
-        debug_bears=debug_bears)
+        debug=debug)
     loaded_valid_local_bears_count = len(local_bear_list)
     # Note: the complete file dict is given as the file dict to bears and
     # the whole project is accessible to every bear. However, local bears are

--- a/tests/processes/ProcessingTest.py
+++ b/tests/processes/ProcessingTest.py
@@ -566,8 +566,8 @@ class ProcessingTest(unittest.TestCase):
     def test_loaded_bears_with_error_result(self):
         class BearWithMissingPrerequisites(Bear):
 
-            def __init__(self, section, queue, timeout=0.1, debugger=False):
-                Bear.__init__(self, section, queue, timeout, debugger)
+            def __init__(self, *args, **kwargs):
+                Bear.__init__(self, *args, **kwargs)
 
             def run(self):
                 return []
@@ -606,33 +606,28 @@ class ProcessingTest(unittest.TestCase):
     def test_global_instantiation(self):
         class TestOneBear(Bear):
 
-            def __init__(self, file_dict, section, queue, timeout=0.1,
-                         debugger=False):
+            def __init__(self, *args, **kwargs):
                 raise RuntimeError
 
         class TestTwoBear(Bear):
 
             BEAR_DEPS = {TestOneBear}
 
-            def __init__(self, file_dict, section, queue, timeout=0.1,
-                         debugger=False):
+            def __init__(self, *args, **kwargs):
                 raise RuntimeError
 
         class TestThreeBear(Bear):
 
             BEAR_DEPS = {TestTwoBear}
 
-            def __init__(self, file_dict, section, queue, timeout=0.1,
-                         debugger=False):
-                Bear.__init__(self, section, queue, timeout, debugger)
+            def __init__(self, file_dict, section, queue, timeout=0.1):
+                Bear.__init__(self, section, queue, timeout)
 
         global_bear_list = [TestTwoBear, TestThreeBear]
         list1, list2 = instantiate_bears(self.sections['cli'], [],
                                          global_bear_list, {}, self.queue,
                                          console_printer=self.console_printer,
-                                         debug=False,
-                                         debug_bears=['TestTwoBear',
-                                                      'TestThreeBear'])
+                                         debug=False)
 
         self.assertEqual(len(list1), 0)
         self.assertEqual(len(list2), 1)
@@ -640,7 +635,7 @@ class ProcessingTest(unittest.TestCase):
             global_bear_list = [TestOneBear]
             instantiate_bears(self.sections['cli'], [], global_bear_list, {},
                               self.queue, console_printer=self.console_printer,
-                              debug=True, debug_bears=False)
+                              debug=True)
 
 
 class ProcessingTest_GetDefaultActions(unittest.TestCase):


### PR DESCRIPTION
Add initial Fix the API breakage problem
because of `debugger` flag in bear base
class.

Related to https://github.com/coala/coala/issues/5676
