### PR TITLE
ConfigurationGathering.py: Change double quotes to single quotes

### DIFF
--- a/coalib/settings/ConfigurationGathering.py
+++ b/coalib/settings/ConfigurationGathering.py
@@ -350,18 +350,18 @@ def get_config_directory(section):
 
     Given an empty section:
 
-    >>> section = Section("name")
+    >>> section = Section('name')
 
     The configuration directory is not defined and will therefore fallback to
     the current directory:
 
-    >>> get_config_directory(section) == os.path.abspath(".")
+    >>> get_config_directory(section) == os.path.abspath('.')
     True
 
     If the ``files`` setting is given with an originating coafile, the directory
     of the coafile will be assumed the configuration directory:
 
-    >>> section.append(Setting("files", "**", origin="/tmp/.coafile"))
+    >>> section.append(Setting('files', '**', origin='/tmp/.coafile'))
     >>> get_config_directory(section) == os.path.abspath('/tmp/')
     True
 
@@ -382,7 +382,7 @@ def get_config_directory(section):
 
     If no section is given, the current directory is returned:
 
-    >>> get_config_directory(None) == os.path.abspath(".")
+    >>> get_config_directory(None) == os.path.abspath('.')
     True
 
     To summarize, the config directory will be chosen by the following


### PR DESCRIPTION
The docstring for function `get_config_directory` consist of
single quotes instead of double quotes.

Closes https://github.com/coala/coala/issues/5858
