### PR TITLE
collecting: Fix incorrect trailing '**' warning

### DIFF
--- a/coalib/collecting/Collectors.py
+++ b/coalib/collecting/Collectors.py
@@ -12,7 +12,7 @@ from coala_utils.decorators import yield_once
 from coalib.misc.Exceptions import log_exception
 from coalib.misc.IterUtilities import partition
 from coalib.output.printers.LOG_LEVEL import LOG_LEVEL
-from coalib.parsing.Globbing import fnmatch, iglob, glob_escape
+from coalib.parsing.Globbing import fnmatch, iglob, glob_escape, has_wildcard
 from coalib.bearlib.languages.Language import Languages
 from coalib.bearlib.languages import definitions
 
@@ -73,7 +73,8 @@ def icollect(file_paths, ignored_globs=None, match_cache={},
     if ignored_globs is None:
         ignored_globs = []
     for index, glob in enumerate(ignored_globs):
-        if glob.endswith('/**') or glob.endswith('\\**'):
+        dirname, basename = os.path.split(glob)
+        if not has_wildcard(dirname) and basename == '**':
             logging.warning("Detected trailing globstar in ignore glob '{}'. "
                             "Please remove the unnecessary '**' from its end."
                             .format(glob))

--- a/tests/collecting/CollectorsTest.py
+++ b/tests/collecting/CollectorsTest.py
@@ -117,19 +117,23 @@ class CollectFilesTest(unittest.TestCase):
             [dir_base('c_files', 'file1.c')])
 
     def test_trailing_globstar(self):
-        ignore_path = os.path.join(self.collectors_test_dir,
-                                   'others',
-                                   'c_files',
-                                   '**')
+        ignore_path1 = os.path.join(self.collectors_test_dir,
+                                    'others',
+                                    'c_files',
+                                    '**')  # should generate warning
+        ignore_path2 = os.path.join(self.collectors_test_dir,
+                                    '**',
+                                    'py_files',
+                                    '**')  # no warning
         with LogCapture() as capture:
             collect_files(file_paths=[],
-                          ignored_file_paths=[ignore_path],
+                          ignored_file_paths=[ignore_path1, ignore_path2],
                           log_printer=self.log_printer)
         capture.check(
             ('root', 'WARNING', 'Detected trailing globstar in ignore glob '
                                 '\'{}\'. Please remove the unnecessary \'**\''
                                 ' from its end.'
-                                .format(ignore_path))
+                                .format(ignore_path1))
         )
 
     def test_limited(self):


### PR DESCRIPTION
The warning is necessary only when the rest of the ignore path is a
canonical directory which doesn't contain any wildcards. This commit
adds a check to ensure that if the path contains other wildcards, the
warning isn't generated.

Fixes #5856

<!--
Thanks for your contribution!

Please take a quick look at those things down there. They're quite important.
Really! We wrote them for you. Yes you! With utmost care. Read them.
-->

**For short term contributors:** we understand that getting your commits well
defined like we require is a hard task and takes some learning. If you
look to help without wanting to contribute long term there's no need
for you to learn this. Just drop us a message and we'll take care of brushing
up your stuff for merge!

### Checklist

- [x] I read the [commit guidelines](http://coala.io/commit) and I've followed
      them.
- [x] I ran coala over my code locally. (*All commits have to pass
      individually.* It is not sufficient to have "fixup commits" on your PR,
      our bot will still report the issues for the previous commit.) You will
      likely receive a lot of bot comments and build failures if coala does not
      pass on every single commit!

After you submit your pull request, **DO NOT click the 'Update Branch' button.**
When asked for a rebase, consult [coala.io/rebase](https://coala.io/rebase)
instead.

Please consider helping us by reviewing other peoples pull requests as well:

- pick up any PR at <https://coala.io/review>
- review it (check <https://coala.io/reviewing> for more info)
- if you are sure that it needs work, use `corobo mark wip <URL>` to get it out
  of the review queue.

The more you review, the more your score will grow at coala.io and we will
review your PRs faster!
