### PR TITLE
languages: Import SCSS in __init__.py

### DIFF
--- a/coalib/bearlib/languages/__init__.py
+++ b/coalib/bearlib/languages/__init__.py
@@ -37,6 +37,7 @@ from .definitions.PowerShell import PowerShell
 from .definitions.Python import Python
 from .definitions.Ruby import Ruby
 from .definitions.Scala import Scala
+from .definitions.SCSS import SCSS
 from .definitions.Shell import Shell
 from .definitions.Swift import Swift
 from .definitions.Tcl import Tcl

--- a/coalib/bearlib/languages/definitions/SCSS.py
+++ b/coalib/bearlib/languages/definitions/SCSS.py
@@ -6,6 +6,8 @@ class SCSS:
     extensions = '.scss',
     comment_delimiters = '//',
     multiline_comment_delimiters = {'/*': '*/'}
+    string_delimiters = {'"': '"', "'": "'"}
+    multiline_string_delimiters = {}
     encapsulators = {'(': ')', '[': ']'}
     versions = {3.1, 3.2, 3.3, 3.4, 3.5, 4.0}
     interpolation = {'{': '}'}


### PR DESCRIPTION
Also adds string_delimiters and multiline_string_delimiters to SCSS.py

Fixes https://github.com/coala/coala/issues/5903