### PR TITLE
Setting.py: Add end line number of setting

### DIFF
--- a/coalib/settings/Section.py
+++ b/coalib/settings/Section.py
@@ -187,6 +187,8 @@ class Section:
         if self.__contains__(key, ignore_defaults=True) and allow_appending:
             val = self[key]
             val.value = str(val._value) + '\n' + setting._value
+            if setting.value != '':
+                val.length += 1
             self.append(val, custom_key=key)
         else:
             self.append(setting, custom_key=key)

--- a/coalib/settings/Setting.py
+++ b/coalib/settings/Setting.py
@@ -198,6 +198,7 @@ class Setting(StringConverter):
         self.from_cli = from_cli
         self.key = key
         self._origin = origin
+        self.length = 1
 
     def __path__(self, origin=None, glob_escape_origin=False):
         """
@@ -312,6 +313,15 @@ class Setting(StringConverter):
     def line_number(self):
         if isinstance(self._origin, SourcePosition):
             return self._origin.line
+        else:
+            raise TypeError("Instantiated with str 'origin' "
+                            'which does not have line numbers. '
+                            'Use SourcePosition for line numbers.')
+
+    @property
+    def end_line_number(self):
+        if isinstance(self._origin, SourcePosition):
+            return self.length + self._origin.line - 1
         else:
             raise TypeError("Instantiated with str 'origin' "
                             'which does not have line numbers. '

--- a/tests/parsing/ConfParserTest.py
+++ b/tests/parsing/ConfParserTest.py
@@ -157,6 +157,10 @@ class ConfParserTest(unittest.TestCase):
         self.assertEqual(line_num, 12)
         line_num = val.contents['append'].line_number
         self.assertEqual(line_num, 20)
+        # Check ending line number of
+        # settings in makefiles section.
+        line_num = val.contents['another'].end_line_number
+        self.assertEqual(line_num, 14)
 
     def test_parse_empty_elem_strip_section(self):
         empty_elem_strip_should = OrderedDict([
@@ -193,6 +197,9 @@ class ConfParserTest(unittest.TestCase):
 
         key, val = self.sections.popitem(last=False)
         line_num = val.contents['key1'].line_number
+        self.assertEqual(line_num, 30)
+
+        line_num = val.contents['key1'].end_line_number
         self.assertEqual(line_num, 30)
 
     def test_remove_empty_iter_elements(self):

--- a/tests/settings/SettingTest.py
+++ b/tests/settings/SettingTest.py
@@ -212,3 +212,11 @@ class SettingTest(unittest.TestCase):
                                     'Use SourcePosition for line numbers.'):
             self.uut = Setting('key', '22\n', origin='filename')
             self.uut.line_number
+
+    def test_end_line_number(self):
+        with self.assertRaisesRegex(TypeError,
+                                    "Instantiated with str 'origin' "
+                                    'which does not have line numbers. '
+                                    'Use SourcePosition for line numbers.'):
+            self.uut = Setting('key', '22\n', origin='filename')
+            self.uut.end_line_number


### PR DESCRIPTION
This adds end line number of a setting in coafile.

Related to https://github.com/coala/coala/issues/5044

<!--
Thanks for your contribution!

Please take a quick look at those things down there. They're quite important.
Really! We wrote them for you. Yes you! With utmost care. Read them.
-->

**For short term contributors:** we understand that getting your commits well
defined like we require is a hard task and takes some learning. If you
look to help without wanting to contribute long term there's no need
for you to learn this. Just drop us a message and we'll take care of brushing
up your stuff for merge!

### Checklist

- [ ] I read the [commit guidelines](http://coala.io/commit) and I've followed
      them.
- [ ] I ran coala over my code locally. (*All commits have to pass
      individually.* It is not sufficient to have "fixup commits" on your PR,
      our bot will still report the issues for the previous commit.) You will
      likely receive a lot of bot comments and build failures if coala does not
      pass on every single commit!

After you submit your pull request, **DO NOT click the 'Update Branch' button.**
When asked for a rebase, consult [coala.io/rebase](https://coala.io/rebase)
instead.

Please consider helping us by reviewing other peoples pull requests as well:

- pick up any PR at <https://coala.io/review>
- review it (check <https://coala.io/reviewing> for more info)
- if you are sure that it needs work, use `corobo mark wip <URL>` to get it out
  of the review queue.

The more you review, the more your score will grow at coala.io and we will
review your PRs faster!
