### PR TITLE
Linter.py: added memory location in Linter meta class __repr__

### DIFF
--- a/coalib/bearlib/abstractions/Linter.py
+++ b/coalib/bearlib/abstractions/Linter.py
@@ -167,8 +167,8 @@ def _create_linter(klass, options):
     class LinterMeta(type):
 
         def __repr__(cls):
-            return '<{} linter class (wrapping {!r})>'.format(
-                cls.__name__, options['executable'])
+            return '<{} linter class (wrapping {!r}) at {}>'.format(
+                cls.__name__, options['executable'], hex(id(cls)))
 
     class LinterBase(metaclass=LinterMeta):
 

--- a/tests/bearlib/abstractions/LinterTest.py
+++ b/tests/bearlib/abstractions/LinterTest.py
@@ -1090,15 +1090,15 @@ class LinterOtherTest(LinterTestBase):
 
     def test_metaclass_repr(self):
         uut = linter('my-tool')(self.ManualProcessingTestLinter)
-        self.assertEqual(
+        self.assertRegex(
             repr(uut),
-            "<ManualProcessingTestLinter linter class (wrapping 'my-tool')>")
+            "<ManualProcessingTestLinter linter class \\(wrapping 'my-tool'\\) at 0x[a-fA-F0-9]+>")
 
         # Test also whether derivatives change the class name accordingly.
         class DerivedLinter(uut):
             pass
-        self.assertEqual(repr(DerivedLinter),
-                         "<DerivedLinter linter class (wrapping 'my-tool')>")
+        self.assertRegex(repr(DerivedLinter),
+                         "<DerivedLinter linter class \\(wrapping 'my-tool'\\) at 0x[a-fA-F0-9]+>")
 
     def test_repr(self):
         uut = (linter(sys.executable)


### PR DESCRIPTION
was having trouble running coala locally, making a PR to test out.