### PR TITLE
Readme remove the link to the dead waffle service

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -35,6 +35,3 @@ coala supports popular programming languages including **Python**, **C/C++**, **
 .. |OpenHub| image:: http://www.openhub.net/p/coala/widgets/project_thin_badge.gif
    :target: https://www.openhub.net/p/coala
 
-.. image:: https://graphs.waffle.io/coala/coala/throughput.svg
- :target: https://waffle.io/coala/coala/metrics/throughput
- :alt: 'Throughput Graph'


### PR DESCRIPTION
The waffle service is defunct with all its resources/assets, see https://discourse.ros.org/t/replacement-for-waffle-io/8355.

Closes https://github.com/coala/coala/issues/5959

