### PR TITLE
repr methods of linter.py now returns memory location.

### DIFF
--- a/coalib/bearlib/abstractions/Linter.py
+++ b/coalib/bearlib/abstractions/Linter.py
@@ -167,8 +167,8 @@ def _create_linter(klass, options):
     class LinterMeta(type):
 
         def __repr__(cls):
-            return '<{} linter class (wrapping {!r})>'.format(
-                cls.__name__, options['executable'])
+            return '<{} linter class (wrapping {!r}) at ({})>'.format(
+                cls.__name__, options['executable'], hex(id(cls)))
 
     class LinterBase(metaclass=LinterMeta):
 

--- a/tests/bearlib/abstractions/LinterTest.py
+++ b/tests/bearlib/abstractions/LinterTest.py
@@ -1090,15 +1090,20 @@ class LinterOtherTest(LinterTestBase):
 
     def test_metaclass_repr(self):
         uut = linter('my-tool')(self.ManualProcessingTestLinter)
-        self.assertEqual(
+        self.assertRegex(
             repr(uut),
-            "<ManualProcessingTestLinter linter class (wrapping 'my-tool')>")
+            '<ManualProcessingTestLinter linter class \\(wrapping ' +
+            '\'my-tool\'\\) at \\(0x[a-fA-F0-9]+\\)>'
+        )
 
         # Test also whether derivatives change the class name accordingly.
         class DerivedLinter(uut):
             pass
-        self.assertEqual(repr(DerivedLinter),
-                         "<DerivedLinter linter class (wrapping 'my-tool')>")
+        self.assertRegex(
+            repr(DerivedLinter),
+            '<DerivedLinter linter class \\(wrapping \'my-tool\'\\)' +
+            ' at \\(0x[a-fA-F0-9]+\\)>'
+        )
 
     def test_repr(self):
         uut = (linter(sys.executable)

--- a/tests/settings/ConfigurationGatheringTest.py
+++ b/tests/settings/ConfigurationGatheringTest.py
@@ -466,9 +466,15 @@ class ConfigurationGatheringCollectionTest(unittest.TestCase):
 
         self.assertEqual(len(local_bears['cli']), TEST_BEARS_COUNT)
 
-        self.assertEqual(
-            [str(bear) for bear in local_bears['cli']],
-            TEST_BEAR_NAME_REPRS)
+        test_string = [str(bear) for bear in local_bears['cli']]
+        test_bear_name_reprs_regex = [test.replace(
+            '(', '\\(').replace(')', '\\)') for test in TEST_BEAR_NAME_REPRS]
+        pattern_string = [f'{test}'[
+            0:-1] + '( at \\(0x[a-fA-F0-9]+\\))?>'
+            for test in test_bear_name_reprs_regex]
+
+        for test, pattern in zip(test_string, pattern_string):
+            self.assertRegex(test, pattern)
 
         with bear_test_module():
             local_bears, global_bears = get_filtered_bears(


### PR DESCRIPTION
`repr` methods in linter.py now returns memory location. Tests have been modified and successfully tested with 100% coverage.
closes #6051 