### PR TITLE
Add language naming format note to bear doc

### DIFF
--- a/docs/Developers/Language_Naming_Format.rst
+++ b/docs/Developers/Language_Naming_Format.rst
@@ -1,0 +1,9 @@
+.. note::
+
+    - For language naming, always consider the format that is used in the
+      corresponding Wikipedia page (exception: use CPP, instead
+      of cpp or c++).
+    - If the definition does not exist already, a language definition
+      should be added while writing a new bear.
+    - The alias used in LANGUAGES should be one of the
+      names in the coala definition.

--- a/docs/Developers/Writing_Linter_Bears.rst
+++ b/docs/Developers/Writing_Linter_Bears.rst
@@ -449,6 +449,8 @@ gather information by using these values. Our bear now looks like:
         return ('--msg-template="L{line}C{column}: {msg_id} - {msg}"',
                 '--reports=n', '--rcfile=' + pylint_rcfile, filename)
 
+.. include:: ./Language_Naming_Format.rst
+
 Running and Testing our Bear
 ----------------------------
 

--- a/docs/Developers/Writing_Native_Bears.rst
+++ b/docs/Developers/Writing_Native_Bears.rst
@@ -411,6 +411,8 @@ strings as a value:
     class SomeBear(Bear):
         LANGUAGES = {'C', 'CPP','C#', 'D'}
 
+.. include:: ./Language_Naming_Format.rst
+
 REQUIREMENTS
 ~~~~~~~~~~~~
 


### PR DESCRIPTION
Add language naming format note to bear doc

This adds language naming format information to
Writing_Native_Bears.rst and Writing_Linter_Bears.rst.
The information is stored in the file Language_Naming_Format.rst.

Closes https://github.com/coala/coala/issues/5826

See the below links for changes.
 https://ibb.co/r3bTtfL

<!--
Thanks for your contribution!

Please take a quick look at those things down there. They're quite important.
Really! We wrote them for you. Yes you! With utmost care. Read them.
-->

**For short term contributors:** we understand that getting your commits well
defined like we require is a hard task and takes some learning. If you
look to help without wanting to contribute long term there's no need
for you to learn this. Just drop us a message and we'll take care of brushing
up your stuff for merge!

### Checklist

- [x] I read the [commit guidelines](http://coala.io/commit) and I've followed
      them.
- [x] I ran coala over my code locally. (*All commits have to pass
      individually.* It is not sufficient to have "fixup commits" on your PR,
      our bot will still report the issues for the previous commit.) You will
      likely receive a lot of bot comments and build failures if coala does not
      pass on every single commit!

After you submit your pull request, **DO NOT click the 'Update Branch' button.**
When asked for a rebase, consult [coala.io/rebase](https://coala.io/rebase)
instead.

Please consider helping us by reviewing other peoples pull requests as well:

- pick up any PR at <https://coala.io/review>
- review it (check <https://coala.io/reviewing> for more info)
- if you are sure that it needs work, use `corobo mark wip <URL>` to get it out
  of the review queue.

The more you review, the more your score will grow at coala.io and we will
review your PRs faster!
