### PR TITLE
Writing_Good_Commits.rst: Fix grammatical error

### DIFF
--- a/docs/Developers/Writing_Good_Commits.rst
+++ b/docs/Developers/Writing_Good_Commits.rst
@@ -54,7 +54,7 @@ We are now looking at pull request `#5789 <https://github.com/coala/coala/pull/5
    of the issue it closes or fixes.
 
 
-At coala we are looking heavily at the maintainability of the code.
+At coala, we are looking heavily at the maintainability of the code.
 
 .. note::
 


### PR DESCRIPTION
This fixes a grammatical error
and changes the line
`At coala we are looking..` --> `At coala, we are looking...`

Fixes https://github.com/coala/coala/issues/5927

