### PR TITLE
[WIP] Make the README a kinder place by removing/replacing the John Woods quote.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -3,10 +3,6 @@
 
 =====
 
-:emphasis:`"Always code as if the guy who ends up maintaining your code will be a violent psychopath who knows where you live."` ― `John F. Woods <http://ruby.zigzo.com/2014/08/01/who-said-that-one-violent-psychopath-quote/>`_
-
-=====
-
 |Linux Build Status| |Windows Build status| |macOS Build Status|
 |codecov.io| |Documentation Status| |AGPL| |OpenHub|
 


### PR DESCRIPTION
Hey folks :wave: 

This PR is to discuss the removal of the John Woods quote from the README. I believe that quote is a product of its time (1991), and that Coala can do better to be a welcoming project. 
We should write maintainable code because we have respect for our peers and colleagues who will read and work with it, not because of threat of death. The quote is also unnecessarily gendered. 

Apologies also for the drive-by PR 🙇  For some additional context, I became aware of this quote because I work with a lot of software development students, and saw a large number were contributors to Coala. Coala is doing an amazing job of being accessible to students and upcoming software developers, but this also makes it important to ensure that students who work on this project are being taught respect for their fellow humans 💖 

I've added [WIP] as currently this commit removes the quote entirely. It may be more suitable to find an alternative to fill that space and act as the one-line pitch. If anyone has suggestions, please feel free to add them! 

### Checklist

- [x] I read the [commit guidelines](http://coala.io/commit) and I've followed
      them.
- [ ] I ran coala over my code locally. _No changes to code - only to the README_
