### PR TITLE
setup.py: Add minimum pip requirement check

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,6 +63,7 @@ coverage.xml
 *.log
 local_settings.py
 db.sqlite3
+db.sqlite3-journal
 
 # Flask stuff:
 instance/
@@ -362,6 +363,7 @@ flycheck_*.el
 
 # Session
 Session.vim
+Sessionx.vim
 
 # Temporary
 .netrwhist

--- a/.misc/appveyor.yml
+++ b/.misc/appveyor.yml
@@ -42,7 +42,7 @@ install:
   # Check that we have the expected version and architecture for Python
   - "python --version"
   - "python -c \"import struct; print(struct.calcsize('P') * 8)\""
-  - "%CMD_IN_ENV% python -m pip install --upgrade setuptools==21 pip==9"
+  - "%CMD_IN_ENV% python -m pip install --upgrade setuptools==21 pip==9.0.1"
   - "%CMD_IN_ENV% python -m pip install -r test-requirements.txt \
     -r requirements.txt -r docs-requirements.txt"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -89,7 +89,7 @@ before_install:
   # Apart from builds with python 2.7 and 3.5, it installs setuptools
   # twice. So, it is required to uninstall one version manually.
   - pip uninstall setuptools --yes
-  - pip install pip==9 setuptools==21
+  - pip install pip==9.0.1 setuptools==21
   - python .misc/check_setuptools.py
 
   # https://github.com/coala/coala/issues/3183

--- a/setup.py
+++ b/setup.py
@@ -8,6 +8,7 @@ import sys
 from os import getenv
 from subprocess import call
 
+import pip
 import setuptools.command.build_py
 from setuptools import find_packages, setup
 from setuptools.command.test import test as TestCommand
@@ -437,6 +438,10 @@ SETUP_COMMANDS.update({
 })
 
 if __name__ == '__main__':
+    pip_version = LooseVersion(pip.__version__)
+    if pip_version < LooseVersion('9.0.1'):
+        raise RuntimeError('Version of pip is less than 9.0.1. '
+                           'Consider upgrading pip to pip~=9.0.1')
     setup(name='coala',
           version=VERSION,
           description=DESCRIPTION,


### PR DESCRIPTION
Older setuptools/pip fails on installation
due to missing syntax in them. This fixes
that problem by avoiding such installation.

Related to: https://github.com/coala/coala/issues/6017

<!--
Thanks for your contribution!

Please take a quick look at those things down there. They're quite important.
Really! We wrote them for you. Yes you! With utmost care. Read them.
-->

**For short term contributors:** we understand that getting your commits well
defined like we require is a hard task and takes some learning. If you
look to help without wanting to contribute long term there's no need
for you to learn this. Just drop us a message and we'll take care of brushing
up your stuff for merge!

### Checklist

- [x] I read the [commit guidelines](http://coala.io/commit) and I've followed
      them.
- [x] I ran coala over my code locally. (*All commits have to pass
      individually.* It is not sufficient to have "fixup commits" on your PR,
      our bot will still report the issues for the previous commit.) You will
      likely receive a lot of bot comments and build failures if coala does not
      pass on every single commit!

After you submit your pull request, **DO NOT click the 'Update Branch' button.**
When asked for a rebase, consult [coala.io/rebase](https://coala.io/rebase)
instead.

Please consider helping us by reviewing other peoples pull requests as well:

- pick up any PR at <https://coala.io/review>
- review it (check <https://coala.io/reviewing> for more info)
- if you are sure that it needs work, use `corobo mark wip <URL>` to get it out
  of the review queue.

The more you review, the more your score will grow at coala.io and we will
review your PRs faster!
