### PR TITLE
__init__.py: Arrange imports alphabetically

### DIFF
--- a/coalib/bearlib/languages/__init__.py
+++ b/coalib/bearlib/languages/__init__.py
@@ -7,6 +7,7 @@ from .Language import Language
 from .Language import Languages
 
 from .definitions.Unknown import Unknown
+
 from .definitions.antlr import antlr
 from .definitions.Bash import Bash
 from .definitions.C import C
@@ -20,12 +21,13 @@ from .definitions.GraphQL import GraphQL
 from .definitions.html import HTML
 from .definitions.Java import Java
 from .definitions.JavaScript import JavaScript
+from .definitions.Jinja2 import Jinja2
 from .definitions.JSON import JSON
 from .definitions.JSP import JSP
 from .definitions.KornShell import KornShell
 from .definitions.m4 import m4
-from .definitions.Matlab import Matlab
 from .definitions.Markdown import Markdown
+from .definitions.Matlab import Matlab
 from .definitions.ObjectiveC import ObjectiveC
 from .definitions.PHP import PHP
 from .definitions.PLSQL import PLSQL
@@ -33,14 +35,14 @@ from .definitions.PowerShell import PowerShell
 from .definitions.Python import Python
 from .definitions.Ruby import Ruby
 from .definitions.Scala import Scala
+from .definitions.Shell import Shell
 from .definitions.Swift import Swift
 from .definitions.Tcl import Tcl
 from .definitions.TinyBasic import TinyBasic
-from .definitions.Vala import Vala
 from .definitions.TypeScript import TypeScript
-from .definitions.Shell import Shell
-from .definitions.Jinja2 import Jinja2
+from .definitions.Vala import Vala
 from .definitions.VisualBasic import VisualBasic
 from .definitions.XML import XML
-from.definitions.ZShell import ZShell
+from .definitions.ZShell import ZShell
+
 # Stop ignoring PyUnusedCodeBear


### PR DESCRIPTION
Fixes  #5745 
I've used a tool called `isort` https://pypi.org/project/isort/.

It helps sorting the imported module in alphabetical order just by running a command and saves time.