### PR TITLE
Fixed CI errors due to autopep8 upgrade

### DIFF
--- a/coala
+++ b/coala
@@ -13,10 +13,10 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+# Start ignoring PEP8Bear*, PyImportSortBear and PycodestyleBear*, we need to
+# assert the version before importing things that could cause an ImportError
 import sys
 
-# Start ignoring PyImportSortBear and PycodestyleBear*, we need to assert the
-# version before importing things that could cause an ImportError
 from coalib import assert_supported_version
 
 assert_supported_version()

--- a/tests/bearlib/abstractions/external_bear_wrap_testfiles/ExternalBearWrapTest.py
+++ b/tests/bearlib/abstractions/external_bear_wrap_testfiles/ExternalBearWrapTest.py
@@ -42,6 +42,12 @@ class ExternalBearWrapComponentTest(unittest.TestCase):
             return 1
 
     def setUp(self):
+        self._old_python_path = os.environ.get('PYTHONPATH')
+        os.environ['PYTHONPATH'] = os.path.join(
+            os.path.dirname(__file__),
+            '..', '..', '..', '..',
+        )
+
         self.section = Section('TEST_SECTION')
 
         self.test_program_path = get_testfile_path('test_external_bear.py')
@@ -49,6 +55,10 @@ class ExternalBearWrapComponentTest(unittest.TestCase):
         self.testfile_path = get_testfile_path('test_file.txt')
         with open(self.testfile_path, mode='r') as fl:
             self.testfile_content = fl.read().splitlines(keepends=True)
+
+    def tearDown(self):
+        if self._old_python_path:
+            os.environ['PYTHONPATH'] = self._old_python_path
 
     def test_decorator_invalid_parameters(self):
         with self.assertRaises(ValueError) as cm:

--- a/tests/bearlib/abstractions/external_bear_wrap_testfiles/test_external_bear.py
+++ b/tests/bearlib/abstractions/external_bear_wrap_testfiles/test_external_bear.py
@@ -1,17 +1,10 @@
-import os
 import sys
 import json
-
-# Start ignoring PycodestyleBear* as those imports may raise
-# import warnings
-sys.path.append(os.path.join(os.path.dirname(__file__),
-                             '..', '..', '..', '..'))
 
 from coalib.results.Result import Result
 from coalib.results.SourceRange import SourceRange
 from coalib.output.JSONEncoder import create_json_encoder
 from coalib.results.RESULT_SEVERITY import RESULT_SEVERITY
-# Stop ignoring
 
 if __name__ == '__main__':
 


### PR DESCRIPTION
The tests were failing due to new feature in autopep8,
i.e. E402 - Fix module level import not at top of file.

Closes #5834

<!--
Thanks for your contribution!

Please take a quick look at those things down there. They're quite important.
Really! We wrote them for you. Yes you! With utmost care. Read them.
-->

**For short term contributors:** we understand that getting your commits well
defined like we require is a hard task and takes some learning. If you
look to help without wanting to contribute long term there's no need
for you to learn this. Just drop us a message and we'll take care of brushing
up your stuff for merge!

### Checklist

- [x] I read the [commit guidelines](http://coala.io/commit) and I've followed
      them.
- [x] I ran coala over my code locally. (*All commits have to pass
      individually.* It is not sufficient to have "fixup commits" on your PR,
      our bot will still report the issues for the previous commit.) You will
      likely receive a lot of bot comments and build failures if coala does not
      pass on every single commit!

After you submit your pull request, **DO NOT click the 'Update Branch' button.**
When asked for a rebase, consult [coala.io/rebase](https://coala.io/rebase)
instead.

Please consider helping us by reviewing other peoples pull requests as well:

- pick up any PR at <https://coala.io/review>
- review it (check <https://coala.io/reviewing> for more info)
- if you are sure that it needs work, use `corobo mark wip <URL>` to get it out
  of the review queue.

The more you review, the more your score will grow at coala.io and we will
review your PRs faster!
