### PR TITLE
ConsoleInteraction: Modify color_letter function

### DIFF
--- a/coalib/output/ConsoleInteraction.py
+++ b/coalib/output/ConsoleInteraction.py
@@ -97,22 +97,24 @@ DIFF_EXCERPT_MAX_SIZE = 4
 
 
 def color_letter(console_printer, line):
-    x = -1
-    y = -1
-    letter = ''
-    for i, l in enumerate(line, 0):
-        if line[i] == '(':
-            x = i
-        if line[i] == ')':
-            y = i
-        if l.isupper() and x != -1:
-            letter = l
+    x = line.find('(')
+    if x == -1:
+        letter = ''
+        y = x + 1
+    else:
+        letter = line[x + 1]
+        y = x + 2
+    warn = line.rfind('[')
+    if warn == 0:
+        warn = len(line)
     first_part = line[:x+1]
-    second_part = line[y:]
+    second_part = line[y:warn]
+    warning_part = line[warn:]
 
     console_printer.print(first_part, end='')
     console_printer.print(letter, color='blue', end='')
-    console_printer.print(second_part)
+    console_printer.print(second_part, end='')
+    console_printer.print(warning_part, color='blue')
 
 
 def format_lines(lines, symbol='', line_nr=''):

--- a/tests/output/ConsoleInteractionTest.py
+++ b/tests/output/ConsoleInteractionTest.py
@@ -22,7 +22,8 @@ from coalib.output.ConsoleInteraction import (
     show_language_bears_capabilities)
 from coalib.output.ConsoleInteraction import (BackgroundSourceRangeStyle,
                                               BackgroundMessageStyle,
-                                              highlight_text)
+                                              highlight_text,
+                                              color_letter)
 from coalib.output.printers.ListLogPrinter import ListLogPrinter
 from coalib.parsing.DefaultArgParser import default_arg_parser
 from coalib.results.Diff import Diff
@@ -188,6 +189,22 @@ class ConsoleInteractionTest(unittest.TestCase):
     def tearDown(self):
         OpenEditorAction.is_applicable = self.old_open_editor_applicable
         ApplyPatchAction.is_applicable = self.old_apply_patch_applicable
+
+    def test_color_letter(self):
+        line1 = '[  ] 1. (A)pply Patch'
+        with retrieve_stdout() as stdout:
+            color_letter(self.console_printer, line1)
+            self.assertEqual(line1 + '\n', stdout.getvalue())
+
+        line2 = '[  ] *0. Apply (P)atch'
+        with retrieve_stdout() as stdout:
+            color_letter(self.console_printer, line2)
+            self.assertEqual(line2 + '\n', stdout.getvalue())
+
+        line3 = '[  ] 3. Apply (P)atch [Note: This will do something]'
+        with retrieve_stdout() as stdout:
+            color_letter(self.console_printer, line3)
+            self.assertEqual(line3 + '\n', stdout.getvalue())
 
     def test_require_settings(self):
         curr_section = Section('')


### PR DESCRIPTION
This modifies color_letter function to run as correctly
when there is a uppercase letter after "the" uppercase
letter in parenthesis and also if action has a associated warning then
it gets highlighted.

Fixes https://github.com/coala/coala/issues/6034