### PR TITLE
docs: fix simple typo, documenation -> documentation

### DIFF
--- a/coalib/bearlib/languages/documentation/DocumentationExtraction.py
+++ b/coalib/bearlib/languages/documentation/DocumentationExtraction.py
@@ -1,5 +1,5 @@
 """
-Language and docstyle independent extraction of documenation comments.
+Language and docstyle independent extraction of documentation comments.
 
 Each of the functions is built upon one another, and at the last,
 exposes a single function :func:`extract_documentation_with_markers`


### PR DESCRIPTION
There is a small typo in coalib/bearlib/languages/documentation/DocumentationExtraction.py.

Should read `documentation` rather than `documenation`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md