### PR TITLE
Collectors.py: Discard trailing ** in ignore glob

### DIFF
--- a/coalib/collecting/Collectors.py
+++ b/coalib/collecting/Collectors.py
@@ -70,6 +70,15 @@ def icollect(file_paths, ignored_globs=None, match_cache={},
     if isinstance(file_paths, str):
         file_paths = [file_paths]
 
+    if ignored_globs is None:
+        ignored_globs = []
+    for index, glob in enumerate(ignored_globs):
+        if glob.endswith('/**') or glob.endswith('\\**'):
+            logging.warning("Detected trailing globstar in ignore glob '{}'. "
+                            "Please remove the unnecessary '**' from its end."
+                            .format(glob))
+            ignored_globs[index] = glob.rstrip('*')
+
     for file_path in file_paths:
         if file_path not in match_cache:
             match_cache[file_path] = list(iglob(file_path))

--- a/tests/collecting/CollectorsTest.py
+++ b/tests/collecting/CollectorsTest.py
@@ -116,6 +116,22 @@ class CollectFilesTest(unittest.TestCase):
                 ignored_file_paths=[dir_base('py_files', '*')]),
             [dir_base('c_files', 'file1.c')])
 
+    def test_trailing_globstar(self):
+        ignore_path = os.path.join(self.collectors_test_dir,
+                                   'others',
+                                   'c_files',
+                                   '**')
+        with LogCapture() as capture:
+            collect_files(file_paths=[],
+                          ignored_file_paths=[ignore_path],
+                          log_printer=self.log_printer)
+        capture.check(
+            ('root', 'WARNING', 'Detected trailing globstar in ignore glob '
+                                '\'{}\'. Please remove the unnecessary \'**\''
+                                ' from its end.'
+                                .format(ignore_path))
+        )
+
     def test_limited(self):
         self.assertEqual(
             collect_files([os.path.join(self.collectors_test_dir,


### PR DESCRIPTION
Remove the trailing globstar from ignore glob patterns and warn the user
about it. This ensures that the entire directory is not globbed.

Closes https://github.com/coala/coala/issues/5737

<!--
Thanks for your contribution!

Please take a quick look at those things down there. They're quite important.
Really! We wrote them for you. Yes you! With utmost care. Read them.
-->

**For short term contributors:** we understand that getting your commits well
defined like we require is a hard task and takes some learning. If you
look to help without wanting to contribute long term there's no need
for you to learn this. Just drop us a message and we'll take care of brushing
up your stuff for merge!

### Checklist

- [x] I read the [commit guidelines](http://coala.io/commit) and I've followed
      them.
- [x] I ran coala over my code locally. (*All commits have to pass
      individually.* It is not sufficient to have "fixup commits" on your PR,
      our bot will still report the issues for the previous commit.) You will
      likely receive a lot of bot comments and build failures if coala does not
      pass on every single commit!

After you submit your pull request, **DO NOT click the 'Update Branch' button.**
When asked for a rebase, consult [coala.io/rebase](https://coala.io/rebase)
instead.

Please consider helping us by reviewing other peoples pull requests as well:

- pick up any PR at <https://coala.io/review>
- review it (check <https://coala.io/reviewing> for more info)
- if you are sure that it needs work, use `corobo mark wip <URL>` to get it out
  of the review queue.

The more you review, the more your score will grow at coala.io and we will
review your PRs faster!

