### PR TITLE
deprecate_settings: Support splitting setting

### DIFF
--- a/tests/bearlib/DeprecateSettingsTest.py
+++ b/tests/bearlib/DeprecateSettingsTest.py
@@ -1,3 +1,4 @@
+import logging
 import unittest
 
 from coalib.bearlib import deprecate_settings
@@ -10,8 +11,39 @@ def func(new):
     """
 
 
+@deprecate_settings(x=('a', lambda a: a+1), y=('a', lambda a: a+2))
+def func_2(x, y):
+    return x+y
+
+
 class DeprecateSettingsTest(unittest.TestCase):
 
     def test_docstring(self):
         self.assertEqual(func.__doc__.strip(),
                          'This docstring will not be lost.')
+
+    def test_splitting_deprecated_arg(self):
+        logger = logging.getLogger()
+
+        with self.assertLogs(logger, 'WARNING') as cm:
+            self.assertEqual(func_2(a=1), 5)
+
+            sortedOutput = sorted(cm.output)
+            self.assertEqual(sortedOutput[0], 'WARNING:root:The setting `a` is '
+                             'deprecated. Please use `x` instead.')
+            self.assertEqual(sortedOutput[1], 'WARNING:root:The setting `a` is '
+                             'deprecated. Please use `y` instead.')
+
+    def test_splitting_with_conflict(self):
+        logger = logging.getLogger()
+
+        with self.assertLogs(logger, 'WARNING') as cm:
+            self.assertEqual(func_2(a=1, x=10, y=20), 30)
+
+            sortedOutput = sorted(cm.output)
+            self.assertEqual(sortedOutput[0], 'WARNING:root:The value of `a`'
+                             ' and `x` are conflicting.'
+                             ' `x` will be used instead.')
+            self.assertEqual(sortedOutput[1], 'WARNING:root:The value of `a`'
+                             ' and `y` are conflicting.'
+                             ' `y` will be used instead.')


### PR DESCRIPTION
Adds support for splitting deprecated arg into multiple new args.
Adds test for it as well.

Closes https://github.com/coala/coala/issues/5683

<!--
Thanks for your contribution!

Please take a quick look at those things down there. They're quite important.
Really! We wrote them for you. Yes you! With utmost care. Read them.
-->

**For short term contributors:** we understand that getting your commits well
defined like we require is a hard task and takes some learning. If you
look to help without wanting to contribute long term there's no need
for you to learn this. Just drop us a message and we'll take care of brushing
up your stuff for merge!

### Checklist

- [x] I read the [commit guidelines](http://coala.io/commit) and I've followed
      them.
- [x] I ran coala over my code locally. (*All commits have to pass
      individually.* It is not sufficient to have "fixup commits" on your PR,
      our bot will still report the issues for the previous commit.) You will
      likely receive a lot of bot comments and build failures if coala does not
      pass on every single commit!

After you submit your pull request, **DO NOT click the 'Update Branch' button.**
When asked for a rebase, consult [coala.io/rebase](https://coala.io/rebase)
instead.

Please consider helping us by reviewing other peoples pull requests as well:

- pick up any PR at <https://coala.io/review>
- review it (check <https://coala.io/reviewing> for more info)
- if you are sure that it needs work, use `corobo mark wip <URL>` to get it out
  of the review queue.

The more you review, the more your score will grow at coala.io and we will
review your PRs faster!
