### PR TITLE
Setting.py: Change property name

### DIFF
--- a/coalib/settings/Setting.py
+++ b/coalib/settings/Setting.py
@@ -310,7 +310,7 @@ class Setting(StringConverter):
             return self._origin
 
     @property
-    def line_number(self):
+    def start_line_number(self):
         if isinstance(self._origin, SourcePosition):
             return self._origin.line
         else:

--- a/tests/parsing/ConfParserTest.py
+++ b/tests/parsing/ConfParserTest.py
@@ -100,7 +100,7 @@ class ConfParserTest(unittest.TestCase):
 
         # Check if line number is correctly set when
         # no section is given
-        line_num = val.contents['setting'].line_number
+        line_num = val.contents['setting'].start_line_number
         self.assertEqual(line_num, 1)
 
     def test_parse_foo_section(self):
@@ -153,9 +153,9 @@ class ConfParserTest(unittest.TestCase):
 
         # Check starting line number of
         # settings in makefiles section.
-        line_num = val.contents['another'].line_number
+        line_num = val.contents['another'].start_line_number
         self.assertEqual(line_num, 12)
-        line_num = val.contents['append'].line_number
+        line_num = val.contents['append'].start_line_number
         self.assertEqual(line_num, 20)
         # Check ending line number of
         # settings in makefiles section.
@@ -185,7 +185,7 @@ class ConfParserTest(unittest.TestCase):
 
         # Check starting line number of
         # settings in empty_elem_strip section.
-        line_num = val.contents['b'].line_number
+        line_num = val.contents['b'].start_line_number
         self.assertEqual(line_num, 24)
 
     def test_line_number_name_section(self):
@@ -196,7 +196,7 @@ class ConfParserTest(unittest.TestCase):
         self.sections.popitem(last=False)
 
         key, val = self.sections.popitem(last=False)
-        line_num = val.contents['key1'].line_number
+        line_num = val.contents['key1'].start_line_number
         self.assertEqual(line_num, 30)
 
         line_num = val.contents['key1'].end_line_number

--- a/tests/settings/SettingTest.py
+++ b/tests/settings/SettingTest.py
@@ -204,14 +204,14 @@ class SettingTest(unittest.TestCase):
 
     def test_line_number(self):
         self.uut = Setting('key', '22\n', origin=SourcePosition('filename', 3))
-        self.assertEqual(self.uut.line_number, 3)
+        self.assertEqual(self.uut.start_line_number, 3)
 
         with self.assertRaisesRegex(TypeError,
                                     "Instantiated with str 'origin' "
                                     'which does not have line numbers. '
                                     'Use SourcePosition for line numbers.'):
             self.uut = Setting('key', '22\n', origin='filename')
-            self.uut.line_number
+            self.uut.start_line_number
 
     def test_end_line_number(self):
         with self.assertRaisesRegex(TypeError,


### PR DESCRIPTION
changed the `line_number` property in `Setting` class to `start_line_number`

Fixes https://github.com/coala/coala/issues/5983