### PR TITLE
Fixing typo in Writing_Native_Bears.rst

### DIFF
--- a/docs/Developers/Writing_Native_Bears.rst
+++ b/docs/Developers/Writing_Native_Bears.rst
@@ -202,7 +202,7 @@ First, coala looked at the parameters of the run method and found that
 we need some value named user\_input. Then it parsed our documentation
 comment and found a description for the parameter which was shown to us
 to help us choose the right value. After the needed values are provided,
-coala converts us the value into a string because we've provided the
+coala converts the value into a string because we've provided the
 ``str`` annotation for this parameter. If no annotation is given or the
 value isn't convertible into the desired data type, you will get a
 ``coalib.settings.Setting.Setting``.


### PR DESCRIPTION
Writing_Native_Bears.rst:Fix typo on line 205
This fixes typo and removes the extra 
us on line 205 in coala documentation.
Fixes https://github.com/coala/coala/issues/5766