### PR TITLE
SpacingHelper.py: Fix docstring typo

### DIFF
--- a/coalib/bearlib/spacing/SpacingHelper.py
+++ b/coalib/bearlib/spacing/SpacingHelper.py
@@ -88,7 +88,7 @@ class SpacingHelper(SectionCreatable):
         """
         currspaces = 0
         result = ''
-        # Tracking the index of the string isnt enough because tabs are
+        # Tracking the index of the string isn't enough because tabs are
         # spanning over multiple columns
         tabless_position = 0
         for char in line:


### PR DESCRIPTION
This fixes the typo and changes
it from isnt --> isn't

Closes https://github.com/coala/coala/issues/5962