### PR TITLE
Dot language definition

### DIFF
--- a/coalib/bearlib/languages/__init__.py
+++ b/coalib/bearlib/languages/__init__.py
@@ -15,6 +15,7 @@ from .definitions.CPP import CPP
 from .definitions.CSharp import CSharp
 from .definitions.CSS import CSS
 from .definitions.D import D
+from .definitions.DOT import DOT
 from .definitions.Fortran import Fortran
 from .definitions.Golang import Golang
 from .definitions.GraphQL import GraphQL

--- a/coalib/bearlib/languages/definitions/DOT.py
+++ b/coalib/bearlib/languages/definitions/DOT.py
@@ -1,0 +1,19 @@
+from coalib.bearlib.languages.Language import Language
+
+
+@Language
+class DOT:
+    aliases = 'DOT',
+    extensions = '.gv', '.dot',
+    comment_delimiters = '//', '#',
+    multiline_comment_delimiters = {'/*': '*/'}
+    string_delimiters = {'"': '"', '<': '>'}
+    indent_types = {'{': '}'}
+    encapsulators = {'(': ')', '[': ']'}
+    keywords = [
+        'node', 'edge', 'graph',
+        'digraph', 'subgraph', 'strict',
+        'shape', 'rank', 'parent',
+        'label', 'labelloc', 'port',
+    ]
+    string_delimiter_escape = {"'": "\'"}

--- a/tests/TestUtilities.py
+++ b/tests/TestUtilities.py
@@ -40,6 +40,7 @@ LANGUAGE_NAMES = [
     'CPP',
     'CSS',
     'D',
+    'DOT',
     'Extensible Markup Language 1.0',
     'Fortran',
     'Golang',


### PR DESCRIPTION
This pull request adds dot language definition.

New language definition is placed in coalib/bearlib/languages/definitions/dot.py

Closes https://github.com/coala/coala/issues/5823