### PR TITLE
Fix `ImportError: cannot import name 'Iterable' from 'collections'`

### DIFF
--- a/coalib/bearlib/languages/documentation/DocstyleDefinition.py
+++ b/coalib/bearlib/languages/documentation/DocstyleDefinition.py
@@ -1,4 +1,11 @@
-from collections import Iterable, namedtuple
+import sys
+
+if sys.version_info.major >= 3 and sys.version_info.minor > 10:
+    from collections.abc import Iterable
+else:
+    from collections import Iterable
+
+from collections import namedtuple
 from glob import iglob
 import os.path
 

--- a/coalib/core/PersistentHash.py
+++ b/coalib/core/PersistentHash.py
@@ -1,4 +1,10 @@
-from collections import Iterable
+import sys
+
+if sys.version_info.major >= 3 and sys.version_info.minor > 10:
+    from collections.abc import Iterable
+else:
+    from collections import Iterable
+
 from copy import deepcopy
 from hashlib import sha1
 import pickle

--- a/coalib/misc/DictUtilities.py
+++ b/coalib/misc/DictUtilities.py
@@ -1,4 +1,15 @@
-from collections import defaultdict, Iterable, OrderedDict
+import sys
+
+#
+# After Python 3.10, collections.Iterable was removed, and is now available as
+# collections.abc.Iterable.
+#
+if sys.version_info.major >= 3 and sys.version_info.minor > 10:
+    from collections.abc import Iterable
+else:
+    from collections import Iterable
+
+from collections import defaultdict, OrderedDict
 
 
 def inverse_dicts(*dicts):

--- a/coalib/misc/DictUtilities.py
+++ b/coalib/misc/DictUtilities.py
@@ -1,9 +1,5 @@
 import sys
 
-#
-# After Python 3.10, collections.Iterable was removed, and is now available as
-# collections.abc.Iterable.
-#
 if sys.version_info.major >= 3 and sys.version_info.minor > 10:
     from collections.abc import Iterable
 else:

--- a/coalib/settings/Setting.py
+++ b/coalib/settings/Setting.py
@@ -1,5 +1,11 @@
-import os
-from collections import Iterable, OrderedDict
+import sys, os
+
+if sys.version_info.major >= 3 and sys.version_info.minor > 10:
+    from collections.abc import Iterable
+else:
+    from collections import Iterable
+
+from collections import OrderedDict
 
 from coala_utils.decorators import (
     enforce_signature,

--- a/tests/core/GraphsTest.py
+++ b/tests/core/GraphsTest.py
@@ -1,4 +1,10 @@
-from collections import Iterable
+import sys
+
+if sys.version_info.major >= 3 and sys.version_info.minor > 10:
+    from collections.abc import Iterable
+else:
+    from collections import Iterable
+
 from functools import partial
 import unittest
 


### PR DESCRIPTION
# Fix `ImportError: cannot import name 'Iterable' from 'collections'`

## Description of Problem

As of Python 3.10, `collections.Iterable` has been removed from the language. As a result, all lines importing `collections.Iterable` (i.e., `from collections import Iterable`) throw an `ImportError` when running Coala with Python 3.10+.

This issue was reported 

## Solution

For those running Coala with Python versions prior to 3.10, no change is necessary. Thus, a simple solution is to replace:

```py
from collections import Iterable
```

With:

```py
if sys.version_info.major >= 3 and sys.version_info.minor > 10:
    from collections.abc import Iterable
else:
    from collections import Iterable
```

Files importing `collections` directly and accessing `collections.Iterable` are not affected, as `collections.Iterable` is aliased to `collections.abc.Iterable` in Python 3.10+:

```py
# From typing.py, Python 3.13
Iterable = _alias(collections.abc.Iterable, 1)
``` 

## Issues Fixed

Fixes #6179
Fixes #6184


