### PR TITLE
Git_Basics.rst: Maximum line length of commit body change to 72

### DIFF
--- a/docs/Developers/Git_Basics.rst
+++ b/docs/Developers/Git_Basics.rst
@@ -208,7 +208,7 @@ parts. They should have a newline between them.
 
   The body should have a short paragraph that briefly describes the change
   that was made, and the reason why this change was needed in imperative.
-  Its maximum length is 50 characters.
+  Its maximum length is 72 characters.
 
 - **The issue that is being fixed**
 


### PR DESCRIPTION
Character length of commit body is changed from 50 to 72.

Closes #5777 