### PR TITLE
LocalBearTestHelper.py: Add deprecation warning

### DIFF
--- a/coalib/testing/LocalBearTestHelper.py
+++ b/coalib/testing/LocalBearTestHelper.py
@@ -1,3 +1,4 @@
+import logging
 import queue
 import unittest
 from contextlib import contextmanager, ExitStack
@@ -370,7 +371,10 @@ def verify_local_bear(bear,
                              needs to be created.
     :return:                 A unittest.TestCase object.
     """
-    assert not timeout
+    if timeout:
+        logging.warning('timeout is ignored as the timeout set in the repo '
+                        'configuration will be sufficient. Use pytest-timeout '
+                        'or similar to achieve same result.')
 
     @generate_skip_decorator(bear)
     class LocalBearTest(LocalBearTestHelper):

--- a/tests/testing/LocalBearTestHelperTest.py
+++ b/tests/testing/LocalBearTestHelperTest.py
@@ -9,7 +9,7 @@ from tests.test_bears.TestBearDep import (TestDepBearBDependsA,
                                           TestDepBearDependsAAndAA)
 from coalib.bearlib.abstractions.Linter import linter
 from tests.test_bears.LineCountTestBear import LineCountTestBear
-from coala_utils.ContextManagers import prepare_file
+from coala_utils.ContextManagers import prepare_file, retrieve_stderr
 from coalib.results.Result import Result
 from coalib.results.RESULT_SEVERITY import RESULT_SEVERITY
 from coalib.settings.Section import Section
@@ -232,3 +232,12 @@ class LocalBearTestHelper(unittest.TestCase):
         with self.assertRaises(AssertionError), execute_bear(
                 self.uut, 'Luke', files[0]) as result:
             pass
+
+
+class VerifyLocalBearTest(unittest.TestCase):
+    def test_timeout_deprecation_warning(self):
+        with retrieve_stderr() as stderr:
+            verify_local_bear(TestBear, valid_files=(),
+                              invalid_files=files, timeout=50)
+            self.assertIn('timeout is ignored as the timeout set in the repo '
+                          'configuration will be sufficient', stderr.getvalue())


### PR DESCRIPTION
The timeout parameter is unused and this patch
logs a deperecation warning for that.

Closes https://github.com/coala/coala/issues/5812

<!--
Thanks for your contribution!

Please take a quick look at those things down there. They're quite important.
Really! We wrote them for you. Yes you! With utmost care. Read them.
-->

**For short term contributors:** we understand that getting your commits well
defined like we require is a hard task and takes some learning. If you
look to help without wanting to contribute long term there's no need
for you to learn this. Just drop us a message and we'll take care of brushing
up your stuff for merge!

### Checklist

- [X] I read the [commit guidelines](http://coala.io/commit) and I've followed
      them.
- [X] I ran coala over my code locally. (*All commits have to pass
      individually.* It is not sufficient to have "fixup commits" on your PR,
      our bot will still report the issues for the previous commit.) You will
      likely receive a lot of bot comments and build failures if coala does not
      pass on every single commit!

After you submit your pull request, **DO NOT click the 'Update Branch' button.**
When asked for a rebase, consult [coala.io/rebase](https://coala.io/rebase)
instead.

Please consider helping us by reviewing other peoples pull requests as well:

- pick up any PR at <https://coala.io/review>
- review it (check <https://coala.io/reviewing> for more info)
- if you are sure that it needs work, use `corobo mark wip <URL>` to get it out
  of the review queue.

The more you review, the more your score will grow at coala.io and we will
review your PRs faster!
