### PR TITLE
LocalBearTestHelper: Decommission timeout

### DIFF
--- a/coalib/testing/LocalBearTestHelper.py
+++ b/coalib/testing/LocalBearTestHelper.py
@@ -3,8 +3,6 @@ import unittest
 from contextlib import contextmanager, ExitStack
 from unittest.mock import patch
 
-import pytest
-
 from coalib.bearlib.abstractions.LinterClass import LinterClass
 from coalib.testing.BearTestHelper import generate_skip_decorator
 from coalib.bears.LocalBear import LocalBear
@@ -367,12 +365,13 @@ def verify_local_bear(bear,
     :param force_linebreaks: Whether to append newlines at each line
                              if needed. (Bears expect a \\n for every line)
     :param create_tempfile:  Whether to save lines in tempfile if needed.
-    :param timeout:          The total time to run the test for.
+    :param timeout:          Unused.  Use pytest-timeout or similar.
     :param tempfile_kwargs:  Kwargs passed to tempfile.mkstemp() if tempfile
                              needs to be created.
     :return:                 A unittest.TestCase object.
     """
-    @pytest.mark.timeout(timeout)
+    assert not timeout
+
     @generate_skip_decorator(bear)
     class LocalBearTest(LocalBearTestHelper):
 


### PR DESCRIPTION
LocalBearTestHelper had an undeclared dependency on pytest-timeout
so it would not work unless the user had install pytest-timeout.
None of our bear test suites use this timeout argument, as the
timeout set in their repo configuration is sufficient.

Fixes https://github.com/coala/coala/issues/5508

<!--
Thanks for your contribution!

Please take a quick look at those things down there. They're quite important.
Really! We wrote them for you. Yes you! With utmost care. Read them.
-->

**For short term contributors:** we understand that getting your commits well
defined like we require is a hard task and takes some learning. If you
look to help without wanting to contribute long term there's no need
for you to learn this. Just drop us a message and we'll take care of brushing
up your stuff for merge!

### Checklist

- [ ] I read the [commit guidelines](http://coala.io/commit) and I've followed
      them.
- [ ] I ran coala over my code locally. (*All commits have to pass
      individually.* It is not sufficient to have "fixup commits" on your PR,
      our bot will still report the issues for the previous commit.) You will
      likely receive a lot of bot comments and build failures if coala does not
      pass on every single commit!

After you submit your pull request, **DO NOT click the 'Update Branch' button.**
When asked for a rebase, consult [coala.io/rebase](https://coala.io/rebase)
instead.

Please consider helping us by reviewing other peoples pull requests as well:

- pick up any PR at <https://coala.io/review>
- review it (check <https://coala.io/reviewing> for more info)
- if you are sure that it needs work, use `corobo mark wip <URL>` to get it out
  of the review queue.

The more you review, the more your score will grow at coala.io and we will
review your PRs faster!
