### PR TITLE
CliParsing.py,ConfParser.py : Change in variable name

### DIFF
--- a/coalib/parsing/CliParsing.py
+++ b/coalib/parsing/CliParsing.py
@@ -5,14 +5,16 @@ from collections import OrderedDict
 from coalib.parsing.DefaultArgParser import default_arg_parser
 from coalib.parsing.LineParser import LineParser
 from coalib.settings.Section import Section, append_to_sections
+from coalib.bearlib import deprecate_settings
 
 
+@deprecate_settings(comment_separators='comment_seperators')
 def parse_cli(arg_list=None,
               origin=os.getcwd(),
               arg_parser=None,
               args=None,
               key_value_delimiters=('=', ':'),
-              comment_seperators=(),
+              comment_separators=(),
               key_delimiters=(',',),
               section_override_delimiters=('.',),
               key_value_append_delimiters=('+=',)):
@@ -28,7 +30,7 @@ def parse_cli(arg_list=None,
     :param key_value_delimiters:        Delimiters to separate key and value
                                         in setting arguments where settings are
                                         being defined.
-    :param comment_seperators:          Allowed prefixes for comments.
+    :param comment_separators:          Allowed prefixes for comments.
     :param key_delimiters:              Delimiter to separate multiple keys of
                                         a setting argument.
     :param section_override_delimiters: The delimiter to delimit the section
@@ -52,7 +54,7 @@ def parse_cli(arg_list=None,
     origin += os.path.sep
     sections = OrderedDict(cli=Section('cli'))
     line_parser = LineParser(key_value_delimiters,
-                             comment_seperators,
+                             comment_separators,
                              key_delimiters,
                              {},
                              section_override_delimiters,

--- a/coalib/parsing/ConfParser.py
+++ b/coalib/parsing/ConfParser.py
@@ -7,20 +7,22 @@ from coalib.misc import Constants
 from coalib.parsing.LineParser import LineParser
 from coalib.settings.Section import Section
 from coalib.settings.Setting import Setting
+from coalib.bearlib import deprecate_settings
 
 
 class ConfParser:
 
+    @deprecate_settings(comment_separators='comment_seperators')
     def __init__(self,
                  key_value_delimiters=('=',),
-                 comment_seperators=('#',),
+                 comment_separators=('#',),
                  key_delimiters=(',', ' '),
                  section_name_surroundings=MappingProxyType({'[': ']'}),
                  remove_empty_iter_elements=True,
                  key_value_append_delimiters=('+=',)):
         self.line_parser = LineParser(
             key_value_delimiters,
-            comment_seperators,
+            comment_separators,
             key_delimiters,
             section_name_surroundings,
             key_value_append_delimiters=key_value_append_delimiters)

--- a/tests/parsing/ConfParserTest.py
+++ b/tests/parsing/ConfParserTest.py
@@ -62,6 +62,15 @@ class ConfParserTest(unittest.TestCase):
     def tearDown(self):
         os.remove(self.file)
 
+    def test_warning_typo(self):
+        logger = logging.getLogger()
+        with self.assertLogs(logger, 'WARNING') as cm:
+            newConf = ConfParser(comment_seperators=('#',))
+            self.assertEquals(cm.output[0], 'WARNING:root:The setting '
+                              '`comment_seperators` is deprecated. '
+                              'Please use `comment_separators` '
+                              'instead.')
+
     def test_parse_nonexisting_file(self):
         self.assertRaises(FileNotFoundError,
                           self.uut.parse,


### PR DESCRIPTION
Corrected typo in variable name comment_seperator and changed it to comment_separator.
Added comment_seperator as a deprecated argument.

Closes https://github.com/coala/coala/issues/5510

### Checklist

- [x] I read the [commit guidelines](http://coala.io/commit) and I've followed
      them.
- [x] I ran coala over my code locally. (*All commits have to pass
      individually.* It is not sufficient to have "fixup commits" on your PR,
      our bot will still report the issues for the previous commit.) You will
      likely receive a lot of bot comments and build failures if coala does not
      pass on every single commit!