### PR TITLE
Setting.py: Add SourcePosition to Setting.origin

### DIFF
--- a/coalib/parsing/ConfParser.py
+++ b/coalib/parsing/ConfParser.py
@@ -8,6 +8,7 @@ from coalib.parsing.LineParser import LineParser
 from coalib.settings.Section import Section
 from coalib.settings.Setting import Setting
 from coalib.bearlib import deprecate_settings
+from coalib.results.SourcePosition import SourcePosition
 
 
 class ConfParser:
@@ -90,6 +91,7 @@ class ConfParser:
         current_section = self.get_section(current_section_name)
         current_keys = []
         no_section = True
+        line_number = 0
 
         for line in lines:
             (section_name,
@@ -98,6 +100,7 @@ class ConfParser:
              append,
              comment) = self.line_parser._parse(line)
 
+            line_number += 1
             if comment != '':
                 self.__add_comment(current_section, comment, origin)
 
@@ -135,7 +138,8 @@ class ConfParser:
                     current_section.add_or_create_setting(
                         Setting(key,
                                 value,
-                                origin,
+                                SourcePosition(
+                                    str(origin), line=line_number),
                                 to_append=append,
                                 # Start ignoring PEP8Bear, PycodestyleBear*
                                 # they fail to resolve this
@@ -149,7 +153,8 @@ class ConfParser:
                         True).add_or_create_setting(
                             Setting(key,
                                     value,
-                                    origin,
+                                    SourcePosition(
+                                        str(origin), line=line_number),
                                     to_append=append,
                                     # Start ignoring PEP8Bear, PycodestyleBear*
                                     # they fail to resolve this

--- a/coalib/results/SourcePosition.py
+++ b/coalib/results/SourcePosition.py
@@ -25,6 +25,7 @@ class SourcePosition(TextPosition):
         """
         TextPosition.__init__(self, line, column)
 
+        self.filename = file
         self._file = abspath(file)
 
     @property
@@ -36,3 +37,11 @@ class SourcePosition(TextPosition):
         if use_relpath:
             _dict['file'] = relpath(_dict['file'])
         return _dict
+
+    def __str__(self):
+        source_position = self.filename
+        if self.line is not None:
+            source_position += ':' + str(self.line)
+        if self.column is not None:
+            source_position += ':' + str(self.column)
+        return source_position

--- a/coalib/settings/ConfigurationGathering.py
+++ b/coalib/settings/ConfigurationGathering.py
@@ -367,8 +367,7 @@ def get_config_directory(section):
 
     However if its origin is already a directory this will be preserved:
 
-    >>> files = section['files']
-    >>> files.origin = os.path.abspath('/tmp/dir/')
+    >>> files = Setting('files', '**', origin=os.path.abspath('/tmp/dir/'))
     >>> section.append(files)
     >>> os.makedirs(section['files'].origin, exist_ok=True)
     >>> get_config_directory(section) == section['files'].origin

--- a/coalib/settings/Setting.py
+++ b/coalib/settings/Setting.py
@@ -8,6 +8,7 @@ from coala_utils.decorators import (
 from coala_utils.string_processing.StringConverter import StringConverter
 from coalib.bearlib.languages.Language import Language, UnknownLanguageError
 from coalib.parsing.Globbing import glob_escape
+from coalib.results.SourcePosition import SourcePosition
 
 
 def path(obj, *args, **kwargs):
@@ -155,7 +156,7 @@ class Setting(StringConverter):
     def __init__(self,
                  key,
                  value,
-                 origin: str = '',
+                 origin: (str, SourcePosition) = '',
                  strip_whitespaces: bool = True,
                  list_delimiters: Iterable = (',', ';'),
                  from_cli: bool = False,
@@ -196,7 +197,7 @@ class Setting(StringConverter):
 
         self.from_cli = from_cli
         self.key = key
-        self.origin = str(origin)
+        self._origin = origin
 
     def __path__(self, origin=None, glob_escape_origin=False):
         """
@@ -296,3 +297,22 @@ class Setting(StringConverter):
                              'incomplete. Please access the value of the '
                              'setting in a section to get the complete value.')
         return self._value
+
+    @property
+    def origin(self):
+        """
+        Returns the filename.
+        """
+        if isinstance(self._origin, SourcePosition):
+            return self._origin.filename
+        else:
+            return self._origin
+
+    @property
+    def line_number(self):
+        if isinstance(self._origin, SourcePosition):
+            return self._origin.line
+        else:
+            raise TypeError("Instantiated with str 'origin' "
+                            'which does not have line numbers. '
+                            'Use SourcePosition for line numbers.')

--- a/tests/parsing/ConfParserTest.py
+++ b/tests/parsing/ConfParserTest.py
@@ -98,6 +98,11 @@ class ConfParserTest(unittest.TestCase):
         self.assertRegex(self.cm.output[0],
                          'A setting does not have a section.')
 
+        # Check if line number is correctly set when
+        # no section is given
+        line_num = val.contents['setting'].line_number
+        self.assertEqual(line_num, 1)
+
     def test_parse_foo_section(self):
         foo_should = OrderedDict([
             ('a_default', 'val'),
@@ -146,6 +151,13 @@ class ConfParserTest(unittest.TestCase):
 
         self.assertEqual(val['comment1'].key, 'comment1')
 
+        # Check starting line number of
+        # settings in makefiles section.
+        line_num = val.contents['another'].line_number
+        self.assertEqual(line_num, 12)
+        line_num = val.contents['append'].line_number
+        self.assertEqual(line_num, 20)
+
     def test_parse_empty_elem_strip_section(self):
         empty_elem_strip_should = OrderedDict([
             ('a', 'a, b, c'),
@@ -166,6 +178,22 @@ class ConfParserTest(unittest.TestCase):
         for k in val:
             is_dict[k] = str(val[k])
         self.assertEqual(is_dict, empty_elem_strip_should)
+
+        # Check starting line number of
+        # settings in empty_elem_strip section.
+        line_num = val.contents['b'].line_number
+        self.assertEqual(line_num, 24)
+
+    def test_line_number_name_section(self):
+        # Pop off the default, foo, makefiles and empty_elem_strip sections.
+        self.sections.popitem(last=False)
+        self.sections.popitem(last=False)
+        self.sections.popitem(last=False)
+        self.sections.popitem(last=False)
+
+        key, val = self.sections.popitem(last=False)
+        line_num = val.contents['key1'].line_number
+        self.assertEqual(line_num, 30)
 
     def test_remove_empty_iter_elements(self):
         # Test with empty-elem stripping.

--- a/tests/results/SourcePositionTest.py
+++ b/tests/results/SourcePositionTest.py
@@ -25,12 +25,17 @@ class SourcePositionTest(unittest.TestCase):
             repr(uut),
             "<SourcePosition object\\(file='.*filename', line=1, "
             'column=None\\) at 0x[0-9a-fA-F]+>')
+        self.assertEqual(str(uut), 'filename:1')
 
         uut = SourcePosition('None', None)
         self.assertRegex(
             repr(uut),
             "<SourcePosition object\\(file='.*None', line=None, column=None\\) "
             'at 0x[0-9a-fA-F]+>')
+        self.assertEqual(str(uut), 'None')
+
+        uut = SourcePosition('filename', 3, 2)
+        self.assertEqual(str(uut), 'filename:3:2')
 
     def test_json(self):
         with prepare_file([''], None) as (_, filename):


### PR DESCRIPTION
This adds SourcePosition to Setting.origin which helps
in identifying the starting line number of a setting in 
.coafile.

Related to https://github.com/coala/coala/issues/5044

<!--
Thanks for your contribution!

Please take a quick look at those things down there. They're quite important.
Really! We wrote them for you. Yes you! With utmost care. Read them.
-->

**For short term contributors:** we understand that getting your commits well
defined like we require is a hard task and takes some learning. If you
look to help without wanting to contribute long term there's no need
for you to learn this. Just drop us a message and we'll take care of brushing
up your stuff for merge!

### Checklist

- [ ] I read the [commit guidelines](http://coala.io/commit) and I've followed
      them.
- [ ] I ran coala over my code locally. (*All commits have to pass
      individually.* It is not sufficient to have "fixup commits" on your PR,
      our bot will still report the issues for the previous commit.) You will
      likely receive a lot of bot comments and build failures if coala does not
      pass on every single commit!

After you submit your pull request, **DO NOT click the 'Update Branch' button.**
When asked for a rebase, consult [coala.io/rebase](https://coala.io/rebase)
instead.

Please consider helping us by reviewing other peoples pull requests as well:

- pick up any PR at <https://coala.io/review>
- review it (check <https://coala.io/reviewing> for more info)
- if you are sure that it needs work, use `corobo mark wip <URL>` to get it out
  of the review queue.

The more you review, the more your score will grow at coala.io and we will
review your PRs faster!
