### PR TITLE
LanguageTest.py: Fix autopep8 issue

### DIFF
--- a/tests/bearlib/languages/LanguageTest.py
+++ b/tests/bearlib/languages/LanguageTest.py
@@ -8,7 +8,7 @@ class LanguageTest(unittest.TestCase):
 
     def test_class__dir__(self):
         assert set(dir(Language)) == {
-            l.__name__ for l in LanguageMeta.all
+            lang.__name__ for lang in LanguageMeta.all
         }.union(type.__dir__(Language))
 
     def test_pickle_ability(self):


### PR DESCRIPTION
This fixes the issue reported by autopep8 in LanguageTest.py file.

Closes https://github.com/coala/coala/issues/6141